### PR TITLE
feat(agent-info): add copyable Agent ID in agent profile

### DIFF
--- a/interface/src/apps/agents/AgentInfoPanel/AgentInfoPanel.module.css
+++ b/interface/src/apps/agents/AgentInfoPanel/AgentInfoPanel.module.css
@@ -152,6 +152,19 @@
   text-overflow: ellipsis;
 }
 
+.metaValueWithAction {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+}
+
+.metaIdValue {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: var(--font-size-xs, 11px);
+  color: var(--color-text-secondary);
+}
+
 /* ── Profile skill tags ── */
 
 .skillTagsSection {

--- a/interface/src/apps/agents/AgentInfoPanel/ProfileTab.tsx
+++ b/interface/src/apps/agents/AgentInfoPanel/ProfileTab.tsx
@@ -11,13 +11,16 @@ import {
   Clock3,
   Activity,
   AlertTriangle,
+  Fingerprint,
 } from "lucide-react";
 import { Avatar } from "../../../components/Avatar";
+import { CopyButton } from "../../../components/CopyButton";
 import { FollowEditButton } from "../../../components/FollowEditButton";
 import { api } from "../../../api/client";
 import { useRemoteAgentState } from "../../../hooks/use-remote-agent-state";
 import {
   formatAdapterLabel,
+  formatAgentIdShort,
   formatAuthSourceLabel,
   formatRunsOnLabel,
 } from "./agent-info-utils";
@@ -274,6 +277,22 @@ function ProfileMetaGrid({ agent }: { agent: Agent }) {
           <span className={styles.metaLabel}>Birthed</span>
           <span className={styles.metaValue}>
             {new Date(agent.created_at).toLocaleDateString("en-US", { month: "long", year: "numeric" })}
+          </span>
+        </div>
+      </div>
+      <div className={styles.metaRow}>
+        <Fingerprint size={13} className={styles.metaIcon} />
+        <div className={styles.metaText}>
+          <span className={styles.metaLabel}>Agent ID</span>
+          <span className={styles.metaValueWithAction}>
+            <span className={styles.metaIdValue} title={agent.agent_id}>
+              {formatAgentIdShort(agent.agent_id)}
+            </span>
+            <CopyButton
+              getText={() => agent.agent_id}
+              ariaLabel="Copy agent ID"
+              iconOnly
+            />
           </span>
         </div>
       </div>

--- a/interface/src/apps/agents/AgentInfoPanel/agent-info-utils.ts
+++ b/interface/src/apps/agents/AgentInfoPanel/agent-info-utils.ts
@@ -24,6 +24,11 @@ export function formatAuthSourceLabel(
   }
 }
 
+export function formatAgentIdShort(agentId: string): string {
+  if (agentId.length <= 14) return agentId;
+  return `${agentId.slice(0, 8)}…${agentId.slice(-4)}`;
+}
+
 export function formatRunsOnLabel(
   environment?: string | null,
   machineType?: string | null,


### PR DESCRIPTION
## Summary

Adds an **Agent ID** row to the profile meta grid in `AgentInfoPanel` so the agent's identifier is visible — and copyable — everywhere the panel renders.

Previously the only way to see an agent's `agent_id` was via dev tools or the URL bar. With the marketplace sidekick now reusing `AgentInfoPanel` (read-only), it's the natural place to surface this for power users who want to wire programmatic flows (e.g. a CEO `hire_agent` tool that takes an `agent_id`).

## What changed

- **`agent-info-utils.ts`** — new `formatAgentIdShort(agentId)` helper. Returns the id untruncated when ≤14 chars, otherwise `first-8 + … + last-4`. Keeps the meta grid compact regardless of id format (UUIDs, short slugs in tests, etc.).
- **`ProfileTab.tsx`** — adds a new `metaRow` under "Birthed":
  - `Fingerprint` icon (lucide-react) for visual distinction from the other meta rows.
  - Monospace truncated id.
  - `title={agent.agent_id}` so hovering reveals the full id without any copy interaction.
  - Inline `CopyButton` (`iconOnly`) reusing the existing shared component (`copyToClipboard` helper handles Capacitor WebView fallbacks).
- **`AgentInfoPanel.module.css`** — two small additions:
  - `.metaValueWithAction` — inline-flex wrapper so the id text and copy button sit on the same line.
  - `.metaIdValue` — monospace font + matching meta-value typography.

## Where it appears

The same `AgentInfoPanel` is reused in multiple places, so this single change covers all of them:

- **Agents app** sidekick panel (your own agents).
- **Marketplace** right-side panel (other users' hireable agents — read-only).
- **Mobile standalone** agent profile view.

No gating on `isOwnAgent` — the id is useful for debugging and programmatic flows in both contexts.

## Design notes

- **Truncation format** (`abc12345…ef89`): keeps enough prefix to disambiguate at a glance while staying compact. The `…` is a single Unicode ellipsis, not three dots.
- **Tooltip + copy**: two redundant paths to the full id. Tooltip for "I just want to read it," copy button for "I want to paste it into something."
- **Why not gate by `isOwnAgent`?**: knowing the id of a marketplace agent is exactly what's needed to wire it into a `hire_agent` / `assign_agent_to_project` tool call. Hiding it in the marketplace context would defeat the main motivation.

## Files changed

| File | What changed | Diff |
| --- | --- | --- |
| [`interface/src/apps/agents/AgentInfoPanel/agent-info-utils.ts`](../blob/feat/agent-id-display/interface/src/apps/agents/AgentInfoPanel/agent-info-utils.ts) | New `formatAgentIdShort` helper that collapses long ids to `first-8 + … + last-4` and returns short ids as-is. | `+5 / -0` |
| [`interface/src/apps/agents/AgentInfoPanel/ProfileTab.tsx`](../blob/feat/agent-id-display/interface/src/apps/agents/AgentInfoPanel/ProfileTab.tsx) | Imports `Fingerprint`, `CopyButton`, and the new helper; renders a new **Agent ID** meta row under "Birthed" with truncated monospace value, hover-tooltip of the full id, and an icon-only copy button. | `+19 / -0` |
| [`interface/src/apps/agents/AgentInfoPanel/AgentInfoPanel.module.css`](../blob/feat/agent-id-display/interface/src/apps/agents/AgentInfoPanel/AgentInfoPanel.module.css) | Adds `.metaValueWithAction` (inline-flex wrapper so the id and copy button share a line) and `.metaIdValue` (monospace + matching meta-value typography). | `+13 / -0` |

## Test plan

- [x] `npx vitest run src/apps/agents/AgentInfoPanel/ProfileTab.test.tsx` — 2/2 passing.
- [x] `npx tsc --noEmit` across `interface/` — clean.
- [x] Open the Agents app, select an agent, confirm the **Agent ID** row appears under "Birthed" with the truncated id, hover shows the full id, click the copy icon shows the "Copied" state, paste yields the full untruncated id.
- [x] Open the Marketplace app, click a hireable agent card, confirm the same row appears in the right-side panel.
- [x] Resize the sidekick narrow and confirm the id row doesn't overflow or break the meta grid layout.
- [ ] Mobile standalone profile view: verify the row renders without colliding with the Remote Runtime / Installed Skills sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)