### PR TITLE
fix(stats): wire token persistence + close cost attribution gaps

### DIFF
--- a/apps/aura-os-server/src/handlers/agents/sessions.rs
+++ b/apps/aura-os-server/src/handlers/agents/sessions.rs
@@ -184,6 +184,8 @@ pub(crate) async fn generate_session_summary(
     router_url: &str,
     jwt: &str,
     session_id: &str,
+    project_id: &str,
+    agent_id: &str,
 ) -> Result<String, String> {
     let events = storage
         .list_events(session_id, jwt, None, None)
@@ -228,9 +230,17 @@ pub(crate) async fn generate_session_summary(
         "messages": [{"role": "user", "content": transcript}],
     });
 
+    // Stamp the aura-* attribution headers so this LLM round-trip's
+    // tokens and cost land on the right session/project. Without these,
+    // aura-router's SessionContext::from_headers returns None and the
+    // resulting token_usage_daily row gets project_id=null — silently
+    // excluded from per-project cost aggregation.
     let resp = http
         .post(format!("{router_url}/v1/messages"))
         .bearer_auth(jwt)
+        .header("x-aura-session-id", session_id)
+        .header("x-aura-project-id", project_id)
+        .header("x-aura-agent-id", agent_id)
         .json(&req_body)
         .send()
         .await
