### PR TITLE
feat(feedback): show comments in Details and let authors close their own feedback items

### DIFF
--- a/interface/src/apps/feedback/FeedbackCommentsPanel/FeedbackCommentsPanel.test.tsx
+++ b/interface/src/apps/feedback/FeedbackCommentsPanel/FeedbackCommentsPanel.test.tsx
@@ -74,6 +74,32 @@ describe("FeedbackCommentsPanel", () => {
     expect(screen.getByText("Nice idea")).toBeInTheDocument();
   });
 
+  it("renders comments newest first regardless of store order", () => {
+    const older: FeedbackComment = {
+      id: "c-older",
+      itemId: "fb-1",
+      author: { name: "Older", type: "user" },
+      text: "First message",
+      createdAt: new Date("2026-04-01T10:00:00Z").toISOString(),
+    };
+    const newer: FeedbackComment = {
+      id: "c-newer",
+      itemId: "fb-1",
+      author: { name: "Newer", type: "user" },
+      text: "Second message",
+      createdAt: new Date("2026-04-02T10:00:00Z").toISOString(),
+    };
+    useFeedbackStore.setState({ selectedId: "fb-1", comments: [older, newer] });
+
+    render(<FeedbackCommentsPanel />);
+
+    const messages = screen.getAllByText(/message/);
+    expect(messages.map((node) => node.textContent)).toEqual([
+      "Second message",
+      "First message",
+    ]);
+  });
+
   it("calls addComment through the store on Enter and clears the draft", () => {
     const addComment = vi.fn();
     useFeedbackStore.setState({ selectedId: "fb-1", addComment });

--- a/interface/src/apps/feedback/FeedbackCommentsPanel/FeedbackCommentsPanel.tsx
+++ b/interface/src/apps/feedback/FeedbackCommentsPanel/FeedbackCommentsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUp, MessageSquare } from "lucide-react";
 import { EmptyState } from "../../../components/EmptyState";
 import { Avatar } from "../../../components/Avatar";
@@ -22,6 +22,14 @@ export function FeedbackCommentsPanel() {
   const { selectedId } = useFeedback();
   const item = useFeedbackItem(selectedId);
   const comments = useFeedbackComments(selectedId);
+  const sortedComments = useMemo(
+    () =>
+      [...comments].sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      ),
+    [comments],
+  );
   const addComment = useAddFeedbackComment();
   const [draft, setDraft] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -79,10 +87,10 @@ export function FeedbackCommentsPanel() {
             data-agent-proof={comments.length > 0 ? "feedback-thread-populated" : undefined}
             data-agent-context-anchor="feedback-comment-list"
           >
-            {comments.length === 0 ? (
+            {sortedComments.length === 0 ? (
               <EmptyState>No comments yet</EmptyState>
             ) : (
-              comments.map((comment) => (
+              sortedComments.map((comment) => (
                 <div key={comment.id} className={styles.commentItem}>
                   <Avatar
                     avatarUrl={comment.author.avatarUrl}

--- a/interface/src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.module.css
+++ b/interface/src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.module.css
@@ -112,3 +112,139 @@
 .statusTag[data-status="in_review"] {
   color: var(--color-accent, #7ca4e2);
 }
+
+.statusSelect {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  font: inherit;
+  font-size: var(--font-size-xs, 11px);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-elevated, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 2px 22px 2px 6px;
+  cursor: pointer;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position:
+    calc(100% - 11px) 50%,
+    calc(100% - 7px) 50%;
+  background-size:
+    4px 4px,
+    4px 4px;
+  background-repeat: no-repeat;
+}
+
+.statusSelect:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-strong, var(--color-border));
+}
+
+.statusSelect:focus-visible {
+  outline: 2px solid var(--color-accent, #7ca4e2);
+  outline-offset: 1px;
+}
+
+.statusSelect[data-status="done"],
+.statusSelect[data-status="deployed"] {
+  color: var(--color-success, #7dd37d);
+}
+
+.statusSelect[data-status="in_progress"],
+.statusSelect[data-status="in_review"] {
+  color: var(--color-accent, #7ca4e2);
+}
+
+.commentsSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+
+.commentsHeading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.commentsCount {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.commentsEmpty {
+  margin: 0;
+  font-size: var(--font-size-sm, 13px);
+  color: var(--color-text-muted);
+}
+
+.commentList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.commentItem {
+  display: flex;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+
+.commentAvatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.commentContent {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.commentHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.commentAuthor {
+  font-weight: 600;
+  font-size: var(--font-size-sm, 13px);
+  color: var(--color-text);
+}
+
+.commentTime {
+  font-size: var(--font-size-xs, 11px);
+  color: var(--color-text-secondary);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.commentText {
+  font-size: var(--font-size-sm, 13px);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}

--- a/interface/src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.test.tsx
+++ b/interface/src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../components/OverlayScrollbar", () => ({
@@ -18,8 +18,9 @@ vi.mock("../../../components/EmptyState", () => ({
 }));
 
 import { FeedbackDetailsPanel } from "./FeedbackDetailsPanel";
+import { useAuthStore } from "../../../stores/auth-store";
 import { useFeedbackStore } from "../../../stores/feedback-store";
-import type { FeedbackItem } from "../types";
+import type { FeedbackComment, FeedbackItem } from "../types";
 
 const item: FeedbackItem = {
   id: "fb-1",
@@ -39,7 +40,12 @@ const item: FeedbackItem = {
 
 describe("FeedbackDetailsPanel", () => {
   beforeEach(() => {
-    useFeedbackStore.setState({ items: [item], selectedId: "fb-1" });
+    useFeedbackStore.setState({
+      items: [item],
+      comments: [],
+      selectedId: "fb-1",
+    });
+    useAuthStore.setState({ user: null });
   });
 
   it("prompts the user to select an item when none is selected", () => {
@@ -71,5 +77,135 @@ describe("FeedbackDetailsPanel", () => {
     useFeedbackStore.setState({ items: [{ ...item, title: "" }] });
     render(<FeedbackDetailsPanel />);
     expect(screen.getByRole("heading", { name: "Untitled" })).toBeInTheDocument();
+  });
+
+  it("shows an empty hint when the selected item has no loaded comments", () => {
+    render(<FeedbackDetailsPanel />);
+    expect(screen.getByText("No comments yet")).toBeInTheDocument();
+  });
+
+  it("renders comments for the selected item, newest first", () => {
+    const older: FeedbackComment = {
+      id: "c-older",
+      itemId: "fb-1",
+      author: { name: "Older Author", type: "user" },
+      text: "First message",
+      createdAt: new Date("2026-04-01T10:00:00Z").toISOString(),
+    };
+    const newer: FeedbackComment = {
+      id: "c-newer",
+      itemId: "fb-1",
+      author: { name: "Newer Author", type: "user" },
+      text: "Second message",
+      createdAt: new Date("2026-04-02T10:00:00Z").toISOString(),
+    };
+    useFeedbackStore.setState({ comments: [older, newer] });
+
+    render(<FeedbackDetailsPanel />);
+
+    const messages = screen.getAllByText(/message/);
+    expect(messages.map((node) => node.textContent)).toEqual([
+      "Second message",
+      "First message",
+    ]);
+  });
+
+  it("shows a static status tag when the viewer is not the author", () => {
+    useFeedbackStore.setState({
+      items: [{ ...item, author: { ...item.author, profileId: "other-prof" } }],
+    });
+    useAuthStore.setState({
+      user: {
+        user_id: "u-1",
+        profile_id: "viewer-prof",
+        display_name: "Viewer",
+        profile_image: "",
+        primary_zid: "",
+        zero_wallet: "",
+        wallets: [],
+      },
+    });
+
+    render(<FeedbackDetailsPanel />);
+    expect(
+      screen.queryByLabelText("Change feedback status"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("In Review")).toBeInTheDocument();
+  });
+
+  it("renders a status dropdown only for the submitting author and writes through setStatus", () => {
+    const setStatus = vi.fn();
+    useFeedbackStore.setState({
+      items: [{ ...item, author: { ...item.author, profileId: "author-prof" } }],
+      setStatus,
+    });
+    useAuthStore.setState({
+      user: {
+        user_id: "u-1",
+        profile_id: "author-prof",
+        display_name: "Ada Lovelace",
+        profile_image: "",
+        primary_zid: "",
+        zero_wallet: "",
+        wallets: [],
+      },
+    });
+
+    render(<FeedbackDetailsPanel />);
+    const select = screen.getByLabelText(
+      "Change feedback status",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe("in_review");
+
+    const options = Array.from(select.options).map((opt) => opt.value);
+    expect(options).toEqual(["in_review", "not_started", "done", "deployed"]);
+
+    fireEvent.change(select, { target: { value: "done" } });
+    expect(setStatus).toHaveBeenCalledWith("fb-1", "done");
+  });
+
+  it("does not duplicate the current status when it is already in the author target list", () => {
+    useFeedbackStore.setState({
+      items: [
+        {
+          ...item,
+          status: "done",
+          author: { ...item.author, profileId: "author-prof" },
+        },
+      ],
+    });
+    useAuthStore.setState({
+      user: {
+        user_id: "u-1",
+        profile_id: "author-prof",
+        display_name: "Ada Lovelace",
+        profile_image: "",
+        primary_zid: "",
+        zero_wallet: "",
+        wallets: [],
+      },
+    });
+
+    render(<FeedbackDetailsPanel />);
+    const select = screen.getByLabelText(
+      "Change feedback status",
+    ) as HTMLSelectElement;
+    const options = Array.from(select.options).map((opt) => opt.value);
+    expect(options).toEqual(["done", "not_started", "deployed"]);
+  });
+
+  it("ignores comments that belong to a different feedback item", () => {
+    const stranger: FeedbackComment = {
+      id: "c-other",
+      itemId: "fb-other",
+      author: { name: "Wrong Item", type: "user" },
+      text: "Should not appear",
+      createdAt: new Date("2026-04-03T10:00:00Z").toISOString(),
+    };
+    useFeedbackStore.setState({ comments: [stranger] });
+
+    render(<FeedbackDetailsPanel />);
+    expect(screen.queryByText("Should not appear")).not.toBeInTheDocument();
+    expect(screen.getByText("No comments yet")).toBeInTheDocument();
   });
 });

--- a/interface/src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.tsx
+++ b/interface/src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.tsx
@@ -1,15 +1,31 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { Info } from "lucide-react";
 import { Avatar } from "../../../components/Avatar";
 import { EmptyState } from "../../../components/EmptyState";
 import { OverlayScrollbar } from "../../../components/OverlayScrollbar";
+import { useAuthStore } from "../../../stores/auth-store";
 import {
   useFeedback,
+  useFeedbackComments,
   useFeedbackItem,
 } from "../../../stores/feedback-store";
 import { timeAgo } from "../../../shared/utils/format";
-import { categoryLabel, productLabel, statusLabel } from "../types";
+import {
+  categoryLabel,
+  productLabel,
+  statusLabel,
+  type FeedbackStatus,
+} from "../types";
 import styles from "./FeedbackDetailsPanel.module.css";
+
+/** Statuses the submitting author can flip their own feedback to from the
+ *  Details panel. The current status is prepended (and deduped) so the
+ *  `<select>` always has its current value as an option. */
+const AUTHOR_STATUS_TARGETS: readonly FeedbackStatus[] = [
+  "not_started",
+  "done",
+  "deployed",
+];
 
 function formatCreatedAt(iso: string): string {
   try {
@@ -32,9 +48,31 @@ function formatCreatedAt(iso: string): string {
  * category/status/product, vote totals, and creation timestamp.
  */
 export function FeedbackDetailsPanel() {
-  const { selectedId } = useFeedback();
+  const { selectedId, setStatus } = useFeedback();
   const item = useFeedbackItem(selectedId);
+  const comments = useFeedbackComments(selectedId);
+  const viewerProfileId = useAuthStore((s) => s.user?.profile_id);
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  const isAuthor =
+    !!viewerProfileId &&
+    !!item?.author.profileId &&
+    viewerProfileId === item.author.profileId;
+
+  const sortedComments = useMemo(
+    () =>
+      [...comments].sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      ),
+    [comments],
+  );
+
+  const statusOptions = useMemo<readonly FeedbackStatus[]>(() => {
+    if (!item) return AUTHOR_STATUS_TARGETS;
+    const rest = AUTHOR_STATUS_TARGETS.filter((s) => s !== item.status);
+    return [item.status, ...rest];
+  }, [item]);
 
   if (!item) {
     return (
@@ -81,13 +119,33 @@ export function FeedbackDetailsPanel() {
             <div className={styles.metaRow}>
               <dt className={styles.metaLabel}>Status</dt>
               <dd className={styles.metaValue}>
-                <span
-                  className={styles.statusTag}
-                  data-status={item.status}
-                  data-agent-proof="feedback-details-status-visible"
-                >
-                  {statusLabel(item.status)}
-                </span>
+                {isAuthor ? (
+                  <select
+                    className={styles.statusSelect}
+                    data-status={item.status}
+                    data-agent-action="change-feedback-status"
+                    data-agent-proof="feedback-details-status-editable"
+                    aria-label="Change feedback status"
+                    value={item.status}
+                    onChange={(event) =>
+                      setStatus(item.id, event.target.value as FeedbackStatus)
+                    }
+                  >
+                    {statusOptions.map((value) => (
+                      <option key={value} value={value}>
+                        {statusLabel(value)}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <span
+                    className={styles.statusTag}
+                    data-status={item.status}
+                    data-agent-proof="feedback-details-status-visible"
+                  >
+                    {statusLabel(item.status)}
+                  </span>
+                )}
               </dd>
             </div>
             <div className={styles.metaRow}>
@@ -107,11 +165,47 @@ export function FeedbackDetailsPanel() {
                 {item.voteScore} ({item.upvotes} up &middot; {item.downvotes} down)
               </dd>
             </div>
-            <div className={styles.metaRow}>
-              <dt className={styles.metaLabel}>Comments</dt>
-              <dd className={styles.metaValue}>{item.commentCount}</dd>
-            </div>
           </dl>
+
+          <section
+            className={styles.commentsSection}
+            aria-label="Comments"
+            data-agent-list="feedback-comments"
+            data-agent-context-anchor="feedback-details-comments"
+          >
+            <h3 className={styles.commentsHeading}>
+              Comments
+              <span className={styles.commentsCount}>{item.commentCount}</span>
+            </h3>
+            {sortedComments.length === 0 ? (
+              <p className={styles.commentsEmpty}>No comments yet</p>
+            ) : (
+              <ul className={styles.commentList}>
+                {sortedComments.map((comment) => (
+                  <li key={comment.id} className={styles.commentItem}>
+                    <Avatar
+                      avatarUrl={comment.author.avatarUrl}
+                      name={comment.author.name}
+                      type={comment.author.type}
+                      size={28}
+                      className={styles.commentAvatar}
+                    />
+                    <div className={styles.commentContent}>
+                      <div className={styles.commentHeader}>
+                        <span className={styles.commentAuthor}>
+                          {comment.author.name}
+                        </span>
+                        <span className={styles.commentTime}>
+                          {timeAgo(comment.createdAt)}
+                        </span>
+                      </div>
+                      <span className={styles.commentText}>{comment.text}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
         </div>
       </div>
       <OverlayScrollbar scrollRef={scrollRef} />

--- a/interface/src/apps/feedback/types.ts
+++ b/interface/src/apps/feedback/types.ts
@@ -35,6 +35,10 @@ export interface FeedbackAuthor {
   name: string;
   avatarUrl?: string;
   type: "user" | "agent";
+  /** Network profile id of the author. Used to gate author-only actions
+   *  (e.g. the submitter changing their feedback's status). Optional because
+   *  legacy mocks and capture sessions don't always thread it through. */
+  profileId?: string;
 }
 
 export interface FeedbackItem {

--- a/interface/src/stores/feedback-store.ts
+++ b/interface/src/stores/feedback-store.ts
@@ -105,6 +105,7 @@ function currentAuthor(): FeedbackAuthor {
     name: user?.display_name ?? "You",
     type: "user",
     avatarUrl: user?.profile_image ?? undefined,
+    profileId: user?.profile_id,
   };
 }
 
@@ -115,6 +116,7 @@ function dtoToItem(dto: FeedbackItemDto): FeedbackItem {
       name: dto.authorName ?? "Unknown",
       avatarUrl: dto.authorAvatar ?? undefined,
       type: "user",
+      profileId: dto.profileId,
     },
     title: dto.title ?? "",
     body: dto.summary ?? "",
@@ -139,6 +141,7 @@ function dtoToComment(dto: FeedbackCommentDto): FeedbackComment {
       name: dto.authorName ?? "Unknown",
       avatarUrl: dto.authorAvatar ?? undefined,
       type: "user",
+      profileId: dto.profileId,
     },
     text: dto.content,
     createdAt: dto.createdAt ?? new Date().toISOString(),


### PR DESCRIPTION
## Summary

Two improvements to the Feedback app's right sidekick:

- **Comments are now visible in the Details tab.** The Details tab previously showed only a `Comments: N` count. It now renders the actual comment thread inline, sorted **newest-first**, with avatar / author / time / body per row and a "No comments yet" hint when none have loaded. The separate Comments tab (which still owns the composer) is sorted newest-first too, so the order matches across both surfaces.
- **The submitting author can close their own feedback** from the Details tab. The Status row turns into a dropdown when `viewer.profile_id` matches the item's author profile id; non-authors continue to see the existing read-only status tag. The dropdown is deliberately narrow: it shows the item's **current status first**, then **Not Started / Done / Deployed** (deduped against the current value), so the most common closing transitions are one click away. Writes go through the existing `setStatus` store action, which already does optimistic update → PATCH `/api/feedback/:id/status` → rollback on failure.

To support author gating, `FeedbackAuthor` now carries an optional `profileId`, threaded through `dtoToItem` / `dtoToComment` and seeded from `useAuthStore` in `currentAuthor()`.

## Files changed

- `interface/src/apps/feedback/types.ts` — `FeedbackAuthor.profileId?`
- `interface/src/stores/feedback-store.ts` — thread `profileId` through DTO mappers and the optimistic-comment author
- `interface/src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.tsx` — inline newest-first comment list + author-gated status `<select>`
- `interface/src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.module.css` — styles for the comment list and the status select (matches existing status color tokens)
- `interface/src/apps/feedback/FeedbackCommentsPanel/FeedbackCommentsPanel.tsx` — sort comments newest-first
- Tests added/updated in `FeedbackDetailsPanel.test.tsx` and `FeedbackCommentsPanel.test.tsx`

## Test plan

- [x] `npx vitest run src/apps/feedback/FeedbackDetailsPanel/FeedbackDetailsPanel.test.tsx src/apps/feedback/FeedbackCommentsPanel/FeedbackCommentsPanel.test.tsx` → 16/16 passing
- [x] `npx tsc --noEmit` → clean
- [x] Manual: opened the running dev desktop, selected a feedback item, confirmed comments render newest-first in both tabs; signed in as the author and confirmed the status dropdown appears with the trimmed option set, and as a non-author confirmed only the static tag is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)