### PR TITLE
feat(chat): persist unsent prompt drafts across session/route switches

### DIFF
--- a/interface/src/apps/chat/components/ChatPanel/useChatPanelState.test.tsx
+++ b/interface/src/apps/chat/components/ChatPanel/useChatPanelState.test.tsx
@@ -84,9 +84,16 @@ vi.mock("../../../../constants/models", () => ({
   availableModelsForAdapter: () => [],
 }));
 
-vi.mock("../../../../stores/chat-ui-store", () => ({
-  useChatUI: () => mockChatUI,
-}));
+vi.mock("../../../../stores/chat-ui-store", async () => {
+  const { useState } = await import("react");
+  return {
+    useChatUI: () => mockChatUI,
+    // Stand-in for the real per-streamKey draft store. Tests don't
+    // exercise cross-session draft persistence — they just need a
+    // setState-shaped pair so `useChatPanelState`'s input still works.
+    useChatDraft: () => useState(""),
+  };
+});
 
 vi.mock("../../../../stores/message-queue-store", () => ({
   useMessageQueueStore: {

--- a/interface/src/apps/chat/components/ChatPanel/useChatPanelState.ts
+++ b/interface/src/apps/chat/components/ChatPanel/useChatPanelState.ts
@@ -10,7 +10,7 @@ import type { DisplaySessionEvent } from "../../../../shared/types/stream";
 import { isGenerationCommand, type SlashCommand } from "../../../../constants/commands";
 import type { GenerationMode } from "../../../../constants/models";
 import { availableModelsForAdapter } from "../../../../constants/models";
-import { useChatUI } from "../../../../stores/chat-ui-store";
+import { useChatDraft, useChatUI } from "../../../../stores/chat-ui-store";
 import { useConversationSnapshot } from "../../../../hooks/use-conversation-snapshot";
 import { useLoadOlderMessages } from "../../../../hooks/use-load-older-messages";
 import { useChatViewStore, useThreadView } from "../../../../stores/chat-view-store";
@@ -63,7 +63,7 @@ export function useChatPanelState({
   selectedProjectId,
   agentId,
 }: UseChatPanelStateOptions) {
-  const [input, setInput] = useState("");
+  const [input, setInput] = useChatDraft(streamKey);
   const [attachments, setAttachments] = useState<AttachmentItem[]>(EMPTY_ATTACHMENTS);
   const [commands, setCommands] = useState<SlashCommand[]>(EMPTY_COMMANDS);
   const availableModels = availableModelsForAdapter(adapterType);
@@ -93,12 +93,14 @@ export function useChatPanelState({
       resetKeyMountRef.current = false;
       return;
     }
-    // Bail out of the reset writes when the state is already empty so React
-    // skips the re-render entirely. Combined with the module-level
-    // `EMPTY_*` constants below, this lets the input bar's `React.memo`
-    // shallow-compare see identical `attachments` / `selectedCommands`
-    // refs across same-agent session switches.
-    setInput((prev) => (prev === "" ? prev : ""));
+    // Drafts live in `chat-ui-store.drafts` keyed by `streamKey`, so
+    // switching sessions reads the new key's slot automatically and the
+    // previous chat's unsent text survives a round trip. Attachments
+    // and command chips still get wiped here — they carry per-session
+    // upload / chip state that doesn't make sense outside the session
+    // it was created in. Bail out of the writes when state is already
+    // empty so the input bar's `React.memo` shallow-compare keeps
+    // skipping re-renders on same-agent session switches.
     setAttachments((prev) => (prev.length === 0 ? prev : EMPTY_ATTACHMENTS));
     setCommands((prev) => (prev.length === 0 ? prev : EMPTY_COMMANDS));
   }, [scrollResetKey]);

--- a/interface/src/stores/chat-ui-store.test.ts
+++ b/interface/src/stores/chat-ui-store.test.ts
@@ -27,7 +27,7 @@ vi.mock("../constants/models", () => ({
 }));
 
 function resetStore() {
-  useChatUIStore.setState({ streams: {} });
+  useChatUIStore.setState({ streams: {}, drafts: {} });
 }
 
 describe("chat-ui-store", () => {
@@ -293,6 +293,50 @@ describe("chat-ui-store", () => {
       expect(
         useChatUIStore.getState().getPinnedSourceImage("stream-1"),
       ).toBeNull();
+    });
+  });
+
+  describe("drafts", () => {
+    it("getDraft returns an empty string when no draft has been set", () => {
+      expect(useChatUIStore.getState().getDraft("stream-1")).toBe("");
+    });
+
+    it("setDraft stores a non-empty draft per streamKey", () => {
+      useChatUIStore.getState().setDraft("stream-1", "hello");
+      useChatUIStore.getState().setDraft("stream-2", "world");
+      expect(useChatUIStore.getState().getDraft("stream-1")).toBe("hello");
+      expect(useChatUIStore.getState().getDraft("stream-2")).toBe("world");
+      expect(useChatUIStore.getState().drafts).toEqual({
+        "stream-1": "hello",
+        "stream-2": "world",
+      });
+    });
+
+    it("setDraft removes the entry when the value becomes empty", () => {
+      useChatUIStore.getState().setDraft("stream-1", "draft text");
+      expect(useChatUIStore.getState().drafts).toHaveProperty("stream-1");
+      useChatUIStore.getState().setDraft("stream-1", "");
+      expect(useChatUIStore.getState().drafts).not.toHaveProperty("stream-1");
+    });
+
+    it("setDraft is a no-op when clearing a stream that has no draft", () => {
+      const before = useChatUIStore.getState().drafts;
+      useChatUIStore.getState().setDraft("stream-1", "");
+      expect(useChatUIStore.getState().drafts).toBe(before);
+    });
+
+    it("setDraft skips re-writes when the value is unchanged", () => {
+      useChatUIStore.getState().setDraft("stream-1", "same");
+      const before = useChatUIStore.getState().drafts;
+      useChatUIStore.getState().setDraft("stream-1", "same");
+      expect(useChatUIStore.getState().drafts).toBe(before);
+    });
+
+    it("each streamKey owns its own draft slot", () => {
+      useChatUIStore.getState().setDraft("stream-1", "a");
+      useChatUIStore.getState().setDraft("stream-2", "b");
+      useChatUIStore.getState().setDraft("stream-1", "");
+      expect(useChatUIStore.getState().drafts).toEqual({ "stream-2": "b" });
     });
   });
 });

--- a/interface/src/stores/chat-ui-store.ts
+++ b/interface/src/stores/chat-ui-store.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { create } from "zustand";
 import {
   availableModelsForAdapter,
@@ -54,6 +55,13 @@ interface StreamState {
 
 interface ChatUIState {
   streams: Record<string, StreamState>;
+  /**
+   * In-progress prompt drafts keyed by `streamKey`. Only chats with a
+   * non-empty unsent draft live here — `setDraft(_, "")` removes the
+   * entry so the map naturally bounds itself to "chats the user is
+   * mid-typing in." In-memory only; cleared on app restart.
+   */
+  drafts: Record<string, string>;
 }
 
 interface ChatUIActions {
@@ -105,6 +113,12 @@ interface ChatUIActions {
     image: PinnedSourceImage | null,
   ) => void;
   getPinnedSourceImage: (streamKey: string) => PinnedSourceImage | null;
+  /**
+   * Write (or clear) the in-progress draft for a stream. Empty strings
+   * delete the key so the `drafts` map stays small.
+   */
+  setDraft: (streamKey: string, text: string) => void;
+  getDraft: (streamKey: string) => string;
 }
 
 type ChatUIStore = ChatUIState & ChatUIActions;
@@ -119,6 +133,7 @@ const getStream = (state: ChatUIState, key: string): StreamState =>
 
 export const useChatUIStore = create<ChatUIStore>()((set, get) => ({
   streams: {},
+  drafts: {},
 
   init: (streamKey, adapterType, defaultModel, agentId) => {
     const existing = get().streams[streamKey];
@@ -245,6 +260,21 @@ export const useChatUIStore = create<ChatUIStore>()((set, get) => ({
   getPinnedSourceImage: (streamKey) =>
     getStream(get(), streamKey).pinnedSourceImage,
 
+  setDraft: (streamKey, text) => {
+    set((s) => {
+      if (text === "") {
+        if (!(streamKey in s.drafts)) return s;
+        const next = { ...s.drafts };
+        delete next[streamKey];
+        return { drafts: next };
+      }
+      if (s.drafts[streamKey] === text) return s;
+      return { drafts: { ...s.drafts, [streamKey]: text } };
+    });
+  },
+
+  getDraft: (streamKey) => get().drafts[streamKey] ?? "",
+
   syncAvailableModels: (streamKey, adapterType, defaultModel, agentId) => {
     const chatModels = availableModelsForAdapter(adapterType);
     set((s) => {
@@ -339,4 +369,29 @@ export function useChatUI(streamKey: string) {
     init,
     syncAvailableModels,
   };
+}
+
+/**
+ * Drop-in replacement for `useState<string>("")` that backs the input by
+ * the per-`streamKey` slot in `chat-ui-store.drafts`. Persists the
+ * unsent prompt across session/route switches within the same app
+ * session; the entry is removed automatically when the value is set
+ * back to `""` (i.e. after send, or when the user clears the field).
+ */
+export function useChatDraft(
+  streamKey: string,
+): [string, (next: string | ((prev: string) => string)) => void] {
+  const draft = useChatUIStore((s) => s.drafts[streamKey] ?? "");
+  const set = useCallback(
+    (next: string | ((prev: string) => string)) => {
+      const store = useChatUIStore.getState();
+      const value =
+        typeof next === "function"
+          ? next(store.drafts[streamKey] ?? "")
+          : next;
+      store.setDraft(streamKey, value);
+    },
+    [streamKey],
+  );
+  return [draft, set];
 }


### PR DESCRIPTION
## Summary

If you type into the chat input, navigate away (different session, different route, even just close the chat panel), and come back, the draft text was previously wiped. This PR persists the typed-but-unsent prompt per chat so it survives that round trip.

Mechanism is intentionally small:

- `chat-ui-store` gains a `drafts: Record<string, string>` map keyed by the same `streamKey` already used for per-stream UI state (mode/model/pinnedSourceImage). A new `setDraft(streamKey, text)` action writes the value, and **deletes the entry when `text === ""`** — so the map naturally contains exactly the chats with currently-typed-but-unsent text.
- A `useChatDraft(streamKey)` hook exposes a `useState`-shaped `[draft, setter]` pair backed by that store, so `useChatPanelState` is a one-line swap (`useState("")` → `useChatDraft(streamKey)`).
- The existing `scrollResetKey` reset effect no longer touches the input. Attachments and slash-command chips still get wiped on session switch — they carry per-session upload / chip state and shouldn't survive (see "Scope" below).
- `handleSend`'s existing `setInput("")` removes the entry from the map automatically. Backspacing to empty does the same.

## Scope (intentionally small)

This PR persists **text only**, **in-memory only**. The chat-input attachment list (file uploads, paste/drag-drop, @-mention file refs) and slash-command chips are *not* persisted. Reasoning:

- **Attachments are tied to a side-effecting upload lifecycle.** Each `AttachmentItem` carries `uploading`, `uploadProgress`, `uploadError`. If you persist an entry mid-upload and the user navigates away, the upload promise either orphans (no UI listening) or never finishes, leaving a phantom "uploading…" entry forever on return.
- **Inline base64 vs S3 URLs.** Some attachments are small inline data, some are URL-backed. Persisting URLs is cheap; persisting base64 image data can be MBs per entry and bloats the store across abandoned chats.
- **Cross-session leak risk.** The current "wipe attachments on session switch" is partly defensive — it makes it impossible for chat A's attachments to leak into chat B's send. Persisting attachments preserves that isolation only if the `streamKey` keying is correct everywhere, which is a wider blast radius than text.
- **`AttachmentItem` is an internal UI type.** Persisting it couples the store to that shape; future field additions could silently corrupt rehydrated entries.

If we want attachments to persist later, the cleanest first step is: persist only fully-uploaded, URL-backed entries; drop in-flight / errored ones on switch; re-validate URLs on rehydrate. That can land as a follow-up.

## Implications of the text-only change

- **Drafts do not accumulate.** Because `setDraft(_, "")` deletes the slot, sending a message or backspacing to empty removes the entry. The map size = number of chats the user is currently mid-typing in (almost always 0–2).
- **Worst case without the guard is still bounded.** Even if the delete-on-empty branch were removed, the upper bound is one short string per chat visited per app session — sub-megabyte at hundreds of chats. The guard is for honest store shape, not memory.
- **In-memory only.** App restart still starts every chat blank. Cross-restart persistence (IndexedDB, where the rest of browser-owned state lives) is a strictly bigger lift — feature flag, hydration race against `init`, eviction policy. Out of scope here.
- **Memo'd input bar still benefits.** The reset effect retains its early-bail for `attachments` / `commands` so `<DesktopChatInputBar>`'s `React.memo` shallow-compare still skips re-renders on same-agent session switches.
- **No behavior change for non-chat surfaces.** The Feedback comment composer and other inputs are untouched.

## Files changed

- `interface/src/stores/chat-ui-store.ts` — `drafts` map, `setDraft` / `getDraft` actions (delete-on-empty), `useChatDraft` hook
- `interface/src/apps/chat/components/ChatPanel/useChatPanelState.ts` — swap `useState("")` for `useChatDraft(streamKey)`; drop the input-clear from the `scrollResetKey` reset effect (attachments and commands still wiped there)
- Tests in `chat-ui-store.test.ts` and `useChatPanelState.test.tsx`

## Test plan

- [x] `npm test -- src/stores/chat-ui-store.test.ts src/apps/chat/components/ChatPanel/useChatPanelState.test.tsx` → 35/35 passing
- [x] `npx tsc --noEmit` → clean
- [x] Manual: type in chat A, navigate to chat B, navigate back → text is still there
- [x] Manual: type, send → text clears, no orphan in the drafts map
- [x] Manual: attach a file in chat A, switch to chat B, switch back → attachment is gone (intentional — only text persists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)