@@ -278,7 +288,7 @@ pub(crate) async fn generate_session_summary(
 pub(crate) async fn summarize_session(
     State(state): State<AppState>,
     AuthJwt(jwt): AuthJwt,
-    Path((_project_id, _agent_instance_id, session_id)): Path<(
+    Path((project_id, agent_instance_id, session_id)): Path<(
         ProjectId,
         AgentInstanceId,
         SessionId,
@@ -287,12 +297,21 @@ pub(crate) async fn summarize_session(
     let storage = state.require_storage_client()?;
 
     let sid = session_id.to_string();
+    let pid = project_id.to_string();
+    let aid = agent_instance_id.to_string();
     info!(%session_id, "Session summary generation requested");
 
-    let summary =
-        generate_session_summary(storage, &state.http_client, &state.router_url, &jwt, &sid)
-            .await
-            .map_err(|e| ApiError::internal(format!("summarizing session: {e}")))?;
+    let summary = generate_session_summary(
+        storage,
+        &state.http_client,
+        &state.router_url,
+        &jwt,
+        &sid,
+        &pid,
+        &aid,
+    )
+    .await
+    .map_err(|e| ApiError::internal(format!("summarizing session: {e}")))?;
 
     info!(%session_id, summary_len = summary.len(), "Session summary generated");
 

--- a/apps/aura-os-server/src/handlers/dev_loop/streaming/side_effects.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/streaming/side_effects.rs
@@ -140,6 +140,15 @@ async fn apply_event_side_effect(
         }
         "task_completed" => {
             set_current_task(state, project_id, agent_instance_id, None).await;
+            // Drain the in-memory `task_output_cache` (tokens, files-
+            // changed, live output, build/test/git steps) into the
+            // persisted aura-storage task record + session events.
+            // Without this, tokens accumulated in `update_usage_cache`
+            // are silently discarded when the cache is evicted,
+            // leaving the dashboard "Tokens" stat at 0.
+            if let (Some(task_id), Some(jwt)) = (task_id, jwt) {
+                persist_cached_task_output(state, project_id, jwt, task_id).await;
+            }
         }
         "task_failed" => {
             set_current_task(state, project_id, agent_instance_id, None).await;
@@ -151,6 +160,9 @@ async fn apply_event_side_effect(
             // reason to render (the hook has nothing to seed from).
             if let (Some(task_id), Some(jwt)) = (task_id, jwt) {
                 persist_task_failure_reason(state, jwt, task_id, event).await;
+                // Same accumulator drain as task_completed: failed tasks
+                // also have token usage that should appear in stats.
+                persist_cached_task_output(state, project_id, jwt, task_id).await;
             }
         }
         "tool_call_completed" => {
@@ -497,4 +509,37 @@ async fn update_usage_cache(
 /// `"runner-<n>"` ids that should not pollute the cache).
 fn parse_task_key(project_id: ProjectId, task_id: &str) -> Option<(ProjectId, TaskId)> {
     TaskId::from_str(task_id).ok().map(|tid| (project_id, tid))
+}
+
+/// Drain the in-memory accumulator for `task_id` and persist it to
+/// aura-storage via `persist_task_output`. Called once per task on
+/// `task_completed` or `task_failed`.
+///
+/// Bridges the live-event accumulator (`task_output_cache`) to the
+/// persisted `tasks` row + session events. The cache entry is removed
+/// after persistence so the in-memory map doesn't grow unbounded
+/// across task completions.
+async fn persist_cached_task_output(
+    state: &AppState,
+    project_id: ProjectId,
+    jwt: &str,
+    task_id: &str,
+) {
+    let Some(key) = parse_task_key(project_id, task_id) else {
+        return;
+    };
+    let cached = {
+        let mut cache = state.task_output_cache.lock().await;
+        cache.remove(&key)
+    };
+    let Some(cached) = cached else {
+        return;
+    };
+    crate::persistence::persist_task_output(
+        state.storage_client.as_ref(),
+        Some(jwt),
+        task_id,
+        &cached,
+    )
+    .await;
 }

--- a/apps/aura-os-server/src/handlers/projects_helpers/session.rs
+++ b/apps/aura-os-server/src/handlers/projects_helpers/session.rs
@@ -171,6 +171,19 @@ pub(crate) async fn project_tool_session_config(
     let template_agent_id_field = remote_instance
         .as_ref()
         .map(|instance| instance.agent_id.to_string());
+    // Project-tool sessions (task-extract, spec-generate, etc.) don't
+    // have a live aura-storage session row — they're one-off harness
+    // invocations. But the router still needs `x-aura-org-id` to
+    // attribute their cost to the project's org. Resolve and stamp it
+    // here. `aura_session_id` stays None (no storage session); the
+    // loosened router accepts `project_id` alone for cost attribution
+    // so that's enough.
+    let aura_org_id = state
+        .project_service
+        .get_project(project_id)
+        .ok()
+        .map(|p| p.org_id.to_string());
+
     SessionConfig {
         agent_id: agent_id_field,
         template_agent_id: template_agent_id_field,
@@ -185,6 +198,7 @@ pub(crate) async fn project_tool_session_config(
         project_path,
         installed_tools,
         installed_integrations,
+        aura_org_id,
         ..Default::default()
     }
 }


### PR DESCRIPTION
## Summary

Closes Neo's two highest-impact stats blockers — Tokens=0 and Cost=$0.99 — by patching three refactor-introduced gaps in the dev-loop's token/cost data flow.

**Project delete** is already fixed in production from earlier work (deployed via aura-network); this PR doesn't touch that.

**Lines** stat is intentionally **not** addressed here — that requires aura-harness changes against 109 upstream commits and a deferred Phase 4 PR.

## What this PR does

### 1. Wire `persist_task_output` to `task_completed` / `task_failed` events
File: `apps/aura-os-server/src/handlers/dev_loop/streaming/side_effects.rs`

`persist_task_output` in `apps/aura-os-server/src/persistence.rs:188` was dead code with **zero callers** in the entire codebase, despite its docstring saying it should be called when a task completes/fails. Tokens accumulated in `task_output_cache.total_input_tokens/total_output_tokens` by `update_usage_cache` on every `assistant_message_end`/`token_usage` event were silently discarded — never written to `tasks.total_input_tokens/total_output_tokens` in aura-storage. **This was the primary cause of "Tokens=0" on the dashboard.**

Both terminal task-event handlers now call a new `persist_cached_task_output` helper that drains the cached entry, hands it to `persist_task_output` (already correctly built — only the wiring was missing), and removes it from the in-memory map.

### 2. Stamp aura-* attribution headers on `generate_session_summary`
File: `apps/aura-os-server/src/handlers/agents/sessions.rs`

The session-summary Haiku call previously hit aura-router with only `Authorization: Bearer <jwt>` — no `x-aura-session-id` / `x-aura-project-id` / `x-aura-agent-id`. aura-router's `SessionContext::from_headers` returned None and the resulting `token_usage_daily` row got `project_id = NULL` — silently excluded from per-project cost aggregation. Function signature now accepts `project_id` + `agent_id` and stamps them.

### 3. Populate `aura_org_id` in `project_tool_session_config`
File: `apps/aura-os-server/src/handlers/projects_helpers/session.rs`

Spec-generate and task-extract harness sessions (project tool sessions) didn't set `aura_org_id`, so their cost rows landed with `org_id = NULL` and were invisible to org-level usage queries. Now resolved from the project's org and stamped on the SessionConfig.

## Already-deployed pieces this PR depends on

- **aura-storage** (just deployed): stats SQL now sums tokens from `tasks` (where this PR's wiring lands them) instead of `sessions`.
- **aura-router** (just deployed): loosened `SessionContext::from_headers` to accept partial header sets + stamps `agent_id` + uses cache-aware cost.

## Tests

- 300 existing aura-os-server unit tests still pass (no regressions).
- aura-storage gained a focused test verifying tokens come from `tasks` and historical session-token rows do NOT contribute.
- aura-router added 5 inline unit tests covering header subsets + early-return on `store_events`.

## After-merge verification (curl + SQL)

After this PR merges and aura-app/aura-api redeploy, run a real coding session in AURA, then:

```sql
-- aura-storage: token totals should now be non-zero
SELECT id, total_input_tokens, total_output_tokens, updated_at
FROM tasks ORDER BY updated_at DESC LIMIT 5;

-- aura-network: cost rows should have non-NULL project_id and agent_id
SELECT project_id, agent_id, estimated_cost_usd, duration_ms, date
FROM token_usage_daily ORDER BY date DESC, id DESC LIMIT 10;
```

Or just observe the dashboard: Tokens tile should show non-zero, Cost tile should show full project spend.

## Rollback

Render → redeploy previous on aura-app + aura-api. No DB cleanup needed — the persistence path stays inert if the wiring isn't called.

## Out of scope (deferred)

- **Lines stat** — requires aura-harness changes against 109 upstream commits including a major rename refactor. Deferred to a separate PR.
- **Per-task model time** — needs `x-aura-task-id` stamping on every LLM call during a task. Best done with someone who owns the harness.
- **Restore UI for soft-deleted projects** — deferred.
