### PR TITLE
Add Change Log link to Settings > General > Updates

### DIFF
--- a/interface/src/components/OrgSettingsGeneral/OrgSettingsGeneral.tsx
+++ b/interface/src/components/OrgSettingsGeneral/OrgSettingsGeneral.tsx
@@ -224,6 +224,15 @@ export function OrgSettingsGeneral({
                 </span>
               </>
             ) : null}
+            <a
+              href="https://aura.ai/changelog"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.rowDescription}
+              style={{ color: "var(--color-brand-primary)", textDecoration: "none" }}
+            >
+              Change Log
+            </a>
           </div>
           <div className={`${styles.rowControl} ${styles.rowControlWide}`}>
             <UpdateControl layout="inline" showLastChecked={false} />


### PR DESCRIPTION
﻿## Summary
- Adds a "Change Log" link (https://aura.ai/changelog) to the Updates section in Settings > General
- Link opens in a new tab, styled with the brand primary color to match the settings UI
- Positioned at the bottom of the Updates info area, below the "Last checked" timestamp

## Test plan
- [x] Open Settings > General and scroll to the Updates section
- [x] Verify the "Change Log" link appears below the update description
- [x] Click the link and confirm it opens https://aura.ai/changelog in a new browser tab
- [x] Verify link styling matches the brand color and has no underline
