### PR TITLE
fix(ci): Windows .cmd spawns, UTF-8 BOM, and harness sibling checkout

### DIFF
--- a/.github/actions/setup-harness-sibling/action.yml
+++ b/.github/actions/setup-harness-sibling/action.yml
@@ -15,11 +15,12 @@ runs:
   steps:
     - name: Checkout aura-harness
       if: inputs.include-harness == 'true'
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ inputs.repository-owner }}/aura-harness
-        # Check out directly as a true sibling (../aura-harness relative to
-        # GITHUB_WORKSPACE). This avoids the symlink workaround that previously
-        # caused cargo to canonicalize the path and resolve relative path
-        # dependencies (../aura-os/crates/...) from the wrong location.
-        path: ../aura-harness
+      shell: bash
+      run: |
+        # actions/checkout@v4 enforces that path: must be within GITHUB_WORKSPACE,
+        # but aura-harness must live as a true sibling (../aura-harness) so that
+        # cargo's canonicalize() resolves path dependencies correctly. A raw git
+        # clone has no workspace boundary restriction.
+        git clone --depth 1 \
+          "https://github.com/${{ inputs.repository-owner }}/aura-harness.git" \
+          "../aura-harness"

--- a/.github/actions/setup-harness-sibling/action.yml
+++ b/.github/actions/setup-harness-sibling/action.yml
@@ -18,28 +18,8 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository-owner }}/aura-harness
-        path: aura-harness
-
-    - name: Link sibling aura-harness on Unix
-      if: runner.os != 'Windows'
-      shell: bash
-      run: |
-        if [ "${{ inputs.include-harness }}" = "true" ]; then
-          rm -rf "$GITHUB_WORKSPACE/../aura-harness"
-          ln -s "$GITHUB_WORKSPACE/aura-harness" "$GITHUB_WORKSPACE/../aura-harness"
-          ls -ld "$GITHUB_WORKSPACE/aura-harness" "$GITHUB_WORKSPACE/../aura-harness"
-        fi
-
-    - name: Link sibling aura-harness on Windows
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $workspace = $env:GITHUB_WORKSPACE
-        $parent = Split-Path $workspace -Parent
-        if ("${{ inputs.include-harness }}" -eq "true") {
-          $harnessSibling = Join-Path $parent "aura-harness"
-          if (Test-Path $harnessSibling) {
-            Remove-Item $harnessSibling -Recurse -Force
-          }
-          New-Item -ItemType Junction -Path $harnessSibling -Target (Join-Path $workspace "aura-harness") | Out-Null
-        }
+        # Check out directly as a true sibling (../aura-harness relative to
+        # GITHUB_WORKSPACE). This avoids the symlink workaround that previously
+        # caused cargo to canonicalize the path and resolve relative path
+        # dependencies (../aura-os/crates/...) from the wrong location.
+        path: ../aura-harness

--- a/.github/workflows/desktop-validate.yml
+++ b/.github/workflows/desktop-validate.yml
@@ -97,13 +97,6 @@ jobs:
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust-toolchain
 
-      - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: desktop-${{ runner.os }}-${{ runner.arch }}
-          workspaces: |
-            . -> .aura-shared-target
-
       - name: Set up sccache
         id: sccache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/desktop-validate.yml
+++ b/.github/workflows/desktop-validate.yml
@@ -103,7 +103,6 @@ jobs:
           shared-key: desktop-${{ runner.os }}-${{ runner.arch }}
           workspaces: |
             . -> ../.aura-shared-target
-            ../aura-harness -> ../.aura-shared-target
 
       - name: Set up sccache
         id: sccache

--- a/.github/workflows/desktop-validate.yml
+++ b/.github/workflows/desktop-validate.yml
@@ -55,8 +55,8 @@ jobs:
   desktop-smoke:
     if: github.event_name != 'push'
     env:
-      CARGO_TARGET_DIR: ../.aura-shared-target
-      AURA_RELEASE_DIR: ../.aura-shared-target/release
+      CARGO_TARGET_DIR: .aura-shared-target
+      AURA_RELEASE_DIR: .aura-shared-target/release
       AURA_NETWORK_URL: ${{ vars.AURA_NETWORK_URL }}
       AURA_STORAGE_URL: ${{ vars.AURA_STORAGE_URL }}
       AURA_INTEGRATIONS_URL: ${{ vars.AURA_INTEGRATIONS_URL }}
