### PR TITLE
fix(stats): wire files_changed cache + merge per-turn diffs (Lines stat)

### DIFF
--- a/apps/aura-os-server/src/handlers/dev_loop/streaming/side_effects.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/streaming/side_effects.rs
@@ -518,18 +518,21 @@ async fn update_usage_cache(
 /// always-empty too.
 ///
 /// Reads the protocol-typed `created` / `modified` / `deleted` arrays
-/// for the file list, then joins per-path against the new `diffs`
-/// array (which the harness populates from `edit_file` line counts) to
-/// fill `lines_added` / `lines_removed` on the persisted summary. Paths
+/// for the file list, then joins per-path against the `diffs` array
+/// (which the harness populates from per-tool line counts) to fill
+/// `lines_added` / `lines_removed` on the persisted summary. Paths
 /// without a `diffs` entry fall through to 0 — that's the "unknown"
 /// signal the dashboard should treat as missing data, not as a real
 /// zero-line change.
 ///
-/// Idempotency: the cache field is rebuilt from scratch on every
-/// `assistant_message_end`, so out-of-order delivery is harmless. We
-/// keep the most recently received summary because the harness emits
-/// the event once per turn with the cumulative net effect — there is
-/// no incremental-append semantics to preserve.
+/// Cross-turn merge: the harness's `AgentLoopResult.file_changes` is
+/// per-turn, so each `assistant_message_end` carries only that turn's
+/// mutations. Multi-turn tasks (the common case in the dev loop) need
+/// their per-turn summaries combined into a single net-effect view per
+/// path, mirroring the within-turn collapse rules aura-agent already
+/// enforces in `record_file_change`. Without this, a task that edits
+/// `lib.rs` in turn 1 and `main.rs` in turn 2 would persist only the
+/// turn-2 change and silently drop turn 1.
 async fn record_files_changed(
     state: &AppState,
     project_id: ProjectId,
@@ -542,14 +545,87 @@ async fn record_files_changed(
     let Some(files) = event.get("files_changed") else {
         return;
     };
-    let summary = build_files_changed_summary(files);
-    if summary.is_empty() {
+    let incoming = build_files_changed_summary(files);
+    if incoming.is_empty() {
         return;
     }
 
     let mut cache = state.task_output_cache.lock().await;
     let entry = cache.entry(key).or_default();
-    entry.files_changed = summary;
+    for change in incoming {
+        merge_file_change(&mut entry.files_changed, change);
+    }
+}
+
+/// Merge a freshly-arrived per-path summary into the existing cache
+/// vector with the same kind-collapse semantics aura-agent applies
+/// within a single turn (see `aura_agent::AgentLoopResult::record_file_change`).
+///
+/// Line counts always sum across merges (`saturating_add` guards the
+/// pathological overflow case). The kind transition table:
+///
+/// | existing | incoming | result    |
+/// |----------|----------|-----------|
+/// | Create   | Modify   | Create    |
+/// | Create   | Delete   | (dropped) |
+/// | Modify   | Modify   | Modify    |
+/// | Modify   | Delete   | Delete    |
+/// | Delete   | Create   | Modify    |
+/// | Delete   | Modify   | Modify    |
+/// | otherwise (same/unknown) | (incoming kind wins) |
+///
+/// Create→Delete drops the entry entirely (the file existed only
+/// transiently across the merged turns) and the accumulated line
+/// counts go with it — matches the within-turn behavior so a file
+/// that's created in turn 1 and deleted in turn 3 doesn't pollute
+/// the dashboard with a phantom line count.
+fn merge_file_change(
+    target: &mut Vec<StorageTaskFileChangeSummary>,
+    incoming: StorageTaskFileChangeSummary,
+) {
+    let Some(idx) = target.iter().position(|c| c.path == incoming.path) else {
+        target.push(incoming);
+        return;
+    };
+    let collapsed = collapse_op(target[idx].op.as_str(), incoming.op.as_str());
+    if collapsed.is_none() {
+        // Create → Delete: net effect is "no file"; drop the entry
+        // entirely along with its accumulated counts.
+        target.swap_remove(idx);
+        return;
+    }
+    target[idx].lines_added = target[idx]
+        .lines_added
+        .saturating_add(incoming.lines_added);
+    target[idx].lines_removed = target[idx]
+        .lines_removed
+        .saturating_add(incoming.lines_removed);
+    if let Some(op) = collapsed {
+        target[idx].op = op.to_string();
+    }
+}
+
+/// Decide the post-merge `op` value for a path that already has an
+/// entry. Returns `None` when the merge net-effect is "no file"
+/// (`Create` followed by `Delete`); the caller drops the entry in
+/// that case.
+fn collapse_op(existing: &str, incoming: &str) -> Option<&'static str> {
+    match (existing, incoming) {
+        ("create", "modify") => Some("create"),
+        ("create", "delete") => None,
+        ("modify", "modify") => Some("modify"),
+        ("modify", "delete") => Some("delete"),
+        ("delete", "create") => Some("modify"),
+        ("delete", "modify") => Some("modify"),
+        ("create", "create") => Some("create"),
+        ("delete", "delete") => Some("delete"),
+        // Any unrecognized op string falls through to the incoming
+        // value, matching the within-turn fallback in aura-agent.
+        (_, "create") => Some("create"),
+        (_, "modify") => Some("modify"),
+        (_, "delete") => Some("delete"),
+        _ => Some("modify"),
+    }
 }
 
 /// Pure conversion from a `files_changed` JSON payload (as emitted on
@@ -648,8 +724,18 @@ async fn persist_cached_task_output(
 
 #[cfg(test)]
 mod tests {
-    use super::build_files_changed_summary;
+    use super::{build_files_changed_summary, collapse_op, merge_file_change};
+    use aura_os_storage::StorageTaskFileChangeSummary;
     use serde_json::json;
+
+    fn s(path: &str, op: &str, added: u32, removed: u32) -> StorageTaskFileChangeSummary {
+        StorageTaskFileChangeSummary {
+            op: op.to_string(),
+            path: path.to_string(),
+            lines_added: added,
+            lines_removed: removed,
+        }
+    }
 
     #[test]
     fn build_files_changed_summary_groups_paths_by_op() {
@@ -716,5 +802,159 @@ mod tests {
         assert_eq!(summary.len(), 1);
         assert_eq!(summary[0].lines_added, u32::MAX);
         assert_eq!(summary[0].lines_removed, 0);
+    }
+
+    // ====================================================================
+    // collapse_op — kind-transition table (mirrors aura_agent's within-turn
+    // record_file_change so cross-turn merges in the cache stay consistent
+    // with the harness's net-effect semantics).
+    // ====================================================================
+
+    #[test]
+    fn collapse_op_create_then_modify_keeps_create() {
+        assert_eq!(collapse_op("create", "modify"), Some("create"));
+    }
+
+    #[test]
+    fn collapse_op_create_then_delete_drops_entry() {
+        assert_eq!(collapse_op("create", "delete"), None);
+    }
+
+    #[test]
+    fn collapse_op_modify_then_modify_stays_modify() {
+        assert_eq!(collapse_op("modify", "modify"), Some("modify"));
+    }
+
+    #[test]
+    fn collapse_op_modify_then_delete_becomes_delete() {
+        assert_eq!(collapse_op("modify", "delete"), Some("delete"));
+    }
+
+    #[test]
+    fn collapse_op_delete_then_create_becomes_modify() {
+        // The file existed before the turn, was deleted, then re-created
+        // with potentially different content — net effect is a modify
+        // (matches aura_agent::record_file_change).
+        assert_eq!(collapse_op("delete", "create"), Some("modify"));
+    }
+
+    #[test]
+    fn collapse_op_delete_then_modify_becomes_modify() {
+        assert_eq!(collapse_op("delete", "modify"), Some("modify"));
+    }
+
+    #[test]
+    fn collapse_op_create_then_create_stays_create() {
+        // Pathological idempotent case (shouldn't happen with a sane
+        // harness) but the merge must still be deterministic.
+        assert_eq!(collapse_op("create", "create"), Some("create"));
+    }
+
+    #[test]
+    fn collapse_op_delete_then_delete_stays_delete() {
+        assert_eq!(collapse_op("delete", "delete"), Some("delete"));
+    }
+
+    #[test]
+    fn collapse_op_unknown_existing_falls_through_to_incoming() {
+        // Defensive fallback: if an upstream contract drift ever
+        // serialised an unrecognised existing op, take the incoming
+        // value rather than panicking.
+        assert_eq!(collapse_op("rename", "modify"), Some("modify"));
+        assert_eq!(collapse_op("rename", "create"), Some("create"));
+        assert_eq!(collapse_op("rename", "delete"), Some("delete"));
+    }
+
+    #[test]
+    fn collapse_op_unknown_pair_defaults_to_modify() {
+        // Both ends unrecognised — pick the safest non-destructive
+        // bucket so the row still surfaces in the dashboard.
+        assert_eq!(collapse_op("rename", "rename"), Some("modify"));
+    }
+
+    // ====================================================================
+    // merge_file_change — applies collapse_op + sums lines on a Vec target.
+    // ====================================================================
+
+    #[test]
+    fn merge_file_change_inserts_new_path() {
+        let mut target = vec![s("src/a.rs", "modify", 1, 1)];
+        merge_file_change(&mut target, s("src/b.rs", "create", 5, 0));
+        assert_eq!(target.len(), 2);
+        let b = target.iter().find(|c| c.path == "src/b.rs").unwrap();
+        assert_eq!(b.op, "create");
+        assert_eq!(b.lines_added, 5);
+    }
+
+    #[test]
+    fn merge_file_change_sums_line_counts_on_existing_path() {
+        let mut target = vec![s("src/lib.rs", "modify", 10, 2)];
+        merge_file_change(&mut target, s("src/lib.rs", "modify", 5, 3));
+        assert_eq!(target.len(), 1);
+        assert_eq!(target[0].lines_added, 15);
+        assert_eq!(target[0].lines_removed, 5);
+    }
+
+    #[test]
+    fn merge_file_change_create_then_delete_drops_entry_and_counts() {
+        let mut target = vec![
+            s("src/keep.rs", "modify", 1, 1),
+            s("src/temp.rs", "create", 100, 0),
+        ];
+        merge_file_change(&mut target, s("src/temp.rs", "delete", 0, 0));
+        assert_eq!(target.len(), 1);
+        assert_eq!(target[0].path, "src/keep.rs");
+    }
+
+    #[test]
+    fn merge_file_change_create_then_modify_preserves_create_kind() {
+        let mut target = vec![s("src/new.rs", "create", 7, 0)];
+        merge_file_change(&mut target, s("src/new.rs", "modify", 3, 1));
+        assert_eq!(target.len(), 1);
+        assert_eq!(target[0].op, "create");
+        assert_eq!(target[0].lines_added, 10);
+        assert_eq!(target[0].lines_removed, 1);
+    }
+
+    #[test]
+    fn merge_file_change_clamps_at_u32_max() {
+        let mut target = vec![s("x", "modify", u32::MAX - 1, 0)];
+        merge_file_change(&mut target, s("x", "modify", 5, 0));
+        assert_eq!(target[0].lines_added, u32::MAX);
+    }
+
+    // ====================================================================
+    // Regression test for the multi-turn merge bug — the original case
+    // that motivated the merge-not-overwrite redesign.
+    // ====================================================================
+
+    #[test]
+    fn merge_preserves_paths_across_simulated_turns() {
+        // Turn 1: edits src/lib.rs (+5/-2)
+        // Turn 2: edits src/main.rs (+10/-0)
+        // Turn 3: re-edits src/lib.rs (+3/-1) and creates src/new.rs (+8/-0)
+        // Final cache must show all three paths with summed line counts —
+        // the original overwrite-on-each-call implementation only kept
+        // the last turn's payload.
+        let mut target: Vec<StorageTaskFileChangeSummary> = Vec::new();
+
+        merge_file_change(&mut target, s("src/lib.rs", "modify", 5, 2));
+        merge_file_change(&mut target, s("src/main.rs", "modify", 10, 0));
+        merge_file_change(&mut target, s("src/lib.rs", "modify", 3, 1));
+        merge_file_change(&mut target, s("src/new.rs", "create", 8, 0));
+
+        assert_eq!(target.len(), 3, "all three paths must survive merging");
+
+        let lib = target.iter().find(|c| c.path == "src/lib.rs").unwrap();
+        assert_eq!(lib.op, "modify");
+        assert_eq!(lib.lines_added, 8); // 5 + 3
+        assert_eq!(lib.lines_removed, 3); // 2 + 1
+
+        let main = target.iter().find(|c| c.path == "src/main.rs").unwrap();
+        assert_eq!(main.lines_added, 10);
+
+        let new = target.iter().find(|c| c.path == "src/new.rs").unwrap();
+        assert_eq!(new.op, "create");
+        assert_eq!(new.lines_added, 8);
     }
 }

--- a/apps/aura-os-server/src/handlers/dev_loop/streaming/side_effects.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/streaming/side_effects.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 
 use aura_os_core::{AgentInstanceId, ProjectId, SessionId, TaskId, TaskStatus};
 use aura_os_events::{DomainEvent, LegacyJsonEvent};
-use aura_os_storage::UpdateTaskRequest;
+use aura_os_storage::{StorageTaskFileChangeSummary, UpdateTaskRequest};
 
 use crate::state::{AppState, CachedTaskOutput, TestPassEvidence};
 
@@ -176,8 +176,13 @@ async fn apply_event_side_effect(
             }
         }
         "token_usage" | "assistant_message_end" | "usage" | "session_usage" => {
-            if let Some(task_id) = task_id {
+            if let Some(task_id) = task_id.as_deref() {
                 update_usage_cache(state, project_id, task_id, event).await;
+            }
+            if event_type == "assistant_message_end" {
+                if let Some(task_id) = task_id.as_deref() {
+                    record_files_changed(state, project_id, task_id, event).await;
+                }
             }
         }
         _ => {}
@@ -503,6 +508,103 @@ async fn update_usage_cache(
     }
 }
 
+/// Drain `assistant_message_end.files_changed` into the per-task cache.
+///
+/// Closes the long-standing "Lines = 0" dashboard gap. The cache field
+/// has documented `Populated from … assistant_message_end` semantics
+/// since the dev-loop refactor, but no production code path was
+/// actually wiring the event payload into the cache — leaving
+/// `cached.files_changed` always-empty and so `tasks.files_changed`
+/// always-empty too.
+///
+/// Reads the protocol-typed `created` / `modified` / `deleted` arrays
+/// for the file list, then joins per-path against the new `diffs`
+/// array (which the harness populates from `edit_file` line counts) to
+/// fill `lines_added` / `lines_removed` on the persisted summary. Paths
+/// without a `diffs` entry fall through to 0 — that's the "unknown"
+/// signal the dashboard should treat as missing data, not as a real
+/// zero-line change.
+///
+/// Idempotency: the cache field is rebuilt from scratch on every
+/// `assistant_message_end`, so out-of-order delivery is harmless. We
+/// keep the most recently received summary because the harness emits
+/// the event once per turn with the cumulative net effect — there is
+/// no incremental-append semantics to preserve.
+async fn record_files_changed(
+    state: &AppState,
+    project_id: ProjectId,
+    task_id: &str,
+    event: &serde_json::Value,
+) {
+    let Some(key) = parse_task_key(project_id, task_id) else {
+        return;
+    };
+    let Some(files) = event.get("files_changed") else {
+        return;
+    };
+    let summary = build_files_changed_summary(files);
+    if summary.is_empty() {
+        return;
+    }
+
+    let mut cache = state.task_output_cache.lock().await;
+    let entry = cache.entry(key).or_default();
+    entry.files_changed = summary;
+}
+
+/// Pure conversion from a `files_changed` JSON payload (as emitted on
+/// `assistant_message_end`) to the typed summary the cache stores.
+///
+/// Joins per-path against the `diffs` array (sent by the harness for
+/// tools that compute a real line diff — currently `edit_file`) to fill
+/// `lines_added` / `lines_removed`. Paths without a matching diff entry
+/// keep counts at 0; consumers must read 0 as "unknown" rather than
+/// "no change".
+fn build_files_changed_summary(files: &serde_json::Value) -> Vec<StorageTaskFileChangeSummary> {
+    let lookup_lines = |path: &str| -> (u32, u32) {
+        let Some(diffs) = files.get("diffs").and_then(|v| v.as_array()) else {
+            return (0, 0);
+        };
+        for diff in diffs {
+            if diff.get("path").and_then(|v| v.as_str()) == Some(path) {
+                let added = diff
+                    .get("lines_added")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0);
+                let removed = diff
+                    .get("lines_removed")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0);
+                return (
+                    u32::try_from(added).unwrap_or(u32::MAX),
+                    u32::try_from(removed).unwrap_or(u32::MAX),
+                );
+            }
+        }
+        (0, 0)
+    };
+
+    let mut summary: Vec<StorageTaskFileChangeSummary> = Vec::new();
+    for (op, field) in [
+        ("create", "created"),
+        ("modify", "modified"),
+        ("delete", "deleted"),
+    ] {
+        if let Some(paths) = files.get(field).and_then(|v| v.as_array()) {
+            for path in paths.iter().filter_map(|v| v.as_str()) {
+                let (lines_added, lines_removed) = lookup_lines(path);
+                summary.push(StorageTaskFileChangeSummary {
+                    op: op.to_string(),
+                    path: path.to_string(),
+                    lines_added,
+                    lines_removed,
+                });
+            }
+        }
+    }
+    summary
+}
+
 /// Parse a free-form task id string into a typed cache key. Returns
 /// `None` for non-UUID task ids; the caller silently drops the entry
 /// in that case (legacy harness payloads occasionally carry synthetic
@@ -542,4 +644,77 @@ async fn persist_cached_task_output(
         &cached,
     )
     .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_files_changed_summary;
+    use serde_json::json;
+
+    #[test]
+    fn build_files_changed_summary_groups_paths_by_op() {
+        let files = json!({
+            "created": ["src/new.rs"],
+            "modified": ["src/lib.rs"],
+            "deleted": ["src/old.rs"],
+        });
+        let summary = build_files_changed_summary(&files);
+        assert_eq!(summary.len(), 3);
+        assert_eq!(summary[0].op, "create");
+        assert_eq!(summary[0].path, "src/new.rs");
+        assert_eq!(summary[1].op, "modify");
+        assert_eq!(summary[2].op, "delete");
+        // No diffs supplied -> counts default to 0 across the board.
+        assert!(summary.iter().all(|s| s.lines_added == 0));
+        assert!(summary.iter().all(|s| s.lines_removed == 0));
+    }
+
+    #[test]
+    fn build_files_changed_summary_joins_diffs_by_path() {
+        let files = json!({
+            "created": [],
+            "modified": ["src/lib.rs", "src/main.rs"],
+            "deleted": [],
+            "diffs": [
+                {"path": "src/lib.rs", "lines_added": 12, "lines_removed": 3},
+                // src/main.rs intentionally absent — exercises the
+                // "unknown" / 0-fallback branch.
+            ],
+        });
+        let summary = build_files_changed_summary(&files);
+        assert_eq!(summary.len(), 2);
+
+        let lib = summary.iter().find(|s| s.path == "src/lib.rs").unwrap();
+        assert_eq!(lib.lines_added, 12);
+        assert_eq!(lib.lines_removed, 3);
+
+        let main = summary.iter().find(|s| s.path == "src/main.rs").unwrap();
+        assert_eq!(main.lines_added, 0);
+        assert_eq!(main.lines_removed, 0);
+    }
+
+    #[test]
+    fn build_files_changed_summary_returns_empty_when_no_paths() {
+        let files = json!({
+            "created": [],
+            "modified": [],
+            "deleted": [],
+        });
+        assert!(build_files_changed_summary(&files).is_empty());
+    }
+
+    #[test]
+    fn build_files_changed_summary_clamps_pathological_line_counts() {
+        let files = json!({
+            "modified": ["x"],
+            "diffs": [
+                // u32::MAX + 1 — out-of-range u32 should clamp, not panic.
+                {"path": "x", "lines_added": 4_294_967_296u64, "lines_removed": 0},
+            ],
+        });
+        let summary = build_files_changed_summary(&files);
+        assert_eq!(summary.len(), 1);
+        assert_eq!(summary[0].lines_added, u32::MAX);
+        assert_eq!(summary[0].lines_removed, 0);
+    }
 }

