### PR TITLE
fix(desktop): fix on dev-channel desktops hitting a dead port (the hardcoded :19847 stable-channel default)

### DIFF
--- a/apps/aura-os-desktop/src/harness/sidecar.rs
+++ b/apps/aura-os-desktop/src/harness/sidecar.rs
@@ -14,7 +14,22 @@ pub(crate) fn preferred_local_harness_port() -> u16 {
     aura_os_core::Channel::current().preferred_sidecar_port()
 }
 
-pub(crate) fn maybe_spawn_local_harness_sidecar(data_dir: &Path) -> Option<Child> {
+/// Spawn the bundled `aura-node` sidecar.
+///
+/// `aura_os_server_port` is the actual port the embedded `aura-os-server`
+/// just bound to. We forward it as `AURA_OS_SERVER_URL=http://127.0.0.1:{port}`
+/// on the child's env so the harness's
+/// `aura-runtime::config::aura_os_server_url` resolves to the live desktop
+/// server instead of falling back to the hardcoded
+/// `DESKTOP_LOOPBACK_OS_SERVER_URL` constant (which assumes the stable
+/// channel's `19847`). Without this, cross-agent callbacks (`list_agents`,
+/// `send_to_agent`, spec writes, image gen, etc.) target the wrong port on
+/// dev-channel desktops (which bind 19848) and on any session where 19847
+/// was already taken and the OS picked an ephemeral port.
+pub(crate) fn maybe_spawn_local_harness_sidecar(
+    data_dir: &Path,
+    aura_os_server_port: u16,
+) -> Option<Child> {
     let explicit_harness_url =
         env_string("LOCAL_HARNESS_URL").map(|value| value.trim_end_matches('/').to_string());
     let harness_binary = resolve_managed_harness_binary(data_dir);
@@ -63,9 +78,12 @@ pub(crate) fn maybe_spawn_local_harness_sidecar(data_dir: &Path) -> Option<Child
     }
 
     let mut command = Command::new(&harness_binary);
-    command
-        .env("AURA_LISTEN_ADDR", &listen_addr)
-        .env("AURA_DATA_DIR", &harness_data_dir);
+    configure_sidecar_command_env(
+        &mut command,
+        &listen_addr,
+        &harness_data_dir,
+        aura_os_server_port,
+    );
     configure_background_child(&mut command, &harness_data_dir.join("sidecar.log"));
 
     if let Some(orbit_url) = env_string("ORBIT_URL").or_else(|| env_string("ORBIT_BASE_URL")) {
@@ -80,6 +98,28 @@ pub(crate) fn maybe_spawn_local_harness_sidecar(data_dir: &Path) -> Option<Child
         }
     }
     child