@@ -72,16 +72,16 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux
-            binary: ../.aura-shared-target/release/aura-os-desktop
+            binary: .aura-shared-target/release/aura-os-desktop
           - os: macos-latest
             target: macos-arm64
-            binary: ../.aura-shared-target/release/aura-os-desktop
+            binary: .aura-shared-target/release/aura-os-desktop
           - os: macos-15-intel
             target: macos-x64
-            binary: ../.aura-shared-target/release/aura-os-desktop
+            binary: .aura-shared-target/release/aura-os-desktop
           - os: windows-latest
             target: windows-x64
-            binary: ../.aura-shared-target/release/aura-os-desktop.exe
+            binary: .aura-shared-target/release/aura-os-desktop.exe
 
     runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os }}
 
@@ -102,7 +102,7 @@ jobs:
         with:
           shared-key: desktop-${{ runner.os }}-${{ runner.arch }}
           workspaces: |
-            . -> ../.aura-shared-target
+            . -> .aura-shared-target
 
       - name: Set up sccache
         id: sccache
@@ -168,9 +168,9 @@ jobs:
         shell: bash
         run: |
           rm -rf cargo-timings-upload
-          if [ -d ../.aura-shared-target/cargo-timings ]; then
+          if [ -d .aura-shared-target/cargo-timings ]; then
             mkdir -p cargo-timings-upload
-            cp -R ../.aura-shared-target/cargo-timings/. cargo-timings-upload/
+            cp -R .aura-shared-target/cargo-timings/. cargo-timings-upload/
           fi
 
       - name: Upload Cargo timings

--- a/.github/workflows/desktop-validate.yml
+++ b/.github/workflows/desktop-validate.yml
@@ -97,6 +97,13 @@ jobs:
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust-toolchain
 
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: desktop-${{ runner.os }}-${{ runner.arch }}
+          workspaces: |
+            . -> .aura-shared-target
+
       - name: Set up sccache
         id: sccache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -44,6 +44,12 @@ jobs:
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
   build-sidecar:
+    env:
+      # Place the sidecar Cargo target inside GITHUB_WORKSPACE so that
+      # Swatinem/rust-cache and upload-artifact can access it. The true-sibling
+      # aura-harness checkout (../aura-harness) is outside the workspace
+      # boundary enforced by actions/cache v4 / upload-artifact@v5.
+      CARGO_TARGET_DIR: .aura-harness-target
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +86,7 @@ jobs:
         with:
           shared-key: desktop-sidecar-${{ runner.os }}-${{ runner.arch }}
           workspaces: |
-            ../aura-harness -> target
+            ../aura-harness -> .aura-harness-target
 
       - name: Set up sccache
         id: sccache-sidecar

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -18,6 +18,12 @@ env:
 
 jobs:
   build-sidecar:
+    env:
+      # Place the sidecar Cargo target inside GITHUB_WORKSPACE so that
+      # Swatinem/rust-cache and upload-artifact can access it. The true-sibling
+      # aura-harness checkout (../aura-harness) is outside the workspace
+      # boundary enforced by actions/cache v4 / upload-artifact@v5.
+      CARGO_TARGET_DIR: .aura-harness-target
     strategy:
       fail-fast: false
       matrix:
@@ -54,7 +60,7 @@ jobs:
         with:
           shared-key: desktop-sidecar-${{ runner.os }}-${{ runner.arch }}
           workspaces: |
