### PR TITLE
feat(chat): add @-mention file autocomplete to chat input

### DIFF
--- a/interface/src/apps/agents/components/AgentChatPanel/AgentChatPanel.tsx
+++ b/interface/src/apps/agents/components/AgentChatPanel/AgentChatPanel.tsx
@@ -20,6 +20,7 @@ import { useHydrateContextUtilization } from "../../../../hooks/use-hydrate-cont
 import type { AgentInstance, Project } from "../../../../shared/types";
 import { useAuraCapabilities } from "../../../../hooks/use-aura-capabilities";
 import { useAgentBusy } from "../../../../hooks/use-agent-busy";
+import { useTerminalTarget } from "../../../../hooks/use-terminal-target";
 import { useFreshCanvas } from "../../hooks/use-fresh-canvas";
 import { useOptimisticSessionRow } from "../../hooks/use-optimistic-session-row";
 import { useAutoRenameFromPrompt } from "../../hooks/use-auto-rename-from-prompt";
@@ -88,6 +89,12 @@ export function AgentChatPanel({
 
   const { agentName, machineType, templateAgentId, adapterType, defaultModel } =
     useAgentChatMeta("project", { projectId, agentInstanceId });
+
+  // Resolves the project's workspace path (and remote-agent id when
+  // the project's agent runs on a remote VM). Same hook the file
+  // explorer + terminal use, so @-mention reads the same tree the
+  // user sees in the side panel.
+  const terminalTarget = useTerminalTarget({ projectId, agentInstanceId });
 
   const optimisticRow = useOptimisticSessionRow({
     projectId,
@@ -296,6 +303,8 @@ export function AgentChatPanel({
     historyMessages,
     projects: currentProject,
     selectedProjectId: projectId,
+    workspacePath: terminalTarget.workspacePath,
+    remoteAgentId: terminalTarget.remoteAgentId,
     contextUsage,
     onNewSession: fresh.newSession,
     onNewChat: () => {

--- a/interface/src/apps/chat/components/ChatInputBar/ChatInputBar.module.css
+++ b/interface/src/apps/chat/components/ChatInputBar/ChatInputBar.module.css
@@ -643,6 +643,27 @@
   white-space: nowrap;
 }
 
+/* ── @-file mention menu ─────────────────────────────────────── */
+
+/* The mention menu reuses .slashMenu / .slashMenuItem chrome; these
+   tweaks add the file icon and a slightly lighter grid (path and
+   name share the row, so descriptions get more breathing room). */
+.mentionMenuItem {
+  gap: 6px;
+}
+
+.mentionMenuIcon {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.mentionMenuEmpty {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
 /* Hide chat-only info-bar chrome on narrow viewports. The shell
  * stylesheet handles responsive sizing for everything it owns
  * (model picker, textarea, send/attach buttons); we only need

--- a/interface/src/apps/chat/components/ChatInputBar/ChatInputBar.tsx
+++ b/interface/src/apps/chat/components/ChatInputBar/ChatInputBar.tsx
@@ -44,6 +44,8 @@ import {
   type InputBarShellHandle,
 } from "../../../../components/InputBarShell";
 import { SlashCommandMenu } from "./SlashCommandMenu";
+import { FileMentionMenu } from "./FileMentionMenu";
+import { useProjectFiles } from "./useProjectFiles";
 import { CommandChips } from "./CommandChips";
 import { useChatUI } from "../../../../stores/chat-ui-store";
 import type { SlashCommand } from "../../../../constants/commands";
@@ -129,6 +131,20 @@ export interface ChatInputBarProps {
   projects?: Project[];
   selectedProjectId?: string;
   onProjectChange?: (projectId: string) => void;
+  /**
+   * Absolute path of the project's workspace on disk (or remote agent
+   * filesystem). When set, typing `@` in the textarea opens the file
+   * mention autocomplete; selecting a file reads it via the desktop /
+   * remote-agent API and attaches it as a text attachment. Standalone
+   * (project-less) chats omit this and the mention menu stays dormant.
+   */
+  workspacePath?: string;
+  /**
+   * When set, file reads for @-mention go through the swarm
+   * remote-agent API instead of the local desktop API. Mirrors the
+   * routing the file explorer uses.
+   */
+  remoteAgentId?: string;
   isVisible?: boolean;
   isCentered?: boolean;
   /**
@@ -211,6 +227,8 @@ export const DesktopChatInputBar = memo(
       projects = [],
       selectedProjectId,
       onProjectChange,
+      workspacePath,
+      remoteAgentId,
       isVisible = true,
       isCentered = false,
       compact = false,
@@ -255,6 +273,16 @@ export const DesktopChatInputBar = memo(
     const [slashMenuOpen, setSlashMenuOpen] = useState(false);
     const [slashQuery, setSlashQuery] = useState("");
     const slashStartRef = useRef<number | null>(null);
+    const [mentionMenuOpen, setMentionMenuOpen] = useState(false);
+    const [mentionQuery, setMentionQuery] = useState("");
+    const [mentionRefreshNonce, setMentionRefreshNonce] = useState(0);
+    const mentionStartRef = useRef<number | null>(null);
+    const canUseMentions = Boolean(workspacePath);
+    const projectFiles = useProjectFiles({
+      workspacePath: canUseMentions ? workspacePath : undefined,
+      remoteAgentId,
+      refreshNonce: mentionRefreshNonce,
+    });
     const projectMenuRef = useRef<HTMLDivElement>(null);
     const shellRef = useRef<InputBarShellHandle>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -272,11 +300,12 @@ export const DesktopChatInputBar = memo(
       [],
     );
 
-    const { canAddMore, addFiles, handleRemove } = useFileAttachments(
+    const { canAddMore, addFiles, addFileFromPath, handleRemove } = useFileAttachments(
       attachments,
       onAttachmentsChange,
       onRemoveAttachment,
       textareaRefShim as React.RefObject<HTMLTextAreaElement | null>,
+      remoteAgentId,
     );
 
     useEffect(() => {
@@ -491,23 +520,72 @@ export const DesktopChatInputBar = memo(
           setSlashQuery("");
           slashStartRef.current = null;
         }
+
+        // @-mention detection mirrors the slash-menu trigger shape but
+        // is only armed when the surrounding chat is project-scoped
+        // (workspacePath is set). The two menus are mutually exclusive
+        // in practice — `@` and `/` are different leading tokens — so
+        // no tie-breaking is needed here.
+        if (canUseMentions) {
+          const mentionMatch = textBefore.match(/(^|\s)@(\S*)$/);
+          if (mentionMatch) {
+            const wasClosed = !mentionMenuOpen;
+            mentionStartRef.current = textBefore.lastIndexOf("@");
+            setMentionQuery(mentionMatch[2]);
+            setMentionMenuOpen(true);
+            // Refresh the file listing the moment the menu opens so
+            // newly-created files show up without waiting for the
+            // explorer's 3s polling loop.
+            if (wasClosed) setMentionRefreshNonce((n) => n + 1);
+          } else if (mentionMenuOpen) {
+            setMentionMenuOpen(false);
+            setMentionQuery("");
+            mentionStartRef.current = null;
+          }
+        }
       },
-      [onInputChange, slashMenuOpen],
+      [canUseMentions, mentionMenuOpen, onInputChange, slashMenuOpen],
     );
 
     const handleTextareaKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (
-          slashMenuOpen &&
+          (slashMenuOpen || mentionMenuOpen) &&
           ["ArrowDown", "ArrowUp", "Enter", "Tab", "Escape"].includes(e.key)
         ) {
-          // The slash menu owns these keys while open; preventDefault tells
-          // the shell not to treat Enter as submit.
+          // The slash / mention menu owns these keys while open;
+          // preventDefault tells the shell not to treat Enter as submit.
           e.preventDefault();
         }
       },
-      [slashMenuOpen],
+      [slashMenuOpen, mentionMenuOpen],
     );
+
+    const handleMentionSelect = useCallback(
+      (file: { path: string; name: string }) => {
+        // Strip the `@query` token from the input the same way the
+        // slash menu strips its `/cmd` token, then push the file into
+        // the attachment pipeline (S3 upload starts in the background).
+        if (mentionStartRef.current !== null) {
+          const before = input.slice(0, mentionStartRef.current);
+          const afterAt = input.slice(mentionStartRef.current);
+          const spaceIdx = afterAt.indexOf(" ");
+          const after = spaceIdx === -1 ? "" : afterAt.slice(spaceIdx + 1);
+          onInputChange(before + after);
+        }
+        setMentionMenuOpen(false);
+        setMentionQuery("");
+        mentionStartRef.current = null;
+        void addFileFromPath(file.path);
+      },
+      [input, onInputChange, addFileFromPath],
+    );
+
+    const handleMentionClose = useCallback(() => {
+      setMentionMenuOpen(false);
+      setMentionQuery("");
+      mentionStartRef.current = null;
+    }, []);
 
     // 3D mode is a two-step in-bar pipeline: with no source image
     // pinned, the user types a prompt and the first send runs the
@@ -667,6 +745,14 @@ export const DesktopChatInputBar = memo(
               setSlashQuery("");
               slashStartRef.current = null;
             }}
+          />
+        )}
+        {mentionMenuOpen && canUseMentions && (
+          <FileMentionMenu
+            query={mentionQuery}
+            files={projectFiles}
+            onSelect={handleMentionSelect}
+            onClose={handleMentionClose}
           />
         )}
         <input

--- a/interface/src/apps/chat/components/ChatInputBar/FileMentionMenu.tsx
+++ b/interface/src/apps/chat/components/ChatInputBar/FileMentionMenu.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo, useRef, useState, memo } from "react";
+import { File } from "lucide-react";
+import { filterProjectFiles, type ProjectFile } from "./useProjectFiles";
+import styles from "./ChatInputBar.module.css";
+
+interface Props {
+  query: string;
+  files: ProjectFile[];
+  onSelect: (file: ProjectFile) => void;
+  onClose: () => void;
+}
+
+export const FileMentionMenu = memo(function FileMentionMenu({
+  query,
+  files,
+  onSelect,
+  onClose,
+}: Props) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const filtered = useMemo(() => filterProjectFiles(files, query), [files, query]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    const active = listRef.current?.querySelector(
+      `.${styles.slashMenuItemActive}`,
+    ) as HTMLElement | null;
+    active?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (filtered.length === 0) {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          onClose();
+        }
+        return;
+      }
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          setActiveIndex((i) => (i + 1) % filtered.length);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          setActiveIndex((i) => (i - 1 + filtered.length) % filtered.length);
+          break;
+        case "Enter":
+        case "Tab":
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          onSelect(filtered[activeIndex]);
+          break;
+        case "Escape":
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          onClose();
+          break;
+      }
+    },
+    [filtered, activeIndex, onSelect, onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [handleKeyDown]);
+
+  if (filtered.length === 0) {
+    return (
+      <div className={styles.slashMenu} ref={listRef}>
+        <div className={styles.mentionMenuEmpty}>No matching files</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.slashMenu} ref={listRef}>
+      {filtered.map((file, i) => (
+        <button
+          key={file.path}
+          type="button"
+          className={`${styles.slashMenuItem} ${styles.mentionMenuItem} ${i === activeIndex ? styles.slashMenuItemActive : ""}`}
+          onMouseEnter={() => setActiveIndex(i)}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(file);
+          }}
+        >
+          <File size={12} className={styles.mentionMenuIcon} />
+          <span className={styles.slashMenuItemLabel}>{file.name}</span>
+          <span className={styles.slashMenuItemDesc}>{file.relativePath}</span>
+        </button>
+      ))}
+    </div>
+  );
+});

--- a/interface/src/apps/chat/components/ChatInputBar/useFileAttachments.ts
+++ b/interface/src/apps/chat/components/ChatInputBar/useFileAttachments.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { AttachmentItem } from "./ChatInputBar";
 import { uploadFile } from "../../../../api/upload";
+import { api } from "../../../../api/client";
 
 const MAX_ATTACHMENTS = 5;
 const MAX_IMAGE_UPLOAD_BYTES = 1_100_000;
@@ -200,6 +201,12 @@ export function useFileAttachments(
   onAttachmentsChange?: (items: AttachmentItem[]) => void,
   onRemoveAttachment?: (id: string) => void,
   textareaRef?: React.RefObject<HTMLTextAreaElement | null>,
+  /**
+   * When set, `addFileFromPath` reads files via the remote-agent
+   * filesystem API (`api.swarm.readRemoteFile`) instead of the local
+   * desktop API. Mirrors the same routing the file explorer uses.
+   */
+  remoteAgentId?: string,
 ) {
   const attachmentsRef = useRef(attachments);
   useEffect(() => { attachmentsRef.current = attachments; }, [attachments]);
@@ -287,6 +294,59 @@ export function useFileAttachments(
     textareaRef?.current?.focus();
   }, [attachments, canAddMore, onAttachmentsChange, updateAttachment, textareaRef]);
 
+  /**
+   * Read a project file by path and attach it as a text attachment.
+   * Used by the @-mention autocomplete in the input bar; it skips the
+   * `processFile` dispatch (which is gated on browser-supplied MIME
+   * type / extension whitelist) because the user explicitly picked
+   * this file from the project tree — so any text-readable extension
+   * is fair game.
+   */
+  const addFileFromPath = useCallback(async (path: string) => {
+    if (!onAttachmentsChange) return;
+    if (!canAddMore) return;
+    const name = path.split(/[\\/]/).pop() ?? path;
+    if (attachmentsRef.current.some((a) => a.name === name && a.attachmentType === "text")) {
+      // Re-pick of the same file is a no-op rather than a duplicate
+      // attachment row; matches how the user mentally models @file.
+      textareaRef?.current?.focus();
+      return;
+    }
+    const res = remoteAgentId
+      ? await api.swarm.readRemoteFile(remoteAgentId, path)
+      : await api.readFile(path);
+    if (!res.ok || res.content == null) {
+      console.warn("[mention] readFile failed", { path, error: res.error });
+      return;
+    }
+    const text = res.content;
+    const bytes = new TextEncoder().encode(text);
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    const mediaType = "text/plain";
+    const file = new File([text], name, { type: mediaType });
+    const item: AttachmentItem = {
+      id: crypto.randomUUID(),
+      file,
+      data: btoa(binary),
+      mediaType,
+      name,
+      attachmentType: "text",
+    };
+    void import("../../../../lib/analytics").then(({ track }) =>
+      track("file_attached", { file_count: 1, source: "mention" }),
+    );
+    const next = [...attachmentsRef.current, item];
+    attachmentsRef.current = next;
+    onAttachmentsChange(next);
+    const controller = new AbortController();
+    uploadAbortRefs.current.set(item.id, controller);
+    void uploadAttachmentToS3(item, updateAttachment, controller.signal).finally(() => {
+      uploadAbortRefs.current.delete(item.id);
+    });
+    textareaRef?.current?.focus();
+  }, [canAddMore, onAttachmentsChange, remoteAgentId, textareaRef, updateAttachment]);
+
   const handleRemove = useCallback((id: string) => {
     // Abort any in-flight upload for this attachment
     const controller = uploadAbortRefs.current.get(id);
@@ -299,5 +359,5 @@ export function useFileAttachments(
     onRemoveAttachment?.(id);
   }, [attachments, onRemoveAttachment]);
 
-  return { canAddMore, addFiles, handleRemove };
+  return { canAddMore, addFiles, addFileFromPath, handleRemove };
 }

--- a/interface/src/apps/chat/components/ChatInputBar/useFileAttachments.ts
+++ b/interface/src/apps/chat/components/ChatInputBar/useFileAttachments.ts
@@ -7,8 +7,16 @@ const MAX_IMAGE_UPLOAD_BYTES = 1_100_000;
 const MAX_IMAGE_DIMENSION = 1536;
 const IMAGE_JPEG_QUALITY = 0.82;
 const IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
-const TEXT_TYPES = ["text/plain", "text/markdown", "text/x-markdown"];
-const TEXT_EXTENSIONS = [".md", ".txt", ".markdown"];
+const TEXT_TYPES = [
+  "text/plain",
+  "text/markdown",
+  "text/x-markdown",
+  "application/json",
+  "application/sql",
+  "application/x-sql",
+  "text/sql",
+];
+const TEXT_EXTENSIONS = [".md", ".txt", ".markdown", ".json", ".sql"];
 
 function isTextFile(file: File): boolean {
   if (TEXT_TYPES.includes(file.type)) return true;

--- a/interface/src/apps/chat/components/ChatInputBar/useFileAttachments.ts
+++ b/interface/src/apps/chat/components/ChatInputBar/useFileAttachments.ts
@@ -312,10 +312,38 @@ export function useFileAttachments(
       textareaRef?.current?.focus();
       return;
     }
+    // Push a placeholder synchronously BEFORE the API read so the chip
+    // appears immediately AND `isUploading` (which gates Enter-to-send)
+    // flips true before the user can race-press Enter. Without this,
+    // a fast user types `@foo`, hits Enter to pick the file, then hits
+    // Enter again — the second Enter fires `handleSend` while the API
+    // read is still in flight and the message goes out without the
+    // file. Mirrors the synchronous registration `addFiles` already
+    // gets via FileReader.
+    const id = crypto.randomUUID();
+    const placeholder: AttachmentItem = {
+      id,
+      file: new File([], name, { type: "text/plain" }),
+      data: "",
+      mediaType: "text/plain",
+      name,
+      attachmentType: "text",
+      uploading: true,
+      uploadProgress: 0,
+    };
+    let next = [...attachmentsRef.current, placeholder];
+    attachmentsRef.current = next;
+    onAttachmentsChange(next);
+
     const res = remoteAgentId
       ? await api.swarm.readRemoteFile(remoteAgentId, path)
       : await api.readFile(path);
     if (!res.ok || res.content == null) {
+      // Drop the placeholder so the user isn't stuck with a phantom
+      // chip they can't send through.
+      next = attachmentsRef.current.filter((a) => a.id !== id);
+      attachmentsRef.current = next;
+      onAttachmentsChange(next);
       console.warn("[mention] readFile failed", { path, error: res.error });
       return;
     }
@@ -325,24 +353,21 @@ export function useFileAttachments(
     for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
     const mediaType = "text/plain";
     const file = new File([text], name, { type: mediaType });
-    const item: AttachmentItem = {
-      id: crypto.randomUUID(),
-      file,
-      data: btoa(binary),
-      mediaType,
-      name,
-      attachmentType: "text",
-    };
+    next = attachmentsRef.current.map((a) =>
+      a.id === id ? { ...a, file, data: btoa(binary) } : a,
+    );
+    attachmentsRef.current = next;
+    onAttachmentsChange(next);
+
     void import("../../../../lib/analytics").then(({ track }) =>
       track("file_attached", { file_count: 1, source: "mention" }),
     );
-    const next = [...attachmentsRef.current, item];
-    attachmentsRef.current = next;
-    onAttachmentsChange(next);
+    const realItem = next.find((a) => a.id === id);
+    if (!realItem) return;
     const controller = new AbortController();
-    uploadAbortRefs.current.set(item.id, controller);
-    void uploadAttachmentToS3(item, updateAttachment, controller.signal).finally(() => {
-      uploadAbortRefs.current.delete(item.id);
+    uploadAbortRefs.current.set(id, controller);
+    void uploadAttachmentToS3(realItem, updateAttachment, controller.signal).finally(() => {
+      uploadAbortRefs.current.delete(id);
     });
     textareaRef?.current?.focus();
   }, [canAddMore, onAttachmentsChange, remoteAgentId, textareaRef, updateAttachment]);

--- a/interface/src/apps/chat/components/ChatInputBar/useProjectFiles.ts
+++ b/interface/src/apps/chat/components/ChatInputBar/useProjectFiles.ts
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import { api, type DirEntry } from "../../../../api/client";
+
+export interface ProjectFile {
+  name: string;
+  path: string;
+  relativePath: string;
+}
+
+function relativeTo(path: string, root: string): string {
+  const normRoot = root.replace(/[\\/]+$/, "");
+  if (path === normRoot) return "";
+  if (path.startsWith(normRoot)) {
+    return path.slice(normRoot.length).replace(/^[\\/]/, "");
+  }
+  return path;
+}
+
+function flattenEntries(entries: DirEntry[], root: string): ProjectFile[] {
+  const out: ProjectFile[] = [];
+  const walk = (nodes: DirEntry[]) => {
+    for (const n of nodes) {
+      if (!n.is_dir) {
+        out.push({
+          name: n.name,
+          path: n.path,
+          relativePath: relativeTo(n.path, root),
+        });
+      }
+      if (n.children) walk(n.children);
+    }
+  };
+  walk(entries);
+  return out;
+}
+
+/**
+ * Lightweight one-shot fetch of the project's file tree, flattened to
+ * a list of files for @-mention autocomplete in the chat input.
+ *
+ * Intentionally separate from `useFileExplorerState` (which owns its
+ * own polling, expand state, ZUI tree shape, and selection callbacks)
+ * — the input bar only needs a flat searchable file list.
+ *
+ * Refetches on `refreshNonce` so the input bar can pull fresh entries
+ * when the user re-opens the mention menu without paying the cost of
+ * a 3s polling loop while the menu is closed.
+ */
+export function useProjectFiles({
+  workspacePath,
+  remoteAgentId,
+  refreshNonce = 0,
+}: {
+  workspacePath?: string;
+  remoteAgentId?: string;
+  refreshNonce?: number;
+}): ProjectFile[] {
+  const [files, setFiles] = useState<ProjectFile[]>([]);
+
+  useEffect(() => {
+    if (!workspacePath) {
+      setFiles([]);
+      return;
+    }
+    let cancelled = false;
+    const fetchPromise = remoteAgentId
+      ? api.swarm.listRemoteDirectory(remoteAgentId, workspacePath)
+      : api.listDirectory(workspacePath);
+    fetchPromise
+      .then((res) => {
+        if (cancelled) return;
+        if (res.ok && res.entries) {
+          setFiles(flattenEntries(res.entries, workspacePath));
+        } else {
+          setFiles([]);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setFiles([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspacePath, remoteAgentId, refreshNonce]);
+
+  return files;
+}
+
+const MENTION_RESULT_LIMIT = 25;
+
+/**
+ * Substring filter ranked so basename-prefix matches beat basename
+ * substring matches beat path substring matches. Ties break on
+ * shorter relative path (closer-to-root files win).
+ */
+export function filterProjectFiles(
+  files: ProjectFile[],
+  query: string,
+  limit = MENTION_RESULT_LIMIT,
+): ProjectFile[] {
+  if (!query) {
+    return files
+      .slice()
+      .sort((a, b) => a.relativePath.length - b.relativePath.length)
+      .slice(0, limit);
+  }
+  const q = query.toLowerCase();
+  const matches: { file: ProjectFile; score: number }[] = [];
+  for (const f of files) {
+    const name = f.name.toLowerCase();
+    const rel = f.relativePath.toLowerCase();
+    let score = -1;
+    if (name.startsWith(q)) score = 3;
+    else if (name.includes(q)) score = 2;
+    else if (rel.includes(q)) score = 1;
+    if (score >= 0) matches.push({ file: f, score });
+  }
+  matches.sort(
+    (a, b) =>
+      b.score - a.score || a.file.relativePath.length - b.file.relativePath.length,
+  );
+  return matches.slice(0, limit).map((m) => m.file);
+}

--- a/interface/src/apps/chat/components/ChatPanel/ChatPanel.tsx
+++ b/interface/src/apps/chat/components/ChatPanel/ChatPanel.tsx
@@ -81,6 +81,18 @@ export interface ChatPanelProps {
   projects?: Project[];
   selectedProjectId?: string;
   onProjectChange?: (projectId: string) => void;
+  /**
+   * Workspace path of the active project (or remote agent). Forwarded
+   * to the input bar so `@`-typed file mentions can resolve against
+   * the project's file tree. Standalone (project-less) agents leave
+   * this unset and the mention menu stays dormant.
+   */
+  workspacePath?: string;
+  /**
+   * When set, the input bar reads mentioned files via the remote-agent
+   * filesystem API instead of the local desktop API.
+   */
+  remoteAgentId?: string;
   header?: ReactNode;
   InputBarComponent?: ForwardRefExoticComponent<ChatInputBarProps & RefAttributes<ChatInputBarHandle>>;
   initialHandoff?: ChatPanelHandoffMode;
@@ -126,6 +138,8 @@ export function ChatPanel({
   projects,
   selectedProjectId,
   onProjectChange,
+  workspacePath,
+  remoteAgentId,
   header,
   InputBarComponent = DesktopChatInputBar,
   initialHandoff,
@@ -573,6 +587,8 @@ export function ChatPanel({
           projects={projects}
           selectedProjectId={selectedProjectId}
           onProjectChange={onProjectChange}
+          workspacePath={workspacePath}
+          remoteAgentId={remoteAgentId}
           isVisible
           isCentered={isThreadEmpty}
           compact={compact}


### PR DESCRIPTION
## Summary
- Type `@` in a project chat to open file autocomplete (mirrors the existing `/` slash-command UX).
- Selecting a file routes it through the existing attachment + S3 upload pipeline — same chip, same spinner, same flow as a drag/drop attach.
- Gated on the project's `workspacePath` (resolved via `useTerminalTarget`), so standalone agent chats leave the trigger dormant.

## Implementation notes
- **New `useProjectFiles` hook** flattens the project's `DirEntry` tree into a searchable file list. Refetches when the menu opens so newly-created files show up without waiting for the explorer's polling loop.
- **New `FileMentionMenu` component** mirrors `SlashCommandMenu` (same keyboard model, same CSS chrome) so the two menus feel identical.
- **`useFileAttachments` extended** with an `addFileFromPath(path)` method that reads the file via `api.readFile` (or `api.swarm.readRemoteFile` when the agent is remote), synthesizes a text `AttachmentItem`, dedupes, and kicks off the same S3 upload the existing intake paths use.
- **`ChatInputBar`, `ChatPanel`, `AgentChatPanel`** thread `workspacePath` + `remoteAgentId` from `useTerminalTarget` down to the input bar.

## Test plan
- [x] Open a project chat (with a workspace attached): type `@` and confirm the menu opens with project files
- [x] Type `@partial` and confirm fuzzy ranking (basename-prefix > basename-substring > path-substring)
- [x] Use Arrow / Enter / Tab / Esc to navigate the menu
- [x] Pick a file and confirm the `@query` is stripped and an attachment chip appears with the upload spinner
- [x] Send a message with an @-attached file and confirm the agent sees the contents
- [x] Open a standalone agent chat (no project) and confirm `@` does NOT open the menu
- [ ] Run `npm run test` in `interface/` — existing 130+ tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)