+}
+
+/// Apply the env vars the harness sidecar process needs to a freshly
+/// constructed [`Command`]. Extracted into a free function so unit tests
+/// can assert on the env without going through `spawn()` / IO.
+///
+/// `aura_os_server_port` is forwarded as `AURA_OS_SERVER_URL` to override
+/// the harness's hardcoded `DESKTOP_LOOPBACK_OS_SERVER_URL` fallback
+/// (`:19847`, the stable-channel port). Without this override, dev-channel
+/// desktops (`:19848`) and any session where 19847 was taken see every
+/// cross-agent harness callback target a dead port.
+fn configure_sidecar_command_env(
+    command: &mut Command,
+    listen_addr: &str,
+    harness_data_dir: &Path,
+    aura_os_server_port: u16,
+) {
+    let aura_os_server_url = format!("http://127.0.0.1:{aura_os_server_port}");
+    command
+        .env("AURA_LISTEN_ADDR", listen_addr)
+        .env("AURA_DATA_DIR", harness_data_dir)
+        .env("AURA_OS_SERVER_URL", aura_os_server_url);
 }
 
 fn spawn_and_wait_for_health(
@@ -199,7 +239,11 @@ pub(crate) fn stop_managed_local_harness(managed_local_harness: &mut Option<Chil
 
 #[cfg(test)]
 mod tests {
-    use super::wait_for_harness_health;
+    use super::{configure_sidecar_command_env, wait_for_harness_health};
+    use std::collections::HashMap;
+    use std::ffi::OsString;
+    use std::path::Path;
+    use std::process::Command;
     use std::time::Duration;
 
     #[test]
@@ -218,5 +262,54 @@ mod tests {
             Duration::ZERO,
             || true,
         ));
+    }
+
+    fn env_map(command: &Command) -> HashMap<OsString, OsString> {
+        command
+            .get_envs()
+            .filter_map(|(k, v)| v.map(|v| (k.to_os_string(), v.to_os_string())))
+            .collect()
+    }
+
+    #[test]
+    fn configure_sidecar_command_env_sets_aura_os_server_url_to_loopback_port() {
+        let mut command = Command::new("does-not-need-to-exist");
+        configure_sidecar_command_env(
+            &mut command,
+            "127.0.0.1:8080",
+            Path::new("/tmp/aura-test"),
+            19848,
+        );
+        let envs = env_map(&command);
+        assert_eq!(
+            envs.get(OsString::from("AURA_OS_SERVER_URL").as_os_str()),
+            Some(&OsString::from("http://127.0.0.1:19848")),
+            "AURA_OS_SERVER_URL must be a loopback URL with the bound port — this is the entire point of the patch"
+        );
+    }
+
+    #[test]
+    fn configure_sidecar_command_env_threads_listen_addr_and_data_dir() {
+        let mut command = Command::new("does-not-need-to-exist");
+        configure_sidecar_command_env(
+            &mut command,
+            "127.0.0.1:9090",
+            Path::new("/tmp/aura-test-data"),
+            19847,
+        );
+        let envs = env_map(&command);
+        assert_eq!(
+            envs.get(OsString::from("AURA_LISTEN_ADDR").as_os_str()),
+            Some(&OsString::from("127.0.0.1:9090")),
+        );
+        assert_eq!(
+            envs.get(OsString::from("AURA_DATA_DIR").as_os_str()),
+            Some(&OsString::from("/tmp/aura-test-data")),
+        );
+        assert_eq!(
+            envs.get(OsString::from("AURA_OS_SERVER_URL").as_os_str()),
+            Some(&OsString::from("http://127.0.0.1:19847")),
+            "stable-channel port 19847 must round-trip unchanged — no behavior change for stable users"
+        );
     }
 }

--- a/apps/aura-os-desktop/src/main.rs
+++ b/apps/aura-os-desktop/src/main.rs
@@ -49,13 +49,22 @@ use crate::ui::main_window::{create_main_webview, create_main_window};
 use crate::ui::menu::install_macos_app_menu;
 use crate::ui::runtime::{run_event_loop, spawn_fallback_show_timer, LoopContext, LoopState};
 
-/// Aggregated artefacts from the data-directory + harness phase of startup.
+/// Aggregated artefacts from the data-directory phase of startup.
+///
+/// The harness sidecar handle was previously bundled here, but it is now
+/// spawned *after* `bind_listener` so the actual bound port can be
+/// forwarded to the child as `AURA_OS_SERVER_URL`. Without that, the
+/// harness's `aura-runtime` config falls back to the hardcoded stable-channel
+/// port (`19847`) and every cross-agent callback into aura-os-server hits a
+/// dead port on dev-channel desktops.
 struct PreBindStartup {
     store_path: std::path::PathBuf,
     webview_data_dir: std::path::PathBuf,
     interface_dir: Option<std::path::PathBuf>,
     route_state: RouteState,
-    managed_local_harness: Option<std::process::Child>,
+    /// `true` when the operator passed `--external-harness` — we must not
+    /// spawn a managed sidecar post-bind in that case.
+    external_harness: bool,
 }
 
 /// Aggregated artefacts produced once the embedded server is up and the
