### PR TITLE
proposal: /api/preferences/* — a shared framework for server-backed user preferences

### DIFF
--- a/apps/aura-os-server/src/handlers/mod.rs
+++ b/apps/aura-os-server/src/handlers/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod org_tools;
 pub(crate) mod orgs;
 pub(crate) mod permissions;
 pub(crate) mod plan_mode;
+pub(crate) mod preferences;
 pub(crate) mod process;
 pub(crate) mod project_artifacts;
 pub(crate) mod project_stats;

--- a/apps/aura-os-server/src/handlers/preferences/mod.rs
+++ b/apps/aura-os-server/src/handlers/preferences/mod.rs
@@ -1,0 +1,93 @@
+//! App-wide / per-user preferences, persisted server-side under the
+//! `preferences:<feature>` key convention in the settings store.
+//!
+//! This module is the shared **skeleton** every preference feature
+//! builds on. A feature adds one child module (e.g. `agent_order.rs`)
+//! that:
+//!   1. defines a `#[derive(Default, Serialize, Deserialize)]` struct,
+//!   2. picks a feature name and stores under [`preferences_key`],
+//!   3. exposes thin `get_*` / `put_*` (and optionally `delete_*`)
+//!      handlers that delegate to [`get_pref`] / [`put_pref`] /
+//!      [`delete_pref`],
+//!   4. registers its route in `router/preferences.rs`.
+//!
+//! The store round-trips an opaque JSON blob, so evolving a
+//! preference's frontend schema never requires a Rust change beyond
+//! the struct itself. Reads of an unset key return `T::default()`
+//! rather than 404, so clients never special-case "not configured."
+//!
+//! Every handler is `AuthJwt`-gated: anonymous reads can't leak
+//! user-scoped prefs and anonymous writes can't poison the store.
+
+// The skeleton ships these helpers ahead of any feature that calls
+// them; each ported preference PR removes a helper from "unused" by
+// wiring up its handlers. Allow dead_code so the skeleton compiles
+// warning-clean on its own.
+#![allow(dead_code)]
+
+use axum::Json;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::error::{ApiError, ApiResult};
+use crate::state::AppState;
+
+// Feature modules register below. Each `pub(crate) use` re-exports the
+// feature's route handlers so `router/preferences.rs` can reference
+// them as `preferences::get_<feature>` etc.
+//
+// (Features are added by the ported PRs — keep this list alphabetical.)
+
+/// Build the canonical settings-store key for a preference feature.
+///
+/// All app-wide preferences share the `preferences:` prefix so they
+/// can be enumerated via `SettingsStore::list_settings_with_prefix`
+/// and never collide with other settings keys. `feature` is the
+/// snake_case feature name (e.g. `agent_order`, `aura_logo`,
+/// `icon_select`).
+pub(crate) fn preferences_key(feature: &str) -> String {
+    format!("preferences:{feature}")
+}
+
+/// Read a preference blob, deserializing into `T`. Returns
+/// `T::default()` when the key is unset or the stored bytes fail to
+/// deserialize (e.g. a schema migration) — preferences are best-effort
+/// and never hard-fail a read.
+pub(crate) fn get_pref<T>(state: &AppState, feature: &str) -> Json<T>
+where
+    T: DeserializeOwned + Default,
+{
+    let prefs = state
+        .store
+        .get_setting(&preferences_key(feature))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .unwrap_or_default();
+    Json(prefs)
+}
+
+/// Persist a preference blob, echoing it back so the client can take
+/// the server's stored shape as authoritative.
+pub(crate) fn put_pref<T>(state: &AppState, feature: &str, prefs: T) -> ApiResult<Json<T>>
+where
+    T: Serialize,
+{
+    let bytes = serde_json::to_vec(&prefs)
+        .map_err(|e| ApiError::internal(format!("serialize {feature} preferences: {e}")))?;
+    state
+        .store
+        .put_setting(&preferences_key(feature), &bytes)
+        .map_err(|e| ApiError::internal(format!("persist {feature} preferences: {e}")))?;
+    Ok(Json(prefs))
+}
+
+/// Reset a preference to its default by deleting the stored key. The
+/// next `get_pref` then returns `T::default()`. Idempotent: deleting an
+/// already-absent key is not an error.
+pub(crate) fn delete_pref(state: &AppState, feature: &str) -> ApiResult<axum::http::StatusCode> {
+    state
+        .store
+        .delete_setting(&preferences_key(feature))
+        .map_err(|e| ApiError::internal(format!("reset {feature} preferences: {e}")))?;
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}

--- a/apps/aura-os-server/src/router/mod.rs
+++ b/apps/aura-os-server/src/router/mod.rs
@@ -22,6 +22,7 @@ mod feedback;
 mod harness_proxy;
 mod marketplace_bootstrap;
 mod notes;
+mod preferences;
 mod process_generation;
 mod projects_files;
 mod public;
@@ -53,6 +54,7 @@ use feedback::feedback_routes;
 use harness_proxy::harness_proxy_routes;
 use marketplace_bootstrap::{agent_bootstrap_routes, marketplace_routes};
 use notes::notes_routes;
+use preferences::preferences_routes;
 use process_generation::{generation_routes, process_routes};
 use projects_files::project_routes;
 use public::public_routes;
@@ -92,6 +94,7 @@ pub fn create_router_with_interface(state: AppState, interface_dir: Option<PathB
         .merge(generation_routes())
         .merge(harness_proxy_routes())
         .merge(notes_routes())
+        .merge(preferences_routes())
         .merge(marketplace_routes())
         .merge(debug_routes())
         .merge(loops_routes())

--- a/apps/aura-os-server/src/router/preferences.rs
+++ b/apps/aura-os-server/src/router/preferences.rs
@@ -1,0 +1,30 @@
+//! Routes for app-wide / per-user preferences (`/api/preferences/*`).
+//!
+//! The skeleton mounts an empty router; each preference feature adds
+//! its own `.route(...)` line here, pointing at the `get_*` / `put_*`
+//! (and optional `delete_*`) handlers in `handlers::preferences`.
+//!
+//! Convention: path `/api/preferences/<feature-kebab>`, GET to read
+//! (returns the feature's default when unset), PUT to write, optional
+//! DELETE to reset-to-default.
+//!
+//! Example (added by a feature PR):
+//! ```ignore
+//! .route(
+//!     "/api/preferences/agent-order",
+//!     get(preferences::get_agent_order)
+//!         .put(preferences::put_agent_order)
+//!         .delete(preferences::delete_agent_order),
+//! )
+//! ```
+
+use axum::Router;
+
+#[allow(unused_imports)]
+use crate::handlers::preferences;
+use crate::state::AppState;
+
+pub(super) fn preferences_routes() -> Router<AppState> {
+    // Feature routes are registered here by the ported preference PRs.
+    Router::new()
+}

--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -48,6 +48,7 @@ import { notesApi } from "../shared/api/notes";
 import { marketplaceApi } from "./marketplace";
 import { debugApi } from "../shared/api/debug";
 import { streamsApi } from "../shared/api/streams";
+import { preferencesApi } from "../shared/api/preferences";
 
 export const api = {
   auth: authApi,
@@ -78,4 +79,5 @@ export const api = {
   marketplace: marketplaceApi,
   debug: debugApi,
   streams: streamsApi,
+  preferences: preferencesApi,
 };

--- a/interface/src/shared/api/preferences.ts
+++ b/interface/src/shared/api/preferences.ts
@@ -1,0 +1,48 @@
+import { apiFetch } from "./core";
+
+/**
+ * App-wide / per-user preferences client. The server persists each
+ * feature opaquely under a `preferences:<feature>` key (see
+ * `apps/aura-os-server/src/handlers/preferences/`), so the wire shape
+ * is owned by the frontend type for that feature.
+ *
+ * This module is the shared **skeleton**: it exposes generic
+ * `getPref` / `putPref` / `deletePref` helpers and an empty
+ * `preferencesApi` namespace. Each preference feature extends
+ * `preferencesApi` with typed `get<Feature>` / `put<Feature>` methods
+ * (thin wrappers over the generic helpers) and defines its own
+ * `<Feature>Prefs` interface here.
+ *
+ * Convention: path `/api/preferences/<feature-kebab>`. GET returns the
+ * feature's default when unset (the server never 404s a preference
+ * read), PUT writes and echoes the stored shape, DELETE resets to
+ * default.
+ */
+
+const PREFERENCES_BASE = "/api/preferences";
+
+/** Read a preference. The server returns the feature default when unset. */
+export function getPref<T>(featureKebab: string): Promise<T> {
+  return apiFetch(`${PREFERENCES_BASE}/${featureKebab}`);
+}
+
+/** Write a preference; resolves to the server's echoed (authoritative) shape. */
+export function putPref<T>(featureKebab: string, prefs: T): Promise<T> {
+  return apiFetch(`${PREFERENCES_BASE}/${featureKebab}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(prefs),
+  });
+}
+
+/** Reset a preference to its default (server deletes the stored key). */
+export function deletePref(featureKebab: string): Promise<void> {
+  return apiFetch(`${PREFERENCES_BASE}/${featureKebab}`, { method: "DELETE" });
+}
+
+/**
+ * Typed preference methods. Feature PRs extend this object with
+ * `get<Feature>` / `put<Feature>` (and optionally `delete<Feature>`)
+ * wrappers — see `getPref` / `putPref` / `deletePref` above.
+ */
+export const preferencesApi = {};


### PR DESCRIPTION
## TL;DR

A small, opt-in scaffold for **app-wide / per-user preferences that persist server-side** under a `preferences:<feature>` key convention. It exists so individual features stop hand-rolling (and re-colliding on) the same persistence wiring, and so user settings can survive an **app reinstall / cache-clear** instead of living only in a single browser's `localStorage`.

This PR adds **no user-facing routes** on its own — it's the shared plumbing that feature PRs build on. It's posted as a **proposal**: if the team is comfortable with the approach, features can adopt it incrementally; if not, it can be closed with nothing else affected.

> **Scope note — this is durability, not sync.** The `SettingsStore` this builds on is a **local** RocksDB rooted at a filesystem path in the per-user data dir (`SettingsStore::open(path)` → local column families). It survives a reinstall/cache-clear because that dir lives *outside* the app install and the WebView cache — but it is still **per-device**. It does **not** sync across machines or between the web and desktop apps. True cross-device sync would require routing preferences through `aura-network` or `aura-storage` (the separate cloud clients on `AppState`), which is explicitly **out of scope** for this PR. See *Durability vs. sync* below.

---

## Why this exists

Three recent feature PRs (#15 logo color, #16 agent drag-order, #20 icon accent) each independently needed "remember this user setting." Each one separately added:

- a `handlers/preferences/<feature>.rs` + a registration line in `handlers/mod.rs`
- a `router/preferences.rs` + a registration line in `router/mod.rs`
- a `shared/api/preferences.ts` + a `preferences` entry in `client.ts`

Because they all touched the **same three shared files** (`handlers/mod.rs`, `router/mod.rs`, `client.ts`), they conflicted with each other and with `main` on every rebase — even though the actual feature logic never overlapped. The scaffold was ~80% identical boilerplate copied three times, with subtly different key names and error handling each time.

This PR extracts that boilerplate **once**, so a feature becomes: *one struct + one key + thin handlers + one route line + one typed client method.* No feature ever edits the shared registration files in a conflicting way again — they only append to documented extension points.

## The deeper motivation: localStorage is not durable

Today most user preferences live in `localStorage` (or IndexedDB). That's fine for ephemeral/cosmetic state, but it has a real failure mode the team keeps running into: **a reinstall / cache-clear wipes it.** A desktop reinstall, a cleared WebView data dir, or "clear browsing data" silently resets every preference, because that storage lives inside the browser/WebView profile.

The server-side settings store does not have that problem — it lives in the per-user OS data dir, outside the app install and the WebView cache, so it survives a clean reinstall on Windows/macOS/Linux.

The canonical example is already documented in this repo: `docs/_infographic-default-model.html` ("the default_model gap") walks through this problem for an agent's default model. This framework is the general-purpose answer to that class of gap.

Critically, this is **not** "localStorage is bad, server-back everything." The right call is per-setting (see *When to use this* below). This framework just makes the durable option **cheap enough to choose** when the setting warrants it.

## Durability vs. sync (what this does and does not give you)

| Concern | `localStorage` / IndexedDB (today) | This framework (local `SettingsStore`) | Would require `aura-network` / `aura-storage` |
|---|---|---|---|
| Survives page reload | ✅ | ✅ | ✅ |
| Survives **app reinstall / cache-clear** | ❌ (lives in the WebView profile) | ✅ (RocksDB in the OS data dir, outside the install) | ✅ |
| Follows the user to a **second machine** | ❌ | ❌ (per-device) | ✅ |
| Shared between **web app and desktop app** | ❌ | ❌ (per-device) | ✅ |

So the honest pitch for this PR is **"reinstall-durable, per-device,"** not cross-device. If/when true cross-device sync is wanted, this same `preferences:<feature>` shape is a natural thing to forward to a cloud service later — but that is a separate, larger change and is not proposed here.

---

## What this PR adds

**Server** (`apps/aura-os-server/src/handlers/preferences/`)
- `mod.rs`: the `preferences_key("<feature>")` convention (`preferences:<feature>`) + three generic helpers over the existing `SettingsStore` API:
  - `get_pref<T>` — returns `T::default()` when unset (reads never 404; clients never special-case "not configured")
  - `put_pref<T>` — persists + echoes the stored shape back as authoritative
  - `delete_pref` — reset-to-default (idempotent)
- `router/preferences.rs`: an (initially empty) `preferences_routes()` merged into the **protected** router, so every preference is `AuthJwt`-gated — anonymous reads can't leak user-scoped prefs and anonymous writes can't poison the store.

**Frontend** (`interface/src/shared/api/preferences.ts`)
- generic `getPref` / `putPref` / `deletePref` helpers + an empty `preferencesApi` namespace, registered once in `client.ts`.

It reuses the **already-existing, unchanged** `SettingsStore` (`crates/aura-os-store/src/store_settings.rs`: `get_setting` / `put_setting` / `delete_setting` / `list_settings_with_prefix`) — a local RocksDB-backed store in the per-user data dir. No storage-layer changes.

## Design conventions a feature follows

1. **Route:** `GET`/`PUT`/`DELETE` `/api/preferences/<feature-kebab>`
2. **Key:** `preferences:<feature_snake>` (enumerable via `list_settings_with_prefix("preferences:")`)
3. **Opaque blobs:** the server round-trips JSON without mirroring the frontend type, so frontend schema evolution needs no Rust change.
4. **Default on empty:** a missing key deserializes to `T::default()`.
5. **Local cache + write-through + post-login hydrate** on the client, so logged-out/first-paint still works and the durable copy wins after login (the pattern documented in the `persistence` skill).

A complete feature handler is ~15 lines; see the worked examples in the v2 feature branches below.

---

## What would take advantage of this

This list is grounded in an actual sweep of `localStorage`/IndexedDB keys on `main`. Items are split into **personal preferences** (good candidates — a user would be annoyed to lose them on reinstall) and **ephemeral/nav/auth state** (should stay local — listed explicitly so the boundary is clear). Reminder: adopting this makes a setting **reinstall-durable on the same device**, not cross-device.

### Already built against the pattern (currently shipping local-only)
- **Agent drag-order** (#31) — per-device IndexedDB today.
- **Icon-select accent + custom theme tokens** (#32) — `localStorage` today.
- **AURA logo color + pulse** (#33) — `localStorage` today.

### The documented gap this was conceived for
- **Per-agent `default_model`** — see `docs/_infographic-default-model.html`; currently local-only, the infographic explicitly proposes migrating it to durable storage.

### Appearance & theming (the whole surface)
The appearance system is the strongest cluster of candidates — pure personal taste a user would not want reset by a reinstall:
- **Base theme choice** (light / dark / system) — persisted to `localStorage` from `Settings → Appearance`.
- **All custom theme tokens** (`aura-theme-overrides`, applied per resolved theme via `EDITABLE_TOKENS`):
  - `--color-border`
  - `--color-border-main-panel`
  - `--color-border-chrome`
  - `--color-surface-tint`
  - `--color-elevated-tint`
  - `--color-sidebar-bg`
  - `--color-sidekick-bg`
  - `--color-titlebar-bg`
  - `--color-accent`
  - `--color-modal-bg`
  - *(+ `--color-icon-selected`, added by #32)*
- **Named theme presets** (`aura-theme-presets`, `theme-presets.ts` / `StoredPresets`) — saved/imported custom palettes; losing these on reinstall is exactly the annoyance this targets.
- **Desktop wallpaper / background** (`aura:desktopBackground`).
- **UI mode** (`aura-ui-mode` / `aura-app-mode` — Simple / Advanced / Public) and **default agent mode** (`aura-selected-mode:default`).

### Layout & chrome personalization
- **Taskbar app order** (`aura-taskbar-app-order`), **hidden apps** (`aura-taskbar-apps-collapsed`), **right-cluster collapsed** (`aura-taskbar-right-collapsed`).
- **Sidebar / sidekick layout**: collapsed state, split, and width (`aura-sidekick-split`, `aura-sidekick-width`, `aura-sidekick-v2`, authed/public sidebar collapsed flags).
- **Project ordering** (`aura-project-order`) and **pinned / favorite agents** (`aura:pinnedAgentIds`, `aura:favoriteAgentIds`) — currently IndexedDB, same reinstall-durability gap as agent drag-order.

### Privacy / account-level
- **Analytics opt-out** (`aura-analytics-opt-out`) — arguably should be durable per-user, so the choice is not silently reverted on a fresh install.

### Explicitly NOT candidates (stay local — listed so the line is unambiguous)
These are ephemeral, navigational, security, or scratch state where per-device + reset-on-clear is correct, and server-backing would add needless round-trips / write amplification:
- **Navigation memory:** `aura-last-project`, `aura-last-agent`, `aura-chat-app:last-agent-id`, `aura:lastNote`, `aura:lastProcessId`, `aura-last-advanced-path`, `aura-last-simple-path`.
- **Boot / session / auth:** `__AURA_BOOT_AUTH__`, `aura-boot-diagnostics`, `aura-jwt`, `aura-session`, `aura-idb:auth:session`, `aura-force-logged-out`, `aura-host-origin`, `aura-native-sw-reset`, `aura-preload-recovery`.
- **First-visit / draft / scratch:** `aura-chat-app:visited`, `aura:new-project-draft`, `aura:new-project-modal-open`, `aura:processViewports`, `aura:desktopWindows`, task-output / turn caches (`aura-task-output-cache-v1`, `aura-task-turns-v1`, `aura-process-node-turns-v1`).

## When to use this (and when not to)

- **Use it** for a per-user choice that a user would be annoyed to lose on a reinstall / cache-clear (everything in the candidate sections above).
- **Don't use it** for the ephemeral/navigational/security/scratch state in the "NOT candidates" list. Those should stay `localStorage`.
- **If the requirement is genuinely cross-device** (same setting on a second machine, or shared between web and desktop), this framework alone is not enough — that needs `aura-network` / `aura-storage`. This framework is still a reasonable first step (reinstall-durable now) and a clean shape to forward to a cloud service later.

This mirrors the guidance in the `persistence` skill: *if you are about to use localStorage for something a user would be annoyed to lose, reach for the durable server pattern instead.*

---

## Scope, risk, and rollout

- **Zero behavior change on its own.** No routes are exposed until a feature adds one; merging this changes nothing a user sees.
- **Additive + low-risk.** New module + helpers over an existing store API; `cargo check -p aura-os-server` is warning-clean.
- **Incremental adoption.** Features opt in one at a time. The current v2 feature PRs (#31/#32/#33) intentionally ship **local-only and independent of this PR**, so none of them block on it — they can each be re-based onto this framework later, individually, if/when reinstall-durable persistence is desired.
- **If rejected:** close this PR; nothing else is affected.

## Verification

`cargo check -p aura-os-server` ✓ (warning-clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