-            ../aura-harness -> target
+            ../aura-harness -> .aura-harness-target
 
       - name: Set up sccache
         id: sccache-sidecar

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[workspace]
+[workspace]
 members = [
     "crates/aura-os-agents",
     "crates/aura-os-auth",

--- a/apps/aura-os-server/Cargo.toml
+++ b/apps/aura-os-server/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[package]
+[package]
 name = "aura-os-server"
 version = "0.1.0"
 edition.workspace = true

--- a/crates/aura-os-harness/Cargo.toml
+++ b/crates/aura-os-harness/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[package]
+[package]
 name = "aura-os-harness"
 version = "0.1.0"
 edition.workspace = true

--- a/crates/aura-os-integrations/Cargo.toml
+++ b/crates/aura-os-integrations/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[package]
+[package]
 name = "aura-os-integrations"
 version = "0.1.0"
 edition.workspace = true

--- a/scripts/ci/lib/utils.mjs
+++ b/scripts/ci/lib/utils.mjs
@@ -47,9 +47,13 @@ export function run(command, args, options = {}) {
     const prefix = label ? `[${label}] ` : "";
     console.log(`\n> ${prefix}${rendered}${suffix}`);
 
-    const result = spawnSync(commandName(command), args, {
+    const resolvedCommand = commandName(command);
+    const result = spawnSync(resolvedCommand, args, {
       cwd: repoRoot,
       stdio: "inherit",
+      // .cmd files on Windows require shell:true — without it spawnSync
+      // returns EINVAL on some GitHub Actions runner configurations.
+      shell: resolvedCommand.endsWith(".cmd"),
       ...spawnOptions,
     });
 
@@ -71,10 +75,12 @@ export function run(command, args, options = {}) {
 }
 
 export function capture(command, args, options = {}) {
-  const result = spawnSync(commandName(command), args, {
+  const resolvedCommand = commandName(command);
+  const result = spawnSync(resolvedCommand, args, {
     cwd: repoRoot,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    shell: resolvedCommand.endsWith(".cmd"),
     ...options,
   });
 


### PR DESCRIPTION
## Summary

Extracted from #14 so the CI fixes can land independently of the project-appearance feature work.

This PR fixes a chain of failures in `desktop-validate` / `desktop-smoke` / the release sidecar build that surfaced when CI began exercising the `include-harness: true` path. The root cause is a Cargo path-resolution interaction with the harness sibling-checkout symlink; the secondary issues are workspace-boundary enforcement in `actions/cache@v4` and a couple of Windows-specific quirks.

---

## CI fix — `aura-harness` symlink breaks Cargo path resolution

### When it was introduced

Commit `c56ea87a` by **n3o** ("Remove stale sibling ZUI references", 2026-04-13) renamed `setup-zui-sibling` to `setup-harness-sibling` and introduced the symlink approach: `aura-harness` was checked out as a subdirectory **inside** `GITHUB_WORKSPACE`, then a symlink (Unix `ln -s` / Windows Junction) was created one level up to make it appear as a true sibling. This commit landed on `main` and has been present in every branch since. **These PRs are the first to exercise the `include-harness: true` path after that change** — prior feature branches either did not trigger the harness build or failed at earlier CI steps — which is why the breakage surfaces here and not before.

### What was failing and why

GitHub Actions sets `GITHUB_WORKSPACE` to `/home/runner/work/aura-os/aura-os` (the repo sits one directory deeper than the runner's work root). The old setup produced this layout on disk:

```
/home/runner/work/aura-os/
  aura-harness        ← symlink → ./aura-os/aura-harness
  aura-os/
    aura-harness/     ← real checkout (inside GITHUB_WORKSPACE)
    crates/
      aura-protocol/
```

Cargo calls `std::fs::canonicalize()` before evaluating `[patch]` sections and path dependencies. `canonicalize` follows symlinks, so the sibling `../aura-harness` resolved to its **real** location inside the repo:

```
canonicalize("../aura-harness")
  → /home/runner/work/aura-os/aura-os/aura-harness
```

`aura-harness/Cargo.toml` declares path dependencies relative to itself — e.g. `../aura-os/crates/aura-protocol`. Cargo resolved this from the canonicalized base path:

```
/home/runner/work/aura-os/aura-os/aura-harness/../aura-os/crates/aura-protocol
= /home/runner/work/aura-os/aura-os/aura-os/crates/aura-protocol   ← wrong
```

The actual file lives at `/home/runner/work/aura-os/aura-os/crates/aura-protocol`, so Cargo failed with:

```
error: failed to read `/home/runner/work/aura-os/aura-os/aura-os/crates/aura-protocol/Cargo.toml`
```

The triple `aura-os` in the path is the tell — the doubled directory segment is Cargo canonicalizing the symlink back inside the repo and then walking `../aura-os` from the wrong base.

### Could the symlink have been kept?

This was investigated before landing on the current fix. The short answer is no — not in a clean, cross-platform way.

`std::fs::canonicalize()` follows symlinks unconditionally. There is no Cargo flag, environment variable, or `config.toml` knob that disables this. For `canonicalize("../aura-harness")` to return the correct sibling path (`/home/runner/work/aura-os/aura-harness`), that path **must be a real directory on disk**, not a symlink to one.

The only mechanism that creates a real directory at one path whose bytes live at another is a **bind mount** (`sudo mount --bind`). On Linux this would work — bind mounts are opaque to `canonicalize` — but it requires `sudo`, is not available on Windows, and adds meaningful platform-specific complexity to CI. On Windows, Directory Junctions and soft symlinks are both followed by `GetFinalPathNameByHandle` (the Win32 equivalent), so there is no equivalent workaround there.

The other cross-platform option would be to change the `aura-harness` repository itself so that its `Cargo.toml` path dependencies do not assume a specific relative location for `aura-os` (e.g. using `[patch.crates-io]` overrides instead of inline path entries). That is a change to a repo not managed here.

### The fix (part 1 — Cargo path resolution)

The initial fix attempt changed `path: aura-harness` to `path: ../aura-harness` in `actions/checkout@v4`. This also fails — `actions/checkout@v4` enforces a strict workspace boundary and rejects any `path:` outside `GITHUB_WORKSPACE` outright:

```
Repository path '/home/runner/work/aura-os/aura-harness' is not under '/home/runner/work/aura-os/aura-os'
```

Since `checkout@v4` cannot be coerced to place files outside the workspace, the fix replaces the step entirely with a raw shell clone. `.github/actions/setup-harness-sibling/action.yml` now does:

```yaml
- name: Checkout aura-harness
  if: inputs.include-harness == 'true'
  shell: bash
  run: |
    git clone --depth 1 \
      "https://github.com/${{ inputs.repository-owner }}/aura-harness.git" \
      "../aura-harness"
```

`git clone` has no workspace boundary restriction — it places a real directory at the sibling path:

```
/home/runner/work/aura-os/
  aura-harness/     ← real checkout, no symlink
  aura-os/
    crates/
      aura-protocol/
```

`canonicalize("../aura-harness")` now resolves to `/home/runner/work/aura-os/aura-harness` — a genuine directory — and Cargo walks `../aura-os/crates/aura-protocol` correctly from there. The three Unix/Windows symlink-creation steps were removed entirely.

### Secondary issue — `actions/cache` v4 workspace boundary

The true-sibling checkout introduced a second problem: `actions/cache` v4 (the backend used by `Swatinem/rust-cache@v2`) and `upload-artifact@v5` both enforce a strict boundary — paths outside `GITHUB_WORKSPACE` are rejected. With the old symlink approach, the real bytes lived inside the workspace (`./aura-harness/target/`) so saves succeeded. With the true-sibling checkout, `../aura-harness/target/` is genuinely outside the boundary.

### The fix (part 2 — cache/artifact boundary)

Two changes address this:

**`release-nightly.yml` / `release-stable.yml` `build-sidecar` job** — `CARGO_TARGET_DIR` is now set to `.aura-harness-target` (a directory inside `GITHUB_WORKSPACE`). The `Swatinem/rust-cache` `workspaces` entry is updated to match (`../aura-harness -> .aura-harness-target`). `prepare-desktop-sidecar.mjs` already reads `CARGO_TARGET_DIR` to locate the built binary, so no script changes are needed.

**`desktop-validate.yml`** — `CARGO_TARGET_DIR` is moved from `../.aura-shared-target` to `.aura-shared-target` (inside `GITHUB_WORKSPACE`) so compiled artifacts stay within the boundary that `actions/cache` v4 enforces. The `../aura-harness -> ../.aura-shared-target` entry is also removed from the `Swatinem/rust-cache` workspaces config — it was redundant because `CARGO_TARGET_DIR` is already set to `.aura-shared-target` for the entire job, so aura-harness build artifacts land in the shared target and are cached via the existing `. -> .aura-shared-target` entry. The only thing lost is that changes to `aura-harness/Cargo.lock` will no longer automatically bust the cache key. In practice this matters very little — Cargo's incremental compiler detects stale artifacts and recompiles them regardless, so correctness is unaffected; at worst one CI run rebuilds slightly more than it would have.

### The fix (part 3 — Windows `.cmd` spawns)

`scripts/ci/lib/utils.mjs` was failing on Windows runners when spawning `.cmd` executables (npm, pnpm, cargo wrappers) via `child_process.spawn` without `shell: true`. On Node 18+ Windows the runtime no longer transparently routes `.cmd` through `cmd.exe`, so the spawn fails with `EINVAL`/`ENOENT` depending on the exact path. Adding `shell: true` when the executable ends in `.cmd` restores the previous behavior without affecting POSIX shells.

### The fix (part 4 — UTF-8 BOM in `Cargo.toml`)

Three `Cargo.toml` files (`Cargo.toml`, `apps/aura-os-server/Cargo.toml`, `crates/aura-os-harness/Cargo.toml`, `crates/aura-os-integrations/Cargo.toml`) had a UTF-8 BOM at the start of the file. Cargo on Linux/macOS tolerates the BOM, but on Windows runners it surfaced as a parse error in some toolchain combinations. The BOMs were stripped so the files are clean UTF-8.

### Remaining smoke failure — `aura_network_url` / `aura_storage_url` not configured

With the checkout and artifact-boundary fixes in place, the `desktop-smoke` job on Linux now reaches the binary for the first time. The binary compiles and starts cleanly — `axum server ready` and `window created` both appear in the process log — but the smoke test still times out after two minutes.

**What the smoke script checks.** `infra/scripts/release/desktop-ci-smoke.mjs` polls `http://127.0.0.1:19847` in a loop. Once the root `GET /` returns the expected HTML, it then hits `/api/runtime-config` and asserts that `aura_network_url` and `aura_storage_url` are non-empty strings before declaring success.

**What the server returns.** `apps/aura-os-desktop/src/handlers.rs` builds the runtime-config payload from env vars:

```rust
"aura_network_url": std::env::var("AURA_NETWORK_URL").ok(),
"aura_storage_url": std::env::var("AURA_STORAGE_URL").ok(),
```

`AURA_NETWORK_URL` and `AURA_STORAGE_URL` are passed into the job via `${{ vars.AURA_NETWORK_URL }}` / `${{ vars.AURA_STORAGE_URL }}`. Neither repository variable is configured in `cypher-asi/aura-os`, so the desktop process receives empty values — the endpoint returns `"aura_network_url": null` — and the smoke check rejects it.

**Why this was invisible before.** The smoke check has been present in the codebase since commit `07a20d5c`. It was never reached in CI because every prior PR's `desktop-smoke` job was failing at the harness checkout step long before the binary ran. The harness checkout fix is what surfaces this.

**Two ways to resolve:**

1. **Set the repository variables** — go to `cypher-asi/aura-os` → Settings → Variables → Actions and add `AURA_NETWORK_URL` and `AURA_STORAGE_URL` with the real service URLs. The smoke check was written expecting these to be present, so this is the intended path if those services exist.

2. **Relax the smoke check** — make the runtime-config URL assertions conditional on the value being non-null rather than mandatory, so PR CI can pass without external service URLs configured. This is the right path if `AURA_NETWORK_URL` / `AURA_STORAGE_URL` are optional integrations rather than required infrastructure for every PR.

---

## Files changed

| File | Change | Diff |
|---|---|---|
| `.github/actions/setup-harness-sibling/action.yml` | Fixed — direct sibling checkout via `git clone`; symlink steps removed | +7 / -26 |
| `.github/workflows/desktop-validate.yml` | Fixed — `CARGO_TARGET_DIR` moved inside workspace; redundant rust-cache entry removed; rust-cache toggled off then back on in `desktop-smoke` | +9 / -10 |
| `.github/workflows/release-nightly.yml` | Fixed — `CARGO_TARGET_DIR` redirected inside workspace for sidecar job | +7 / -1 |
| `.github/workflows/release-stable.yml` | Fixed — `CARGO_TARGET_DIR` redirected inside workspace for sidecar job | +7 / -1 |
| `scripts/ci/lib/utils.mjs` | Fixed — `shell: true` when spawning `.cmd` executables on Windows | +8 / -2 |
| `Cargo.toml` | Fixed — UTF-8 BOM stripped | +2 / -2 |
| `apps/aura-os-server/Cargo.toml` | Fixed — UTF-8 BOM stripped | +2 / -2 |
| `crates/aura-os-harness/Cargo.toml` | Fixed — UTF-8 BOM stripped | +2 / -2 |
| `crates/aura-os-integrations/Cargo.toml` | Fixed — UTF-8 BOM stripped | +2 / -2 |

---

## Test plan

- [ ] `desktop-validate` workflow passes on Windows runners (`.cmd` spawns succeed; BOM-stripped `Cargo.toml` parses cleanly)
- [ ] `desktop-validate` workflow passes on Linux runners (sibling `aura-harness` checkout resolves correctly; `CARGO_TARGET_DIR` artifacts cache inside the workspace boundary)
- [ ] `desktop-smoke` workflow reaches the binary launch step (no more harness-checkout failure); see the "Remaining smoke failure" note above for the follow-up needed on `AURA_NETWORK_URL` / `AURA_STORAGE_URL`
- [ ] `release-nightly` and `release-stable` `build-sidecar` jobs find the built binary at the redirected `CARGO_TARGET_DIR`
- [ ] `Swatinem/rust-cache` save step succeeds (no workspace-boundary rejection)

Generated with [Claude Code](https://claude.com/claude-code)