--- a/crates/aura-protocol/src/lib.rs
+++ b/crates/aura-protocol/src/lib.rs
@@ -54,7 +54,7 @@ pub use permissions::{
     AgentPermissionsWire, AgentScopeWire, AgentToolPermissionsWire, CapabilityWire,
 };
 pub use server::{
-    AssistantMessageEnd, AssistantMessageStart, ErrorMsg, FileOp, FilesChanged,
+    AssistantMessageEnd, AssistantMessageStart, ErrorMsg, FileDiff, FileOp, FilesChanged,
     GenerationCompleted, GenerationErrorMsg, GenerationPartialImage, GenerationProgressMsg,
     GenerationStart, OutboundMessage, SessionReady, SessionUsage, SkillInfo, TextDelta,
     ThinkingDelta, ToolApprovalPrompt, ToolCallSnapshot, ToolInfo, ToolResultMsg, ToolUseStart,

--- a/crates/aura-protocol/src/server.rs
+++ b/crates/aura-protocol/src/server.rs
@@ -190,13 +190,35 @@ pub struct FileOp {
     pub operation: String,
 }
 
+/// Per-file diff metadata that runs alongside the path lists in
+/// [`FilesChanged`]. Optional and additive: senders that don't compute
+/// line counts (older harnesses, write/delete tool paths) simply omit
+/// the entry, and consumers must treat "no entry for path" / "0 / 0"
+/// as "unknown", not "no change".
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typescript", derive(TS), ts(export))]
+pub struct FileDiff {
+    pub path: String,
+    pub lines_added: u32,
+    pub lines_removed: u32,
+}
+
 /// Summary of file mutations during a turn.
+///
+/// `diffs` is a parallel list of per-path line-count metadata. It lives
+/// alongside `created` / `modified` / `deleted` (rather than replacing
+/// them) so older clients that only know about the path lists keep
+/// working untouched. The serde default + skip_if_empty pair keeps the
+/// wire format byte-identical when no diffs are computed, preserving
+/// JSON-shape compatibility with any pinned schemas.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "typescript", derive(TS), ts(export))]
 pub struct FilesChanged {
     pub created: Vec<String>,
     pub modified: Vec<String>,
     pub deleted: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diffs: Vec<FileDiff>,
 }
 
 impl FilesChanged {


### PR DESCRIPTION
## Summary

Closes the dashboard's "Lines = 0" gap end-to-end on the server side: extends the `FilesChanged` protocol with per-path line counts, wires the previously-aspirational `task_output_cache.files_changed` field to the canonical `assistant_message_end` signal, and merges per-turn payloads with the same kind-collapse rules the harness already uses within a turn.

Pairs with cypher-asi/aura-harness PR (link to follow) which produces the line-diff data this PR consumes.

## Why

`task_output_cache.files_changed` has had a doc-comment promising "Populated from … `assistant_message_end`" since the dev-loop refactor, but no production code path was wiring the event payload into the cache. Result: `cached.files_changed` was always empty, `persist_task_output`'s files_changed branch never fired, `tasks.files_changed` JSONB stayed null, and the per-project stats endpoint summed 0 lines no matter how much code the agent wrote.

## What this PR does

### 1. `feat(protocol): add per-path line diffs to FilesChanged` (`f1991cc9`)

- New `FileDiff { path, lines_added, lines_removed }` struct.
- `FilesChanged.diffs: Vec<FileDiff>` parallel field (path lists unchanged).
- `#[serde(default, skip_serializing_if = "Vec::is_empty")]` — wire format byte-identical when no diffs.
- `is_empty()` semantics intentionally unchanged (UI's "did anything change this turn?" check stays correct).
- `FileDiff` re-exported from crate root next to `FilesChanged`.

### 2. `feat(stats): populate per-task files_changed cache from assistant events` (`84d7ec2d`)

- `record_event_side_effects` now invokes a new `record_files_changed` helper alongside `update_usage_cache` whenever an `assistant_message_end` carries a `task_id`. Other events in the existing match arm (`token_usage` / `usage` / `session_usage`) still skip the files-changed branch — only `assistant_message_end` carries the cumulative `FilesChanged` payload.
- `record_files_changed` extracts the path lists, joins per-path against the new `diffs` array, and writes typed `Vec<StorageTaskFileChangeSummary>` into the cache.
- Pure conversion logic extracted into `build_files_changed_summary` for unit testing without spinning up `AppState`.

### 3. `fix(stats): merge per-turn files_changed instead of overwriting` (`8e975a39`)

**Real correctness bug found in self-review:** the original `record_files_changed` overwrote the cache field on every `assistant_message_end`, but the harness emits that event **per-turn**, not cumulatively. A multi-turn task that edited `src/lib.rs` in turn 1 and `src/main.rs` in turn 2 would persist only the turn-2 entry — turn 1 silently dropped.

Fix replaces overwrite with a per-path merge mirroring the within-turn collapse rules `aura-agent::AgentLoopResult::record_file_change` already enforces:

| existing | incoming | result |
|---|---|---|
| Create | Modify | Create |
| Create | Delete | (dropped — net effect "no file") |
| Modify | Modify | Modify |
| Modify | Delete | Delete |
| Delete | Create | Modify |
| Delete | Modify | Modify |
| same op | (kept) |
| unknown | (defensive fallback to incoming, then "modify") |

Line counts always sum across merges via `saturating_add`.

## Tests

- `aura-os-server` 320 passed (0 failed)
- `aura-protocol` 3 passed (0 failed)

**20 new tests** covering:
- `build_files_changed_summary` (path grouping, diff-by-path join, empty-input short-circuit, `u32::MAX` clamp) — 4
- `collapse_op` full kind-transition matrix + idempotents + unknown-op fallbacks — 10
- `merge_file_change` (insert new path, sum on existing, drop on Create→Delete, preserve Create kind, saturating clamp) — 5
- `merge_preserves_paths_across_simulated_turns` — regression test simulating the exact 4-step multi-turn pattern that was failing before `8e975a39`

## End-to-end flow (after merge + paired aura-harness PR + nightly/swarm redeploy)

1. Agent calls `edit_file` / `write_file` / `delete_file` →
2. Tool computes line diff at execution time, attaches to `ToolResult.line_diff` →
3. Kernel boundary copies into `ToolOutput.line_diff` →
4. `aura-agent::kernel_gateway` reads it into `FileChange.lines_added/_removed` →
5. `aura-runtime::summarize_files_changed` emits `FilesChanged.diffs` on `assistant_message_end` →
6. **This PR**: `record_files_changed` joins paths with diffs and merges into the per-task cache →
7. `persist_task_output` (already wired in #5) writes them to `tasks.files_changed` JSONB on completion →
8. aura-storage stats SQL (already wired) sums per project → dashboard shows real Lines stat.

## Rollback

Single-commit reverts. Protocol changes are additive (`#[serde(default)]`) so old/new senders & receivers stay compatible regardless of merge order.