@@ -90,6 +99,15 @@ fn main() {
 
     let (std_listener, server_port, server_url) = bind_listener();
     self_heal_loopback_overrides(server_port);
+
+    // Spawn the harness sidecar AFTER `bind_listener` so the actual bound
+    // port can be threaded to the child as `AURA_OS_SERVER_URL`. Without
+    // this, the harness's hardcoded `DESKTOP_LOOPBACK_OS_SERVER_URL`
+    // fallback (`:19847`, the stable-channel port) is wrong on dev
+    // channel (`:19848`) and on any session where the OS auto-picked an
+    // ephemeral port — and every cross-agent callback the harness makes
+    // back into aura-os-server hits the wrong port.
+    let managed_local_harness = maybe_spawn_managed_local_harness(&pre_bind, server_port);
 
     let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
     let proxy = event_loop.create_proxy();
@@ -183,7 +201,7 @@ fn main() {
         main_webview,
         web_context,
         managed_frontend_dev_server: server.managed_frontend_dev_server,
-        managed_local_harness: pre_bind.managed_local_harness,
+        managed_local_harness,
         initial_frontend_base_url,
         initial_using_frontend_dev_server: server.frontend_target.using_frontend_dev_server,
         icon_data,
@@ -206,19 +224,41 @@ fn prepare_pre_bind(cli: DesktopCliArgs) -> PreBindStartup {
     let route_state = RouteState::load(&data_dir);
     install_panic_hook(&data_dir);
     install_native_crash_handler(&data_dir);
-    let managed_local_harness = if cli.external_harness {
+    // External-harness operators must have a reachable harness *before* we
+    // bind the embedded server, otherwise the subsequent server-thread
+    // startup picks up a broken upstream and fails opaque-ly. This check
+    // exits the process on its own when the configured harness is missing.
+    if cli.external_harness {
         enforce_external_harness_or_exit();
-        None
-    } else {
-        maybe_spawn_local_harness_sidecar(&data_dir)
-    };
+    }
     PreBindStartup {
         store_path,
         webview_data_dir,
         interface_dir,
         route_state,
-        managed_local_harness,
+        external_harness: cli.external_harness,
     }
+}
+
+/// Spawn the managed local harness sidecar with the actual bound
+/// `aura-os-server` port threaded through. Called *after* `bind_listener`
+/// so the child receives an accurate `AURA_OS_SERVER_URL`. Returns `None`
+/// when the operator opted into an externally-managed harness via
+/// `--external-harness` (in which case the harness was already verified
+/// reachable in `prepare_pre_bind`).
+fn maybe_spawn_managed_local_harness(
+    pre_bind: &PreBindStartup,
+    server_port: u16,
+) -> Option<std::process::Child> {
+    if pre_bind.external_harness {
+        return None;
+    }
+    let data_dir = pre_bind
+        .store_path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| pre_bind.store_path.clone());
+    maybe_spawn_local_harness_sidecar(&data_dir, server_port)
 }
 
 fn resolve_frontend(server_url: &str, server_port: u16) -> ServerStartup {


### PR DESCRIPTION
## Summary

Repairs cross-agent harness callbacks on dev-channel desktops and on any session that lands on an ephemeral port. Currently those sessions hit a dead port (the hardcoded `:19847` stable-channel default) and the model interprets the connection-refused errors as "the server is down" — which reads as a hallucination because the real aura-os-server is alive on a different port.

Stable-channel behavior is unchanged: the env override matches the existing harness default for that channel.

## Why it broke

Two ports, two channels, one hardcoded constant:

| Channel | `aura-os-desktop` binds | `aura-harness` defaults `AURA_OS_SERVER_URL` to | Result |
|---|---|---|---|
| Stable | `19847` (\`Channel::Stable.preferred_desktop_port\`) | `19847` (\`DESKTOP_LOOPBACK_OS_SERVER_URL\` in \`aura-harness/crates/aura-runtime/src/config/mod.rs\`) | ✅ matches |
| **Dev** (the broken one) | **`19848`** | **`19847`** | ❌ every callback hits a dead port |
| Either, ephemeral fallback | OS-picked port | `19847` | ❌ same |

Tools affected: `list_agents`, `send_to_agent`, `delegate_task`, `list_specs`, `create_spec`, `generate_image`, anything else routed through \`aura-runtime::HttpDomainApi\` or the cross-agent hook in \`session/cross_agent_hook.rs\`.

## How the fix works

The desktop now spawns the harness sidecar **after** \`bind_listener\` returns the actual bound port and forwards that port to the child as \`AURA_OS_SERVER_URL\`. The harness's existing precedence rule wins (env var first, hardcoded fallback only when unset — see \`aura-runtime/src/config/mod.rs:232-255\`), so this is strictly additive: it only changes behavior in the broken cases.

Previously, sidecar spawn happened in \`prepare_pre_bind\` (before bind), so the bound port was unknown at spawn time. Restructure: drop the sidecar handle from \`PreBindStartup\`, add a \`maybe_spawn_managed_local_harness(&pre_bind, server_port)\` post-bind that honors \`--external-harness\`.

## Files changed

| File | Lines | Change |
|------|-------|--------|
| \`apps/aura-os-desktop/src/harness/sidecar.rs\` | +97 / -6 | \`maybe_spawn_local_harness_sidecar\` takes \`aura_os_server_port: u16\`. New private helper \`configure_sidecar_command_env\` builds the child env (extracted for unit-testability — no longer requires actually spawning). Two new unit tests assert (a) the AURA_OS_SERVER_URL is wired to \`http://127.0.0.1:{port}\` for dev-channel 19848, and (b) stable-channel 19847 round-trips unchanged (no behavior change for stable users). |
| \`apps/aura-os-desktop/src/main.rs\` | +50 / -8 | \`PreBindStartup\` drops \`managed_local_harness\`, adds \`external_harness: bool\`. \`prepare_pre_bind\` only runs the \`enforce_external_harness_or_exit\` check (still pre-bind, so a missing external harness fails fast). New \`maybe_spawn_managed_local_harness(&pre_bind, server_port)\` runs after \`bind_listener\` + \`self_heal_loopback_overrides\` so it can pass the bound port to the sidecar. \`build_loop_state\` receives the new handle directly. |

**Totals: 2 files changed, 147 insertions(+), 14 deletions(-).**

## Impact on the regular (stable-channel) app

**None.** The override sets \`AURA_OS_SERVER_URL=http://127.0.0.1:19847\` for a stable-channel desktop — the same value the harness was already using via its hardcoded fallback. The only behavior change is in cases that were already broken (dev channel, ephemeral fallback).

## Why spawn-after-bind is OK for cold-start time

The sidecar spawn waits up to 10 s for the child's \`/health\` to come up (\`spawn_and_wait_for_health\` in sidecar.rs:125-148). That wait was previously serialized with the rest of \`prepare_pre_bind\` — \`bind_listener\` ran *after* the sidecar was healthy. Moving the spawn post-bind keeps the same serialization profile (bind is sub-millisecond OS port allocation; the sidecar's health wait dominates either way), so there's no measurable cold-start regression.

## Test plan

- [x] \`cargo test -p aura-os-desktop --bin aura-os-desktop\` — full suite 88/88 pass, including the two new \`configure_sidecar_command_env_*\` tests
- [x] \`cargo build -p aura-os-desktop\` — clean
- [x] Manual end-to-end: re-launched the dev-channel desktop with \`AURA_HARNESS_BIN\` pointing at a sibling \`aura-node.exe\`. With the env override applied (this PR's behavior), CEO agent's \`list_agents\` tool returned a real roster instead of the previous "service unreachable at port 19847" message
- [ ] Stable-channel build smoke (the override matches the existing default — no behavior change expected, but worth a quick \`/print-channel\` verification before merge)

## Follow-up out of scope for this PR

- The \`.env.example\` / \`.env\` shipping the value \`LOCAL_HARNESS_URL=http://localhost:8080\` causes a separate aura-node parse error (the harness's socket-address parser rejects \`localhost:8080\`, only accepts IP literals). Caught during the same dev session but logically a separate fix — leaving that for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)