### PR TITLE
fix(stats): per-task tracking, line counts, soft-delete projects + restore UI

### DIFF
--- a/apps/aura-os-server/src/handlers/agents/sessions.rs
+++ b/apps/aura-os-server/src/handlers/agents/sessions.rs
@@ -183,6 +183,8 @@ pub(crate) async fn generate_session_summary(
     router_url: &str,
     jwt: &str,
     session_id: &str,
+    project_id: &str,
+    agent_id: &str,
 ) -> Result<String, String> {
     let events = storage
         .list_events(session_id, jwt, None, None)
@@ -227,9 +229,16 @@ pub(crate) async fn generate_session_summary(
         "messages": [{"role": "user", "content": transcript}],
     });
 
+    // Stamp the aura-* attribution headers so this LLM round-trip's tokens
+    // and cost land on the right session/project. Without these, the
+    // router falls back to None for project_id and the row is excluded
+    // from per-project cost aggregation.
     let resp = http
         .post(format!("{router_url}/v1/messages"))
         .bearer_auth(jwt)
+        .header("x-aura-session-id", session_id)
+        .header("x-aura-project-id", project_id)
+        .header("x-aura-agent-id", agent_id)
         .json(&req_body)
         .send()
         .await
@@ -277,7 +286,7 @@ pub(crate) async fn generate_session_summary(
 pub(crate) async fn summarize_session(
     State(state): State<AppState>,
     AuthJwt(jwt): AuthJwt,
-    Path((_project_id, _agent_instance_id, session_id)): Path<(
+    Path((project_id, agent_instance_id, session_id)): Path<(
         ProjectId,
         AgentInstanceId,
         SessionId,
@@ -286,6 +295,8 @@ pub(crate) async fn summarize_session(
     let storage = state.require_storage_client()?;
 
     let sid = session_id.to_string();
+    let pid = project_id.to_string();
+    let aid = agent_instance_id.to_string();
     info!(%session_id, "Session summary generation requested");
 
     let summary = generate_session_summary(
@@ -294,6 +305,8 @@ pub(crate) async fn summarize_session(
         &state.agent_runtime.router_url,
         &jwt,
         &sid,
+        &pid,
+        &aid,
     )
     .await
     .map_err(|e| ApiError::internal(format!("summarizing session: {e}")))?;

--- a/apps/aura-os-server/src/handlers/dev_loop.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop.rs
@@ -1213,6 +1213,30 @@ fn extract_files_changed(event: &serde_json::Value) -> Vec<StorageTaskFileChange
         return Vec::new();
     };
 
+    // Build a path -> (lines_added, lines_removed) lookup from the protocol's
+    // optional `diffs` array. Older harness builds emit no diffs, so the
+    // lookup is empty and counts default to 0 — same behaviour as before.
+    let line_counts: std::collections::HashMap<String, (u32, u32)> = files_changed
+        .get("diffs")
+        .and_then(serde_json::Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|entry| {
+                    let path = entry.get("path")?.as_str()?.to_string();
+                    let added = entry
+                        .get("lines_added")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let removed = entry
+                        .get("lines_removed")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    Some((path, (added, removed)))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     [
         ("create", "created"),
         ("modify", "modified"),
@@ -1220,17 +1244,22 @@ fn extract_files_changed(event: &serde_json::Value) -> Vec<StorageTaskFileChange
     ]
     .into_iter()
     .flat_map(|(op, key)| {
+        let line_counts = &line_counts;
         files_changed
             .get(key)
             .and_then(serde_json::Value::as_array)
             .into_iter()
             .flatten()
             .filter_map(move |value| {
-                value.as_str().map(|path| StorageTaskFileChangeSummary {
-                    op: op.to_string(),
-                    path: path.to_string(),
-                    lines_added: 0,
-                    lines_removed: 0,
+                value.as_str().map(|path| {
+                    let (lines_added, lines_removed) =
+                        line_counts.get(path).copied().unwrap_or((0, 0));
+                    StorageTaskFileChangeSummary {
+                        op: op.to_string(),
+                        path: path.to_string(),
+                        lines_added,
+                        lines_removed,
+                    }
                 })
             })
     })
@@ -2310,6 +2339,14 @@ fn forward_automaton_events(params: ForwardParams) -> tokio::task::AbortHandle {
                         if let (Some(session_id), Some(turn_usage)) =
                             (current_session_id, extract_turn_usage(&event))
                         {
+                            // Don't pass cumulative token totals here — the
+                            // router atomically increments sessions tokens on
+                            // every successful LLM round-trip via aura-storage's
+                            // /internal/sessions/:id/tokens endpoint, so a
+                            // SET-based write here would race with those
+                            // increments. Per-turn input/output deltas + the
+                            // context-utilization estimate still flow through
+                            // for event-stream consumers that watch them.
                             if let Err(error) = session_service
                                 .update_context_usage(UpdateContextUsageParams {
                                     project_id,
@@ -2317,8 +2354,8 @@ fn forward_automaton_events(params: ForwardParams) -> tokio::task::AbortHandle {
                                     session_id,
                                     input_tokens: turn_usage.input_tokens,
                                     output_tokens: turn_usage.output_tokens,
-                                    total_input_tokens: turn_usage.cumulative_input_tokens,
-                                    total_output_tokens: turn_usage.cumulative_output_tokens,
+                                    total_input_tokens: None,
+                                    total_output_tokens: None,
                                     context_usage_estimate: turn_usage.context_utilization,
                                 })
                                 .await
@@ -2896,11 +2933,13 @@ fn forward_automaton_events(params: ForwardParams) -> tokio::task::AbortHandle {
 
                                 if let (Some(sc), Some(j)) = (storage_client.clone(), jwt.clone()) {
                                     let sid = session_id.to_string();
+                                    let pid = project_id.to_string();
+                                    let aid = agent_instance_id.to_string();
                                     let rurl = router_url.clone();
                                     let hclient = http_client.clone();
                                     tokio::spawn(async move {
                                         if let Err(e) = super::agents::generate_session_summary(
-                                            &sc, &hclient, &rurl, &j, &sid,
+                                            &sc, &hclient, &rurl, &j, &sid, &pid, &aid,
                                         )
                                         .await
                                         {
@@ -3244,11 +3283,13 @@ fn forward_automaton_events(params: ForwardParams) -> tokio::task::AbortHandle {
 
                         if let (Some(sc), Some(j)) = (storage_client.clone(), jwt.clone()) {
                             let sid = session_id.to_string();
+                            let pid = project_id.to_string();
+                            let aid = agent_instance_id.to_string();
                             let rurl = router_url.clone();
                             let hclient = http_client.clone();
                             tokio::spawn(async move {
                                 if let Err(e) = super::agents::generate_session_summary(
-                                    &sc, &hclient, &rurl, &j, &sid,
+                                    &sc, &hclient, &rurl, &j, &sid, &pid, &aid,
                                 )
                                 .await
                                 {
@@ -4733,6 +4774,40 @@ mod tests {
         assert!(files
             .iter()
             .any(|file| file.op == "delete" && file.path == "src/old.rs"));
+
+        // Without diffs, line counts default to 0 (older harness builds).
+        assert!(files.iter().all(|f| f.lines_added == 0 && f.lines_removed == 0));
+    }
+
+    #[test]
+    fn extracts_line_counts_from_diffs() {
+        // New harness builds emit per-file diffs alongside the path lists.
+        // extract_files_changed must merge them so the dashboard "Lines"
+        // stat receives non-zero values.
+        let event = serde_json::json!({
+            "type": "assistant_message_end",
+            "files_changed": {
+                "created": ["src/new.rs"],
+                "modified": ["src/lib.rs"],
+                "deleted": ["src/old.rs"],
+                "diffs": [
+                    { "path": "src/new.rs", "lines_added": 12, "lines_removed": 0 },
+                    { "path": "src/lib.rs", "lines_added": 3,  "lines_removed": 1 }
+                ]
+            }
+        });
+
+        let files = extract_files_changed(&event);
+        let new_rs = files.iter().find(|f| f.path == "src/new.rs").unwrap();
+        assert_eq!(new_rs.lines_added, 12);
+        assert_eq!(new_rs.lines_removed, 0);
+        let lib_rs = files.iter().find(|f| f.path == "src/lib.rs").unwrap();
+        assert_eq!(lib_rs.lines_added, 3);
+        assert_eq!(lib_rs.lines_removed, 1);
+        // Path missing from diffs (old.rs) keeps zero counts.
+        let old_rs = files.iter().find(|f| f.path == "src/old.rs").unwrap();
+        assert_eq!(old_rs.lines_added, 0);
+        assert_eq!(old_rs.lines_removed, 0);
     }
 
     #[test]

--- a/apps/aura-os-server/src/handlers/projects.rs
+++ b/apps/aura-os-server/src/handlers/projects.rs
@@ -10,9 +10,9 @@ use crate::error::{map_network_error, ApiError, ApiResult, UpstreamErrorContext}
 use crate::state::{AppState, AuthJwt};
 
 use super::projects_helpers::{
-    build_local_shadow, canonical_workspace_path, ensure_canonical_workspace_dir,
-    ensure_local_shadow, normalize_project_workspace, project_from_network, slugify,
-    to_project_input, write_imported_files, ListProjectsQuery,
+    build_local_shadow, ensure_canonical_workspace_dir, ensure_local_shadow,
+    normalize_project_workspace, project_from_network, slugify, to_project_input,
+    write_imported_files, ListProjectsQuery,
 };
 
 pub(crate) async fn list_all_projects_from_network(
@@ -375,8 +375,11 @@ pub(crate) async fn delete_project(
             _ => ApiError::internal(format!("verifying project exists: {e}")),
         })?;
 
-    // Delete remotely first so that a rejection (e.g. project has agent
-    // children) prevents us from removing the local copy.
+    // aura-network's DELETE is now soft-delete: it flips status to
+    // 'deleted' and leaves all linked rows intact. The local mirror is
+    // removed below so the project disappears from the active project
+    // list, but we deliberately keep the workspace directory on disk so
+    // restoring brings back the agent-generated code.
     if let Some(client) = &state.network_client {
         client
             .delete_project(&project_id.to_string(), &jwt)
@@ -389,20 +392,82 @@ pub(crate) async fn delete_project(
         .delete_project(&project_id)
         .map_err(|e| ApiError::internal(format!("deleting project: {e}")))?;
 
-    // Clean up local workspace directory (best-effort)
-    let workspace = canonical_workspace_path(&state.data_dir, &project_id);
-    if workspace.exists() {
-        if let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
-            tracing::warn!(
-                project_id = %project_id,
-                path = %workspace.display(),
-                error = %e,
-                "failed to remove workspace directory"
-            );
-        }
-    }
-
+    // Workspace directory intentionally preserved — restore_project relies on
+    // it to bring back the project's files.
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Restore a soft-deleted project. Calls aura-network's restore endpoint,
+/// rehydrates the local shadow from the network response, and returns the
+/// restored project.
+pub(crate) async fn restore_project(
+    State(state): State<AppState>,
+    AuthJwt(jwt): AuthJwt,
+    Path(project_id): Path<ProjectId>,
+) -> ApiResult<Json<Project>> {
+    let client = state.require_network_client()?;
+    let net = client
+        .restore_project(&project_id.to_string(), &jwt)
+        .await
+        .map_err(map_network_error)?;
+
+    let local = state.project_service.get_project(&project_id).ok();
+    let project = normalize_project_workspace(
+        &state,
+        &project_from_network(&net, local.as_ref())?,
+    );
+    ensure_local_shadow(&state, &project);
+    Ok(Json(project))
+}
+
+/// Returns soft-deleted projects in the user's orgs. Drives the "Deleted
+/// Projects" recovery section in the project list UI.
+pub(crate) async fn list_deleted_projects(
+    State(state): State<AppState>,
+    AuthJwt(jwt): AuthJwt,
+    Query(query): Query<ListProjectsQuery>,
+) -> ApiResult<Json<Vec<Project>>> {
+    let client = state.require_network_client()?;
+
+    let net_projects = if let Some(ref org_id) = query.org_id {
+        client
+            .list_deleted_projects_by_org(&org_id.to_string(), &jwt)
+            .await
+            .map_err(map_network_error)?
+    } else {
+        // Fan out across all orgs, mirroring list_all_projects_from_network.
+        let orgs = client.list_orgs(&jwt).await.map_err(map_network_error)?;
+        let futs = orgs
+            .iter()
+            .map(|org| client.list_deleted_projects_by_org(&org.id, &jwt));
+        let results = futures_util::future::join_all(futs).await;
+        let mut acc = Vec::new();
+        for r in results {
+            acc.extend(r.map_err(map_network_error)?);
+        }
+        acc
+    };
+
+    // Don't ensure_local_shadow for deleted projects — they should not
+    // re-appear in the active project list. Caller can map them as needed
+    // for the recovery UI; we still normalize workspace paths so the UI
+    // can show "where the files would land if restored".
+    let projects: Vec<Project> = net_projects
+        .iter()
+        .map(|net| {
+            let local =
+                net.id.parse::<ProjectId>().ok().and_then(|project_id| {
+                    state.project_service.get_project(&project_id).ok()
+                });
+            let project = normalize_project_workspace(
+                &state,
+                &project_from_network(net, local.as_ref())?,
+            );
+            Ok(project)
+        })
+        .collect::<ApiResult<_>>()?;
+
+    Ok(Json(projects))
 }
 
 /// Translate upstream delete-project errors into user-actionable responses.

--- a/apps/aura-os-server/src/handlers/projects_helpers.rs
+++ b/apps/aura-os-server/src/handlers/projects_helpers.rs
@@ -283,6 +283,17 @@ pub(crate) async fn project_tool_session_config(
         }
         None => None,
     };
+    // Project-tool sessions (task-extract, spec-generate, etc.) don't have a
+    // live aura-storage session row — they're one-off harness invocations.
+    // But the router needs `x-aura-org-id` for cost attribution, so resolve
+    // and stamp the project's org here. aura_session_id stays None (the
+    // loosened router accepts project_id alone).
+    let aura_org_id = state
+        .project_service
+        .get_project(project_id)
+        .ok()
+        .map(|p| p.org_id.to_string());
+
     SessionConfig {
         agent_id: if let Some(instance) = remote_instance.as_ref() {
             Some(instance.agent_id.to_string())
@@ -302,6 +313,7 @@ pub(crate) async fn project_tool_session_config(
         project_path,
         installed_tools,
         installed_integrations,
+        aura_org_id,
         ..Default::default()
     }
 }

--- a/apps/aura-os-server/src/router.rs
+++ b/apps/aura-os-server/src/router.rs
@@ -235,11 +235,21 @@ fn project_routes() -> Router<AppState> {
             "/api/projects/import",
             post(projects::create_imported_project),
         )
+        // /api/projects/deleted must come before /:project_id so it isn't
+        // captured by the dynamic segment.
+        .route(
+            "/api/projects/deleted",
+            get(projects::list_deleted_projects),
+        )
         .route(
             "/api/projects/:project_id",
             get(projects::get_project)
                 .put(projects::update_project)
                 .delete(projects::delete_project),
+        )
+        .route(
+            "/api/projects/:project_id/restore",
+            post(projects::restore_project),
         )
         .route(
             "/api/projects/:project_id/archive",

--- a/crates/aura-os-network/src/client/projects.rs
+++ b/crates/aura-os-network/src/client/projects.rs
@@ -58,4 +58,32 @@ impl NetworkClient {
         )
         .await
     }
+
+    /// Restore a soft-deleted project. Returns the restored project with
+    /// `status='active'`.
+    pub async fn restore_project(
+        &self,
+        project_id: &str,
+        jwt: &str,
+    ) -> Result<NetworkProject, NetworkError> {
+        self.post_authed(
+            &format!("{}/api/projects/{}/restore", self.base_url, project_id),
+            jwt,
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    /// List soft-deleted projects in the org. Used by the recovery UI.
+    pub async fn list_deleted_projects_by_org(
+        &self,
+        org_id: &str,
+        jwt: &str,
+    ) -> Result<Vec<NetworkProject>, NetworkError> {
+        self.get_authed(
+            &format!("{}/api/projects/deleted?org_id={}", self.base_url, org_id),
+            jwt,
+        )
+        .await
+    }
 }

--- a/crates/aura-protocol/src/lib.rs
+++ b/crates/aura-protocol/src/lib.rs
@@ -508,6 +508,24 @@ pub struct FilesChanged {
     pub created: Vec<String>,
     pub modified: Vec<String>,
     pub deleted: Vec<String>,
+    /// Per-file line-count diffs. Populated by aura-harness's edit/write
+    /// tools when content-aware tools mutate files. Empty for tool changes
+    /// the harness cannot diff (e.g. arbitrary bash commands). Optional and
+    /// backward-compatible: older aura-harness builds emit no diffs and
+    /// older aura-code builds simply ignore the field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diffs: Vec<FileDiff>,
+}
+
+/// Per-file line-count diff. Aggregated by aura-code into
+/// `tasks.files_changed` JSONB so the dashboard's "Lines" stat reflects
+/// real edits instead of zero.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "typescript", derive(TS), ts(export))]
+pub struct FileDiff {
+    pub path: String,
+    pub lines_added: u32,
+    pub lines_removed: u32,
 }
 
 impl FilesChanged {

--- a/interface/src/api/projects.ts
+++ b/interface/src/api/projects.ts
@@ -119,6 +119,12 @@ export const projectsApi = {
     }),
   deleteProject: (id: ProjectId) =>
     apiFetch<void>(`/api/projects/${id}`, { method: "DELETE" }),
+  restoreProject: (id: ProjectId) =>
+    apiFetch<Project>(`/api/projects/${id}/restore`, { method: "POST" }),
+  listDeletedProjects: (orgId?: string) => {
+    const qs = orgId ? `?org_id=${encodeURIComponent(orgId)}` : "";
+    return apiFetch<Project[]>(`/api/projects/deleted${qs}`);
+  },
   archiveProject: (id: ProjectId) =>
     apiFetch<Project>(`/api/projects/${id}/archive`, { method: "POST" }),
 

--- a/interface/src/components/DeletedProjectsModal/DeletedProjectsModal.module.css
+++ b/interface/src/components/DeletedProjectsModal/DeletedProjectsModal.module.css
@@ -1,0 +1,76 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 120px;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--zui-surface-elevated, rgba(255, 255, 255, 0.03));
+  gap: 12px;
+}
+
+.row:hover {
+  background: var(--zui-surface-hover, rgba(255, 255, 255, 0.05));
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.description {
+  font-size: 12px;
+  color: var(--zui-text-muted, rgba(255, 255, 255, 0.6));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px 16px;
+  color: var(--zui-text-muted, rgba(255, 255, 255, 0.6));
+}
+
+.error {
+  color: var(--zui-text-error, #ff6b6b);
+  font-size: 13px;
+  padding: 8px 12px;
+  background: rgba(255, 107, 107, 0.1);
+  border-radius: 4px;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/interface/src/components/DeletedProjectsModal/DeletedProjectsModal.tsx
+++ b/interface/src/components/DeletedProjectsModal/DeletedProjectsModal.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from "react";
+import { Modal, Button } from "@cypher-asi/zui";
+import { Trash2 } from "lucide-react";
+import type { Project } from "../../types";
+import { useProjectsListStore } from "../../stores/projects-list-store";
+import { useProjectListActions } from "../../hooks/use-project-list-actions";
+import styles from "./DeletedProjectsModal.module.css";
+
+interface DeletedProjectsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function DeletedProjectsModal({ isOpen, onClose }: DeletedProjectsModalProps) {
+  const deletedProjects = useProjectsListStore((s) => s.deletedProjects);
+  const loading = useProjectsListStore((s) => s.loadingDeletedProjects);
+  const error = useProjectsListStore((s) => s.deletedProjectsError);
+  const refresh = useProjectsListStore((s) => s.refreshDeletedProjects);
+  const { handleRestore, restoreLoadingIds, restoreError } =
+    useProjectListActions();
+
+  useEffect(() => {
+    if (isOpen) {
+      void refresh();
+    }
+  }, [isOpen, refresh]);
+
+  const onRestore = async (project: Project) => {
+    await handleRestore(project);
+    await refresh();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Deleted Projects"
+      size="md"
+      footer={
+        <div className={styles.footer}>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      }
+    >
+      <div className={styles.body}>
+        {loading && <div className={styles.empty}>Loading…</div>}
+        {!loading && error && (
+          <div className={styles.error} role="alert">
+            {error}
+          </div>
+        )}
+        {!loading && !error && deletedProjects.length === 0 && (
+          <div className={styles.empty}>
+            <Trash2 size={32} />
+            <p>No deleted projects yet.</p>
+          </div>
+        )}
+        {!loading && deletedProjects.length > 0 && (
+          <ul className={styles.list}>
+            {deletedProjects.map((project) => {
+              const isRestoring = restoreLoadingIds.includes(project.project_id);
+              return (
+                <li key={project.project_id} className={styles.row}>
+                  <div className={styles.meta}>
+                    <div className={styles.name}>{project.name}</div>
+                    {project.description && (
+                      <div className={styles.description}>{project.description}</div>
+                    )}
+                  </div>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => void onRestore(project)}
+                    disabled={isRestoring}
+                  >
+                    {isRestoring ? "Restoring…" : "Restore"}
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {restoreError && (
+          <div className={styles.error} role="alert">
+            {restoreError}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/interface/src/components/DeletedProjectsModal/index.ts
+++ b/interface/src/components/DeletedProjectsModal/index.ts
@@ -1,0 +1,1 @@
+export { DeletedProjectsModal } from "./DeletedProjectsModal";

--- a/interface/src/components/ProjectList/ProjectList.module.css
+++ b/interface/src/components/ProjectList/ProjectList.module.css
@@ -4,6 +4,26 @@
   height: 100%;
 }
 
+.deletedProjectsLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 6px 12px;
+  padding: 4px 6px;
+  font-size: 11px;
+  color: var(--zui-text-muted, rgba(255, 255, 255, 0.5));
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  align-self: flex-start;
+  border-radius: 4px;
+}
+
+.deletedProjectsLink:hover {
+  color: var(--zui-text, rgba(255, 255, 255, 0.85));
+  background: var(--zui-surface-hover, rgba(255, 255, 255, 0.05));
+}
+
 .explorerWrap {
   position: relative;
   flex: 1;

--- a/interface/src/components/ProjectList/ProjectList.test.tsx
+++ b/interface/src/components/ProjectList/ProjectList.test.tsx
@@ -174,6 +174,9 @@ vi.mock("../ProjectSettingsModal", () => ({
 vi.mock("../AgentSelectorModal", () => ({
   AgentSelectorModal: () => null,
 }));
+vi.mock("../DeletedProjectsModal", () => ({
+  DeletedProjectsModal: () => null,
+}));
 
 vi.mock("./ProjectList.module.css", () => ({
   default: new Proxy({}, { get: (_t, prop) => String(prop) }),

--- a/interface/src/components/ProjectList/ProjectList.tsx
+++ b/interface/src/components/ProjectList/ProjectList.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { Explorer, PageEmptyState } from "@cypher-asi/zui";
-import { FolderGit2 } from "lucide-react";
+import { FolderGit2, Trash2 } from "lucide-react";
 import { useProjectListData } from "./useProjectListData";
 import { ProjectListModals } from "./ProjectListModals";
 import { ExplorerContextMenu } from "./ExplorerContextMenu";
 import { useProjectsExplorerModel } from "./project-list-projects-explorer";
+import { DeletedProjectsModal } from "../DeletedProjectsModal";
 
 import styles from "./ProjectList.module.css";
 
@@ -22,11 +24,25 @@ const explorerNodeStyles = {
 export function ProjectList() {
   const data = useProjectListData("projects");
   const explorer = useProjectsExplorerModel(data, explorerNodeStyles);
+  const [showDeleted, setShowDeleted] = useState(false);
 
   if (explorer.isEmptyState) {
     return (
       <div className={styles.root}>
         <PageEmptyState icon={<FolderGit2 size={32} />} title="No projects yet" description="Open an existing project or create a linked one from the desktop app." />
+        <button
+          type="button"
+          className={styles.deletedProjectsLink}
+          onClick={() => setShowDeleted(true)}
+        >
+          <Trash2 size={12} /> Deleted projects
+        </button>
+        {showDeleted && (
+          <DeletedProjectsModal
+            isOpen={showDeleted}
+            onClose={() => setShowDeleted(false)}
+          />
+        )}
       </div>
     );
   }
@@ -49,8 +65,20 @@ export function ProjectList() {
         />
       </div>
 
+      <button
+        type="button"
+        className={styles.deletedProjectsLink}
+        onClick={() => setShowDeleted(true)}
+      >
+        <Trash2 size={12} /> Deleted projects
+      </button>
+
       <ExplorerContextMenu actions={explorer.actions} />
       <ProjectListModals actions={explorer.actions} />
+      <DeletedProjectsModal
+        isOpen={showDeleted}
+        onClose={() => setShowDeleted(false)}
+      />
     </div>
   );
 }

--- a/interface/src/hooks/use-project-list-actions.test.tsx
+++ b/interface/src/hooks/use-project-list-actions.test.tsx
@@ -40,6 +40,17 @@ vi.mock("../api/client", () => ({
   api: {
     updateProject: vi.fn().mockResolvedValue({}),
     deleteProject: vi.fn().mockResolvedValue(undefined),
+    restoreProject: vi.fn().mockResolvedValue({
+      project_id: "p-deleted",
+      org_id: "org-1",
+      name: "Restored",
+      description: "",
+      folder: null,
+      status: "active",
+      visibility: "private",
+      created_at: "",
+      updated_at: "",
+    }),
     deleteAgentInstance: vi.fn().mockResolvedValue(undefined),
     createGeneralAgentInstance: vi.fn().mockResolvedValue({
       agent_instance_id: "general-ai",
@@ -366,5 +377,52 @@ describe("useProjectListActions", () => {
 
     expect(mockSetProjects).toHaveBeenCalled();
     expect(result.current.settingsTarget).toBeNull();
+  });
+
+  it("handleRestore calls api.restoreProject and refreshes the list", async () => {
+    const { result } = renderHook(() => useProjectListActions(), { wrapper });
+    const target = {
+      project_id: "p-deleted",
+      org_id: "o-1",
+      name: "Lost",
+      description: "",
+      current_status: "deleted",
+      created_at: "",
+      updated_at: "",
+    };
+
+    await act(async () => {
+      await result.current.handleRestore(target);
+    });
+
+    expect(api.restoreProject).toHaveBeenCalledWith("p-deleted");
+    expect(mockRefreshProjects).toHaveBeenCalled();
+    expect(result.current.restoreError).toBeNull();
+    expect(result.current.restoreLoadingIds).toEqual([]);
+  });
+
+  it("handleRestore surfaces API errors via restoreError", async () => {
+    (api.restoreProject as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiClientError(409, {
+        error: "Project is not deleted",
+        code: "INVALID_STATE",
+        details: null,
+      }),
+    );
+    const { result } = renderHook(() => useProjectListActions(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleRestore({
+        project_id: "p-deleted",
+        org_id: "o-1",
+        name: "Lost",
+        description: "",
+        current_status: "deleted",
+        created_at: "",
+        updated_at: "",
+      });
+    });
+
+    expect(result.current.restoreError).toContain("Project is not deleted");
   });
 });

--- a/interface/src/hooks/use-project-list-actions.ts
+++ b/interface/src/hooks/use-project-list-actions.ts
@@ -264,6 +264,30 @@ export function useProjectListActions() {
     [setProjects],
   );
 
+  const [restoreLoadingIds, setRestoreLoadingIds] = useState<string[]>([]);
+  const [restoreError, setRestoreError] = useState<string | null>(null);
+
+  const handleRestore = useCallback(
+    async (project: Project) => {
+      setRestoreError(null);
+      setRestoreLoadingIds((prev) => [...prev, project.project_id]);
+      try {
+        await api.restoreProject(project.project_id);
+        await refreshProjects();
+      } catch (err) {
+        console.error("Failed to restore project", err);
+        const message = getApiErrorMessage(err);
+        const details = getApiErrorDetails(err);
+        setRestoreError(details ? `${message} ${details}` : message);
+      } finally {
+        setRestoreLoadingIds((prev) =>
+          prev.filter((id) => id !== project.project_id),
+        );
+      }
+    },
+    [refreshProjects],
+  );
+
   return {
     ctxMenu, setCtxMenu, ctxMenuRef,
     renameTarget, setRenameTarget,
@@ -273,6 +297,9 @@ export function useProjectListActions() {
     agentSelectorProjectId, setAgentSelectorProjectId, pendingCreatedAgent,
     creatingGeneralAgentProjectIds,
     archivingAgentInstanceIds,
+    restoreLoadingIds,
+    restoreError,
+    setRestoreError,
     handleAddAgent,
     handleQuickAddAgent,
     handleMenuAction,
@@ -282,5 +309,6 @@ export function useProjectListActions() {
     handleAgentCreated,
     handleArchiveAgent,
     handleProjectSaved,
+    handleRestore,
   };
 }

--- a/interface/src/stores/projects-list-store.ts
+++ b/interface/src/stores/projects-list-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { Agent, AgentInstance, Project } from "../types";
+import { api } from "../api/client";
 import { queryClient } from "../lib/query-client";
 import {
   dedupeProjects,
@@ -78,10 +79,17 @@ interface ProjectsListState {
   agentsByProject: Record<string, AgentInstance[]>;
   loadingAgentsByProject: Record<string, boolean>;
   newProjectModalOpen: boolean;
+  /// Soft-deleted projects in the active org. Loaded on demand by the
+  /// recovery UI; not persisted or query-cached because the list is only
+  /// shown when the user explicitly opens the "Deleted Projects" section.
+  deletedProjects: Project[];
+  loadingDeletedProjects: boolean;
+  deletedProjectsError: string | null;
 
   setProjects: (updater: Project[] | ((prev: Project[]) => Project[])) => void;
   saveProjectOrder: (orderedIds: string[]) => void;
   refreshProjects: () => Promise<void>;
+  refreshDeletedProjects: () => Promise<void>;
   setAgentsByProject: (
     updater:
       | Record<string, AgentInstance[]>
@@ -165,6 +173,9 @@ export const useProjectsListStore = create<ProjectsListState>()((set, get) => ({
   newProjectModalOpen:
     typeof window !== "undefined" &&
     window.sessionStorage.getItem(NEW_PROJECT_MODAL_STORAGE_KEY) === "1",
+  deletedProjects: [],
+  loadingDeletedProjects: false,
+  deletedProjectsError: null,
 
   setProjects: (updater) => {
     set((state) => ({
@@ -227,6 +238,24 @@ export const useProjectsListStore = create<ProjectsListState>()((set, get) => ({
       if (useAuthStore.getState().user) {
         markFirstProjectsDataReady();
       }
+    }
+  },
+
+  refreshDeletedProjects: async () => {
+    const orgId = getActiveOrgId();
+    set({ loadingDeletedProjects: true, deletedProjectsError: null });
+    try {
+      const projects = await api.listDeletedProjects(orgId);
+      set({ deletedProjects: projects, loadingDeletedProjects: false });
+    } catch (error) {
+      console.error("Failed to load deleted projects", error);
+      set({
+        loadingDeletedProjects: false,
+        deletedProjectsError:
+          error instanceof Error
+            ? error.message
+            : "Could not load deleted projects.",
+      });
     }
   },
 

--- a/interface/src/types/enums.ts
+++ b/interface/src/types/enums.ts
@@ -1,4 +1,4 @@
-export type ProjectStatus = "planning" | "active" | "paused" | "completed" | "archived";
+export type ProjectStatus = "planning" | "active" | "paused" | "completed" | "archived" | "deleted";
 export type TaskStatus = "backlog" | "to_do" | "pending" | "ready" | "in_progress" | "blocked" | "done" | "failed";
 export type AgentStatus = "idle" | "working" | "blocked" | "stopped" | "error" | "archived";
 export type SessionStatus = "active" | "completed" | "failed" | "rolled_over";


### PR DESCRIPTION
## Summary

Closes Neo's two stats blockers + adds per-task model time tracking (his benchmarking ask).

**Server-side fixes already deployed to Render** (aura-storage, aura-network, aura-router) before this PR — those changes are live now. This PR is the aura-code side: header propagation, line-count reading, soft-delete restore UI.

## What this PR does

### `fix(stats): read line diffs from FilesChanged + stop racing the router`
- `extract_files_changed` now reads per-file `lines_added` / `lines_removed` from the new `FilesChanged.diffs` field that aura-harness emits. Hardcoded `0` is gone — dashboard "Lines" stat reflects real edits.
- `update_context_usage` no longer sends cumulative token totals on `assistant_message_end`. aura-router's deployed code now atomically increments session tokens via aura-storage's `/internal/sessions/:id/tokens` endpoint on every successful round-trip. Two writers SET-ing and incrementing the same column would race; this stops the dev loop's SET so the router is sole writer.

### `fix(stats): stamp aura-* attribution headers on harness/summary calls`
- `generate_session_summary` was hitting the router with no `x-aura-*` headers — its tokens went unattributed to any project. Now stamps session/project/agent IDs.
- `project_tool_session_config` (task-extract / spec-generate harness sessions) was missing `aura_org_id`. Now populated. The loosened router accepts `project_id` alone for cost attribution, so utility tool calls land on the right project.

### `feat(projects): soft-delete proxies + restore endpoint`
- New `POST /api/projects/:id/restore` and `GET /api/projects/deleted` server-side proxies to aura-network.
- `delete_project` no longer removes the workspace directory — it's a soft delete now, restore brings the project back with files intact. Local project_service entry is still removed so the project disappears from the active list immediately.

### `feat(protocol): FilesChanged carries per-file line diffs`
Adds optional `diffs: Vec<FileDiff>` to `FilesChanged` (backward-compatible: `skip_serializing_if = Vec::is_empty`). aura-harness emits these for edit_file / write_file Create.

### `feat(ui): DeletedProjectsModal + handleRestore`
Recovery surface accessible from a small "Deleted projects" link at the bottom of the project list. Shows soft-deleted projects with a Restore button per row; per-project loading state lets multiple restores run in parallel.

## Why merge soon

aura-router was just deployed with per-call session-token increments. Until this aura-code merge lands, prod aura-code is still sending **cumulative** SET writes alongside the router's increments — they race for the same `sessions.total_input_tokens` column. Net effect: tokens may over-count for active sessions during the window. Better than the current "tokens=0" symptom but worth closing.

## Verification status

**Locally**:
- `cargo check` clean; 327 aura-agent tests + 124 aura-node tests + 47 aura-os-server dev_loop tests pass.
- Vitest: 11 hook tests (2 new), 15 ProjectList tests; full suite has same pre-existing failures as origin/main.
- Pre-existing failure in `test_memory_bulk_delete_events_alias` is unchanged from origin/main.

**Cross-version compatibility verified**: no `deny_unknown_fields` on `NetworkProject`, `StorageTask`, `StorageSession`, `ProjectStats`, so the production aura-code (currently deployed) accepts the new fields aura-storage / aura-network are now returning.

## After merge — verify against prod DBs

\`\`\`sql
-- aura-storage: new sessions should show non-zero tokens after a real coding turn
SELECT id, total_input_tokens, total_output_tokens, ended_at
FROM sessions ORDER BY started_at DESC LIMIT 5;

-- aura-network: usage rows should now have non-NULL agent_id, project_id and non-zero duration_ms
SELECT project_id, agent_id, task_id, duration_ms, estimated_cost_usd
FROM token_usage_daily ORDER BY date DESC, id DESC LIMIT 10;

-- aura-storage: tasks completed via dev-loop should have non-zero linesAdded/linesRemoved
SELECT id, files_changed FROM tasks
WHERE files_changed IS NOT NULL ORDER BY updated_at DESC LIMIT 5;

-- aura-network: soft-delete preserves associations
-- (delete a test project, then check)
SELECT status FROM projects WHERE id = '<test-project-id>';  -- should be 'deleted'
SELECT COUNT(*) FROM activity_events WHERE project_id = '<test-project-id>';  -- unchanged
SELECT COUNT(*) FROM token_usage_daily WHERE project_id = '<test-project-id>';  -- unchanged
\`\`\`

## Rollback

Each Render service has "redeploy previous" if anything misbehaves. Rolling back aura-network requires first running \`UPDATE projects SET status='archived' WHERE status='deleted'\` so the old CHECK constraint accepts. No other service rollback needs DB cleanup.