### PR TITLE
feat(agents): drag-to-reorder sidebar with cross-app persistent order (v2)

### DIFF
--- a/interface/src/apps/agents/AgentList/AgentList.module.css
+++ b/interface/src/apps/agents/AgentList/AgentList.module.css
@@ -87,6 +87,22 @@
   overflow-y: auto;
 }
 
+.sortableRow {
+  cursor: grab;
+  touch-action: none;
+}
+
+.sortableRow:active {
+  cursor: grabbing;
+}
+
+.sortableRowOverlay {
+  opacity: 0.85;
+  border-radius: 4px;
+  background: var(--color-overlay-subtle);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
 .contextMenuOverlay {
   position: fixed;
   z-index: 9999;

--- a/interface/src/apps/agents/AgentList/AgentList.tsx
+++ b/interface/src/apps/agents/AgentList/AgentList.tsx
@@ -1,18 +1,32 @@
 import { useMemo, useCallback, useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { Menu } from "@cypher-asi/zui";
-import type { MenuItem } from "@cypher-asi/zui";
-import { Pencil, Pin, PinOff, Star, StarOff, Trash2 } from "lucide-react";
 import { EmptyState } from "../../../components/EmptyState";
 import { AgentEditorModal } from "../components/AgentEditorModal";
 import { ProjectsPlusButton } from "../../../components/ProjectsPlusButton";
 import { AgentConversationRow } from "../AgentConversationRow";
+import { AgentConversationRowWithHistory, SortableAgentConversationRow } from "./SortableAgentRow";
+import { useAgentPrefetch } from "./useAgentPrefetch";
+import { useAgentContextMenu } from "./useAgentContextMenu";
+import { buildAgentMenuItems, pickReplacementAgentId } from "./agent-list-menu-items";
 import { useProfileStatusStore } from "../../../stores/profile-status-store";
-import {
-  api,
-  STANDALONE_AGENT_HISTORY_LIMIT,
-} from "../../../api/client";
 import {
   useAgents,
   useSelectedAgent,
@@ -21,112 +35,19 @@ import {
 } from "../stores";
 import { useAuth } from "../../../stores/auth-store";
 import { useChatHandoffStore } from "../../../stores/chat-handoff-store";
-import { useChatHistoryStore, agentHistoryKey, sessionHistoryKey } from "../../../stores/chat-history-store";
 import { useProjectsListStore } from "../../../stores/projects-list-store";
-import {
-  agentSessionsSurfaceKey,
-  findMostRecentRealSession,
-  useSessionsListStore,
-} from "../../../stores/sessions-list-store";
 import { useSidebarSearch } from "../../../hooks/use-sidebar-search";
 import { useOverlayScrollbar } from "../../../shared/hooks/use-overlay-scrollbar";
 import { createAgentChatHandoffState } from "../../../utils/chat-handoff";
 import { standaloneAgentHandoffTarget } from "../../../utils/chat-handoff";
-import { useCascadeDeleteAgent } from "../hooks/use-cascade-delete-agent";
 import { DeleteAgentConfirmModal } from "../hooks/DeleteAgentConfirmModal";
-import { useDeferredModalOpen } from "../../../shared/hooks/use-deferred-modal-open";
 import { agentDisplayName } from "../../../lib/derive-project-agent-title";
 
 import type { Agent } from "../../../shared/types";
-import { isSuperAgent as isSuperAgentByPerms } from "../../../shared/types/permissions";
 import styles from "./AgentList.module.css";
-
-function buildAgentMenuItems(
-  agent: Agent,
-  pinnedIds: Set<string>,
-  favoriteIds: Set<string>,
-  isOwnAgent: boolean,
-): MenuItem[] {
-  const isSuperAgent = isSuperAgentByPerms(agent);
-  const isPinned = agent.is_pinned || pinnedIds.has(agent.agent_id);
-  const isFavorite = favoriteIds.has(agent.agent_id);
-  const items: MenuItem[] = [];
-
-  if (isOwnAgent) {
-    items.push({ id: "edit", label: "Edit", icon: <Pencil size={14} /> });
-  }
-
-  if (!isSuperAgent) {
-    items.push(
-      isPinned
-        ? { id: "unpin", label: "Unpin", icon: <PinOff size={14} /> }
-        : { id: "pin", label: "Pin to top", icon: <Pin size={14} /> },
-    );
-  }
-
-  items.push(
-    isFavorite
-      ? { id: "unfavorite", label: "Remove from taskbar", icon: <StarOff size={14} /> }
-      : { id: "favorite", label: "Add to taskbar", icon: <Star size={14} /> },
-  );
-
-  if (!isSuperAgent) {
-    items.push({ id: "delete", label: "Delete", icon: <Trash2 size={14} /> });
-  }
-
-  return items;
-}
-
-function pickReplacementAgentId(agents: Agent[], deletedAgentId: string): string | null {
-  const index = agents.findIndex((agent) => agent.agent_id === deletedAgentId);
-  if (index === -1) {
-    return agents[0]?.agent_id ?? null;
-  }
-
-  return agents[index + 1]?.agent_id ?? agents[index - 1]?.agent_id ?? null;
-}
-
-interface CtxMenuState {
-  x: number;
-  y: number;
-  agent: Agent;
-}
 
 interface AgentListProps {
   mode?: "default" | "responsive-controls" | "mobile-library";
-}
-
-function AgentConversationRowWithHistory({
-  agent,
-  isMobileLibrary,
-  isSelected,
-  onClick,
-  onContextMenu,
-  onMouseEnter,
-}: {
-  agent: Agent;
-  isMobileLibrary: boolean;
-  isSelected: boolean;
-  onClick: () => void;
-  onContextMenu: (e: React.MouseEvent) => void;
-  onMouseEnter: () => void;
-}) {
-  const lastMessage = useChatHistoryStore((state) => {
-    if (isMobileLibrary) return undefined;
-    return state.previewLastMessages[agentHistoryKey(agent.agent_id)];
-  });
-
-  return (
-    <AgentConversationRow
-      agent={agent}
-      lastMessage={lastMessage}
-      showMetadataOnly={isMobileLibrary}
-      isSelected={isSelected}
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      onMouseEnter={onMouseEnter}
-    />
-  );
 }
 
 export function AgentList({ mode = "default" }: AgentListProps) {
@@ -153,8 +74,6 @@ export function AgentList({ mode = "default" }: AgentListProps) {
   const pendingCreateAgentHandoff = useChatHandoffStore((state) => state.pendingCreateAgentHandoff);
   const beginCreateAgentHandoff = useChatHandoffStore((state) => state.beginCreateAgentHandoff);
 
-  // Desktop/tablet: `AgentMainPanel` loads the agent list. Mobile standalone library (`/agents`)
-  // renders this list without the main panel — fetch here only in that mode.
   useEffect(() => {
     if (!isMobileLibrary) return;
     void fetchAgents().catch(() => {});
@@ -177,20 +96,8 @@ export function AgentList({ mode = "default" }: AgentListProps) {
     setPendingCreatedAgentId(null);
   }, [pendingCreateAgentHandoff, pendingCreatedAgentId]);
 
-  const [ctxMenu, setCtxMenu] = useState<CtxMenuState | null>(null);
-  const ctxMenuRef = useRef<HTMLDivElement>(null);
-  const [editTarget, setEditTarget] = useState<Agent | null>(null);
   const { user } = useAuth();
-  const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null);
   const [optimisticDeletedAgentId, setOptimisticDeletedAgentId] = useState<string | null>(null);
-  const cascade = useCascadeDeleteAgent(deleteTarget);
-  // Defer opening the confirm modal until bindings have loaded so the
-  // modal opens once at its final size (footer button label depends on
-  // bindings.length; without this it widens mid-render).
-  const { isOpen: deleteModalOpen } = useDeferredModalOpen({
-    requestedOpen: !!deleteTarget,
-    prepare: () => cascade.refresh(),
-  });
   const scrollRef = useRef<HTMLDivElement>(null);
   const { thumbStyle, visible, onThumbPointerDown } = useOverlayScrollbar(scrollRef);
 
@@ -207,23 +114,20 @@ export function AgentList({ mode = "default" }: AgentListProps) {
     [agents],
   );
 
-  useEffect(() => {
-    if (!ctxMenu) return;
-    const handleMouseDown = (e: MouseEvent) => {
-      if (ctxMenuRef.current && !ctxMenuRef.current.contains(e.target as Node)) {
-        setCtxMenu(null);
-      }
-    };
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setCtxMenu(null);
-    };
-    document.addEventListener("mousedown", handleMouseDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleMouseDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [ctxMenu]);
+  const {
+    ctxMenu,
+    ctxMenuRef,
+    editTarget,
+    setEditTarget,
+    deleteTarget,
+    setDeleteTarget,
+    deleteModalOpen,
+    cascade,
+    pinnedIds,
+    favoriteIds,
+    handleContextMenu,
+    handleMenuAction,
+  } = useAgentContextMenu(agentMap);
 
   const handleAgentSaved = useCallback(
     (agent: Agent) => {
@@ -249,188 +153,18 @@ export function AgentList({ mode = "default" }: AgentListProps) {
     navigate(`/agents/${selectedAgentId}`);
   }, [agentId, navigate]);
 
-  // Pre-warm the chat-history-store entry for the most-recent session
-  // of `selectedAgentId`, which is the slot `AgentChatPanel`
-  // mounts on top of after `useDefaultStandaloneSessionRedirect` rewrites
-  // the URL with `?project=&instance=&session=`. Without this, the
-  // destination historyKey is `idle` at click time, `historyResolved`
-  // flips false on the first render, and `ChatPanel`'s cold-load gate
-  // re-arms — `.messageContentHidden` (`visibility: hidden`) is then
-  // applied across the message area for ~2 frames + a 120ms overlay
-  // fade, the user-visible "messages flicker on agent switch".
-  //
-  // Calls `loadAgentSessions` (idempotent — guarded by per-surface
-  // request ids) to discover the agent's bindings + sessions, then
-  // resolves the most-recent session synchronously off the store and
-  // calls `fetchHistory` (not `prefetchHistory`) so the entry lands in
-  // `useChatHistoryStore.entries` with `status: "ready"` — that is the
-  // store the panel reads, not the React Query cache `prefetchHistory`
-  // populates.
-  const warmDestinationSessionForAgent = useCallback((selectedAgentId: string) => {
-    const sessionsStore = useSessionsListStore.getState();
-    const surfaceKey = agentSessionsSurfaceKey(selectedAgentId);
-    const tryWarmFromCurrentSnapshot = () => {
-      const list = useSessionsListStore.getState().sessionsBySurface[surfaceKey];
-      if (!list || list.length === 0) return;
-      const mostRecent = findMostRecentRealSession(list);
-      if (!mostRecent) return;
-      const key = sessionHistoryKey(
-        mostRecent._projectId,
-        mostRecent._agentInstanceId,
-        mostRecent.session_id,
-      );
-      void useChatHistoryStore.getState().fetchHistory(
-        key,
-        () =>
-          api.listSessionEvents(
-            mostRecent._projectId,
-            mostRecent._agentInstanceId,
-            mostRecent.session_id,
-          ),
-      );
-    };
-    // If sessions are already loaded for this surface, warm immediately.
-    if (sessionsStore.sessionsBySurface[surfaceKey] !== undefined) {
-      tryWarmFromCurrentSnapshot();
-      return;
-    }
-    // Otherwise kick off the load and warm once it lands. The store
-    // dedupes concurrent loaders via per-surface request ids so the
-    // hover-then-mount-worker overlap stays cheap.
-    void sessionsStore.loadAgentSessions(selectedAgentId).then(() => {
-      tryWarmFromCurrentSnapshot();
-    });
-  }, []);
-
-  const handleHoverPrefetch = useCallback((selectedAgentId: string) => {
-    if (isMobileLibrary) return;
-    useChatHistoryStore.getState().prefetchHistory(
-      agentHistoryKey(selectedAgentId),
-      () =>
-        api.agents.listEvents(selectedAgentId, {
-          limit: STANDALONE_AGENT_HISTORY_LIMIT,
-        }),
-    );
-    warmDestinationSessionForAgent(selectedAgentId);
-  }, [isMobileLibrary, warmDestinationSessionForAgent]);
-
-  // Prefetch last-message previews for the OTHER agents in the sidebar so
-  // each row can render a recent-message snippet. Excludes the currently
-  // selected agent because `AgentChatRoute` is already fetching that one —
-  // queuing it here would just put the foreground request at the back of
-  // the line on cold boot. The currently-selected fetch also gates our
-  // start so the active chat's history round-trip doesn't contend with
-  // preview prefetches for every other agent.
-  const prefetchAgentIds = useMemo(() => {
-    if (!isDesktopSidebar) return [];
-    return agents.map((a) => a.agent_id).filter((id) => id !== agentId);
-  }, [agents, isDesktopSidebar, agentId]);
-
-  const activeHistoryResolved = useChatHistoryStore((s) => {
-    if (!isDesktopSidebar || !agentId) return true;
-    const entry = s.entries[agentHistoryKey(agentId)];
-    return entry?.status === "ready" || entry?.status === "error";
+  const { handleHoverPrefetch } = useAgentPrefetch({
+    agents,
+    agentId,
+    isMobileLibrary,
+    isDesktopSidebar,
   });
 
-  useEffect(() => {
-    if (prefetchAgentIds.length === 0) return;
-    if (!activeHistoryResolved) return;
-    // Small concurrency gate + idle scheduling so the foreground chat has
-    // finished loading before we spray the storage backend with preview
-    // fetches for every other agent. The chat-history store TTL-caches,
-    // so repeats are cheap.
-    const CONCURRENCY = 2;
-    let cancelled = false;
-    const queue = [...prefetchAgentIds];
-    const runWhenIdle = (cb: () => void) => {
-      const ric = (
-        window as unknown as {
-          requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
-        }
-      ).requestIdleCallback;
-      if (typeof ric === "function") {
-        ric(cb, { timeout: 500 });
-      } else {
-        setTimeout(cb, 0);
-      }
-    };
-    const worker = async () => {
-      while (!cancelled && queue.length > 0) {
-        const id = queue.shift();
-        if (!id) break;
-        try {
-          await useChatHistoryStore.getState().fetchHistory(
-            agentHistoryKey(id),
-            () =>
-              api.agents.listEvents(id, {
-                limit: STANDALONE_AGENT_HISTORY_LIMIT,
-              }),
-          );
-        } catch {
-          // errors are stored on the history entry; keep draining the queue
-        }
-        if (cancelled) break;
-        // Also warm the most-recent project session for this agent so
-        // clicking it lands on a `historyResolved=true` first render and
-        // skips the cold-load reveal cycle. Best-effort; failures are
-        // already absorbed by the loader and `fetchHistory`.
-        warmDestinationSessionForAgent(id);
-      }
-    };
-    runWhenIdle(() => {
-      if (cancelled) return;
-      const workers = Array.from(
-        { length: Math.min(CONCURRENCY, prefetchAgentIds.length) },
-        () => worker(),
-      );
-      void Promise.all(workers);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [prefetchAgentIds, activeHistoryResolved, warmDestinationSessionForAgent]);
+  const setAgentOrder = useAgentStore((s) => s.setAgentOrder);
+  const [activeAgentId, setActiveAgentId] = useState<string | null>(null);
 
-  const handleContextMenu = useCallback(
-    (e: React.MouseEvent) => {
-      const target = (e.target as HTMLElement).closest("button[id]");
-      if (!target) return;
-      const agent = agentMap.get(target.id);
-      if (agent) {
-        e.preventDefault();
-        setCtxMenu({ x: e.clientX, y: e.clientY, agent });
-      }
-    },
-    [agentMap],
-  );
-
-  const togglePin = useAgentStore((s) => s.togglePin);
-  const toggleFavorite = useAgentStore((s) => s.toggleFavorite);
-  const pinnedIds = useAgentStore((s) => s.pinnedAgentIds);
-  const favoriteIds = useAgentStore((s) => s.favoriteAgentIds);
-
-  const handleMenuAction = useCallback(
-    (actionId: string) => {
-      if (!ctxMenu) return;
-      switch (actionId) {
-        case "edit":
-          setEditTarget(ctxMenu.agent);
-          break;
-        case "pin":
-        case "unpin":
-          togglePin(ctxMenu.agent.agent_id);
-          break;
-        case "favorite":
-        case "unfavorite":
-          toggleFavorite(ctxMenu.agent.agent_id);
-          break;
-        case "delete":
-          setDeleteTarget(ctxMenu.agent);
-          cascade.reset();
-          break;
-      }
-      setCtxMenu(null);
-    },
-    [cascade, ctxMenu, togglePin, toggleFavorite],
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
   );
 
   const sortedAgents = useSortedAgents();
@@ -458,6 +192,24 @@ export function AgentList({ mode = "default" }: AgentListProps) {
     });
   }, [visibleSortedAgents, searchQuery]);
 
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveAgentId(String(event.active.id));
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveAgentId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const currentIds = visibleSortedAgents.map((a) => a.agent_id);
+      const fromIndex = currentIds.indexOf(String(active.id));
+      const toIndex = currentIds.indexOf(String(over.id));
+      if (fromIndex === -1 || toIndex === -1) return;
+      setAgentOrder(arrayMove(currentIds, fromIndex, toIndex));
+    },
+    [visibleSortedAgents, setAgentOrder],
+  );
+
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return;
     const target = deleteTarget;
@@ -479,13 +231,11 @@ export function AgentList({ mode = "default" }: AgentListProps) {
       setOptimisticDeletedAgentId(null);
       setDeleteTarget(null);
     } catch {
-      // Restore the row in the sidebar so the user can retry.
       setOptimisticDeletedAgentId(null);
       if (deletingSelectedAgent) {
         setSelectedAgent(target.agent_id);
         navigate(`/agents/${target.agent_id}`);
       }
-      // Keep `deleteTarget` set so the modal stays open with `cascade.error` rendered.
     }
   }, [agentId, cascade, deleteTarget, filteredAgents, navigate, setSelectedAgent, sortedAgents]);
 
@@ -504,17 +254,35 @@ export function AgentList({ mode = "default" }: AgentListProps) {
     );
   }
 
-  const entries = filteredAgents.map((agent) => (
-    <AgentConversationRowWithHistory
-      key={agent.agent_id}
-      agent={agent}
-      isMobileLibrary={isMobileLibrary}
-      isSelected={agent.agent_id === agentId}
-      onClick={() => handleAgentRowClick(agent.agent_id)}
-      onContextMenu={handleContextMenu}
-      onMouseEnter={() => handleHoverPrefetch(agent.agent_id)}
-    />
-  ));
+  const isDraggable = isDesktopSidebar && !searchQuery;
+  const activeAgent = activeAgentId ? agentMap.get(activeAgentId) ?? null : null;
+  const rowAgents = isDraggable ? visibleSortedAgents : filteredAgents;
+
+  const entries = rowAgents.map((agent) =>
+    isDraggable ? (
+      <SortableAgentConversationRow
+        key={agent.agent_id}
+        agent={agent}
+        isMobileLibrary={isMobileLibrary}
+        isSelected={agent.agent_id === agentId}
+        onClick={() => handleAgentRowClick(agent.agent_id)}
+        onContextMenu={handleContextMenu}
+        onMouseEnter={() => handleHoverPrefetch(agent.agent_id)}
+      />
+    ) : (
+      <AgentConversationRowWithHistory
+        key={agent.agent_id}
+        agent={agent}
+        isMobileLibrary={isMobileLibrary}
+        isSelected={agent.agent_id === agentId}
+        onClick={() => handleAgentRowClick(agent.agent_id)}
+        onContextMenu={handleContextMenu}
+        onMouseEnter={() => handleHoverPrefetch(agent.agent_id)}
+      />
+    ),
+  );
+
+  const sortableIds = rowAgents.map((a) => a.agent_id);
 
   return (
     <>
@@ -524,20 +292,47 @@ export function AgentList({ mode = "default" }: AgentListProps) {
           data-agent-surface="agent-list"
           data-agent-mode={mode}
         >
-          <div
-            ref={scrollRef}
-            className={styles.sidebarScrollArea}
-            onContextMenu={handleContextMenu}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            modifiers={[restrictToVerticalAxis]}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={() => setActiveAgentId(null)}
           >
-            <div className={styles.sidebarEntries}>{entries}</div>
-          </div>
-          <div className={styles.scrollTrack}>
             <div
-              className={`${styles.scrollThumb} ${visible ? styles.scrollThumbVisible : ""}`}
-              style={thumbStyle}
-              onPointerDown={onThumbPointerDown}
-            />
-          </div>
+              ref={scrollRef}
+              className={styles.sidebarScrollArea}
+              onContextMenu={handleContextMenu}
+            >
+              <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+                <div className={styles.sidebarEntries}>{entries}</div>
+              </SortableContext>
+            </div>
+            <div className={styles.scrollTrack}>
+              <div
+                className={`${styles.scrollThumb} ${visible ? styles.scrollThumbVisible : ""}`}
+                style={thumbStyle}
+                onPointerDown={onThumbPointerDown}
+              />
+            </div>
+            {activeAgent &&
+              createPortal(
+                <DragOverlay dropAnimation={null} style={{ zIndex: 9998 }}>
+                  <div className={styles.sortableRowOverlay}>
+                    <AgentConversationRow
+                      agent={activeAgent}
+                      lastMessage={undefined}
+                      isSelected={activeAgent.agent_id === agentId}
+                      onClick={() => {}}
+                      onContextMenu={() => {}}
+                      onMouseEnter={() => {}}
+                    />
+                  </div>
+                </DragOverlay>,
+                document.body,
+              )}
+          </DndContext>
         </div>
       ) : (
         <div
@@ -606,11 +401,6 @@ export function AgentList({ mode = "default" }: AgentListProps) {
           const projectsStore = useProjectsListStore.getState();
           useAgentStore.getState().patchAgent(updated);
           projectsStore.patchAgentTemplateFields(updated);
-          // The agent template's `local_workspace_path` flows into every
-          // project instance's `workspace_path` via `resolve_workspace_path`
-          // on the server. Refresh the agent caches for each project
-          // hosting an instance so the env-overlay's "Workspace Folder"
-          // row picks up the new path without requiring a manual reload.
           projectsStore.refreshAgentInstancesForTemplate(updated.agent_id);
           void fetchAgents({ force: true });
           setEditTarget(null);

--- a/interface/src/apps/agents/AgentList/SortableAgentRow.tsx
+++ b/interface/src/apps/agents/AgentList/SortableAgentRow.tsx
@@ -1,0 +1,90 @@
+import { type CSSProperties } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { AgentConversationRow } from "../AgentConversationRow";
+import { useChatHistoryStore, agentHistoryKey } from "../../../stores/chat-history-store";
+import type { Agent } from "../../../shared/types";
+import styles from "./AgentList.module.css";
+
+export function AgentConversationRowWithHistory({
+  agent,
+  isMobileLibrary,
+  isSelected,
+  onClick,
+  onContextMenu,
+  onMouseEnter,
+}: {
+  agent: Agent;
+  isMobileLibrary: boolean;
+  isSelected: boolean;
+  onClick: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onMouseEnter: () => void;
+}) {
+  const lastMessage = useChatHistoryStore((state) => {
+    if (isMobileLibrary) return undefined;
+    return state.previewLastMessages[agentHistoryKey(agent.agent_id)];
+  });
+
+  return (
+    <AgentConversationRow
+      agent={agent}
+      lastMessage={lastMessage}
+      showMetadataOnly={isMobileLibrary}
+      isSelected={isSelected}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      onMouseEnter={onMouseEnter}
+    />
+  );
+}
+
+export function SortableAgentConversationRow({
+  agent,
+  isMobileLibrary,
+  isSelected,
+  onClick,
+  onContextMenu,
+  onMouseEnter,
+}: {
+  agent: Agent;
+  isMobileLibrary: boolean;
+  isSelected: boolean;
+  onClick: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onMouseEnter: () => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: agent.agent_id });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={styles.sortableRow}
+      {...attributes}
+      {...listeners}
+    >
+      <AgentConversationRowWithHistory
+        agent={agent}
+        isMobileLibrary={isMobileLibrary}
+        isSelected={isSelected}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        onMouseEnter={onMouseEnter}
+      />
+    </div>
+  );
+}

--- a/interface/src/apps/agents/AgentList/agent-list-menu-items.tsx
+++ b/interface/src/apps/agents/AgentList/agent-list-menu-items.tsx
@@ -1,0 +1,48 @@
+import type { MenuItem } from "@cypher-asi/zui";
+import { Pencil, Pin, PinOff, Star, StarOff, Trash2 } from "lucide-react";
+import type { Agent } from "../../../shared/types";
+import { isSuperAgent as isSuperAgentByPerms } from "../../../shared/types/permissions";
+
+export function buildAgentMenuItems(
+  agent: Agent,
+  pinnedIds: Set<string>,
+  favoriteIds: Set<string>,
+  isOwnAgent: boolean,
+): MenuItem[] {
+  const isSuperAgent = isSuperAgentByPerms(agent);
+  const isPinned = agent.is_pinned || pinnedIds.has(agent.agent_id);
+  const isFavorite = favoriteIds.has(agent.agent_id);
+  const items: MenuItem[] = [];
+
+  if (isOwnAgent) {
+    items.push({ id: "edit", label: "Edit", icon: <Pencil size={14} /> });
+  }
+
+  if (!isSuperAgent) {
+    items.push(
+      isPinned
+        ? { id: "unpin", label: "Unpin", icon: <PinOff size={14} /> }
+        : { id: "pin", label: "Pin to top", icon: <Pin size={14} /> },
+    );
+  }
+
+  items.push(
+    isFavorite
+      ? { id: "unfavorite", label: "Remove from taskbar", icon: <StarOff size={14} /> }
+      : { id: "favorite", label: "Add to taskbar", icon: <Star size={14} /> },
+  );
+
+  if (!isSuperAgent) {
+    items.push({ id: "delete", label: "Delete", icon: <Trash2 size={14} /> });
+  }
+
+  return items;
+}
+
+export function pickReplacementAgentId(agents: Agent[], deletedAgentId: string): string | null {
+  const index = agents.findIndex((agent) => agent.agent_id === deletedAgentId);
+  if (index === -1) {
+    return agents[0]?.agent_id ?? null;
+  }
+  return agents[index + 1]?.agent_id ?? agents[index - 1]?.agent_id ?? null;
+}

--- a/interface/src/apps/agents/AgentList/useAgentContextMenu.ts
+++ b/interface/src/apps/agents/AgentList/useAgentContextMenu.ts
@@ -1,0 +1,99 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useAgentStore } from "../stores";
+import { useCascadeDeleteAgent } from "../hooks/use-cascade-delete-agent";
+import { useDeferredModalOpen } from "../../../shared/hooks/use-deferred-modal-open";
+import type { Agent } from "../../../shared/types";
+
+interface CtxMenuState {
+  x: number;
+  y: number;
+  agent: Agent;
+}
+
+export function useAgentContextMenu(agentMap: Map<string, Agent>) {
+  const [ctxMenu, setCtxMenu] = useState<CtxMenuState | null>(null);
+  const ctxMenuRef = useRef<HTMLDivElement>(null);
+  const [editTarget, setEditTarget] = useState<Agent | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null);
+  const cascade = useCascadeDeleteAgent(deleteTarget);
+  const { isOpen: deleteModalOpen } = useDeferredModalOpen({
+    requestedOpen: !!deleteTarget,
+    prepare: () => cascade.refresh(),
+  });
+
+  const togglePin = useAgentStore((s) => s.togglePin);
+  const toggleFavorite = useAgentStore((s) => s.toggleFavorite);
+  const pinnedIds = useAgentStore((s) => s.pinnedAgentIds);
+  const favoriteIds = useAgentStore((s) => s.favoriteAgentIds);
+
+  useEffect(() => {
+    if (!ctxMenu) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (ctxMenuRef.current && !ctxMenuRef.current.contains(e.target as Node)) {
+        setCtxMenu(null);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setCtxMenu(null);
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [ctxMenu]);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      const target = (e.target as HTMLElement).closest("button[id]");
+      if (!target) return;
+      const agent = agentMap.get(target.id);
+      if (agent) {
+        e.preventDefault();
+        setCtxMenu({ x: e.clientX, y: e.clientY, agent });
+      }
+    },
+    [agentMap],
+  );
+
+  const handleMenuAction = useCallback(
+    (actionId: string) => {
+      if (!ctxMenu) return;
+      switch (actionId) {
+        case "edit":
+          setEditTarget(ctxMenu.agent);
+          break;
+        case "pin":
+        case "unpin":
+          togglePin(ctxMenu.agent.agent_id);
+          break;
+        case "favorite":
+        case "unfavorite":
+          toggleFavorite(ctxMenu.agent.agent_id);
+          break;
+        case "delete":
+          setDeleteTarget(ctxMenu.agent);
+          cascade.reset();
+          break;
+      }
+      setCtxMenu(null);
+    },
+    [cascade, ctxMenu, togglePin, toggleFavorite],
+  );
+
+  return {
+    ctxMenu,
+    ctxMenuRef,
+    editTarget,
+    setEditTarget,
+    deleteTarget,
+    setDeleteTarget,
+    deleteModalOpen,
+    cascade,
+    pinnedIds,
+    favoriteIds,
+    handleContextMenu,
+    handleMenuAction,
+  };
+}

--- a/interface/src/apps/agents/AgentList/useAgentPrefetch.ts
+++ b/interface/src/apps/agents/AgentList/useAgentPrefetch.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo } from "react";
+import {
+  api,
+  STANDALONE_AGENT_HISTORY_LIMIT,
+} from "../../../api/client";
+import { useChatHistoryStore, agentHistoryKey, sessionHistoryKey } from "../../../stores/chat-history-store";
+import {
+  agentSessionsSurfaceKey,
+  findMostRecentRealSession,
+  useSessionsListStore,
+} from "../../../stores/sessions-list-store";
+import type { Agent } from "../../../shared/types";
+
+export function useAgentPrefetch({
+  agents,
+  agentId,
+  isMobileLibrary,
+  isDesktopSidebar,
+}: {
+  agents: Agent[];
+  agentId: string | undefined;
+  isMobileLibrary: boolean;
+  isDesktopSidebar: boolean;
+}) {
+  const warmDestinationSessionForAgent = useCallback((selectedAgentId: string) => {
+    const sessionsStore = useSessionsListStore.getState();
+    const surfaceKey = agentSessionsSurfaceKey(selectedAgentId);
+    const tryWarmFromCurrentSnapshot = () => {
+      const list = useSessionsListStore.getState().sessionsBySurface[surfaceKey];
+      if (!list || list.length === 0) return;
+      const mostRecent = findMostRecentRealSession(list);
+      if (!mostRecent) return;
+      const key = sessionHistoryKey(
+        mostRecent._projectId,
+        mostRecent._agentInstanceId,
+        mostRecent.session_id,
+      );
+      void useChatHistoryStore.getState().fetchHistory(
+        key,
+        () =>
+          api.listSessionEvents(
+            mostRecent._projectId,
+            mostRecent._agentInstanceId,
+            mostRecent.session_id,
+          ),
+      );
+    };
+    if (sessionsStore.sessionsBySurface[surfaceKey] !== undefined) {
+      tryWarmFromCurrentSnapshot();
+      return;
+    }
+    void sessionsStore.loadAgentSessions(selectedAgentId).then(() => {
+      tryWarmFromCurrentSnapshot();
+    });
+  }, []);
+
+  const handleHoverPrefetch = useCallback((selectedAgentId: string) => {
+    if (isMobileLibrary) return;
+    useChatHistoryStore.getState().prefetchHistory(
+      agentHistoryKey(selectedAgentId),
+      () =>
+        api.agents.listEvents(selectedAgentId, {
+          limit: STANDALONE_AGENT_HISTORY_LIMIT,
+        }),
+    );
+    warmDestinationSessionForAgent(selectedAgentId);
+  }, [isMobileLibrary, warmDestinationSessionForAgent]);
+
+  const prefetchAgentIds = useMemo(() => {
+    if (!isDesktopSidebar) return [];
+    return agents.map((a) => a.agent_id).filter((id) => id !== agentId);
+  }, [agents, isDesktopSidebar, agentId]);
+
+  const activeHistoryResolved = useChatHistoryStore((s) => {
+    if (!isDesktopSidebar || !agentId) return true;
+    const entry = s.entries[agentHistoryKey(agentId)];
+    return entry?.status === "ready" || entry?.status === "error";
+  });
+
+  useEffect(() => {
+    if (prefetchAgentIds.length === 0) return;
+    if (!activeHistoryResolved) return;
+    const CONCURRENCY = 2;
+    let cancelled = false;
+    const queue = [...prefetchAgentIds];
+    const runWhenIdle = (cb: () => void) => {
+      const ric = (
+        window as unknown as {
+          requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+        }
+      ).requestIdleCallback;
+      if (typeof ric === "function") {
+        ric(cb, { timeout: 500 });
+      } else {
+        setTimeout(cb, 0);
+      }
+    };
+    const worker = async () => {
+      while (!cancelled && queue.length > 0) {
+        const id = queue.shift();
+        if (!id) break;
+        try {
+          await useChatHistoryStore.getState().fetchHistory(
+            agentHistoryKey(id),
+            () =>
+              api.agents.listEvents(id, {
+                limit: STANDALONE_AGENT_HISTORY_LIMIT,
+              }),
+          );
+        } catch {
+          // errors are stored on the history entry; keep draining the queue
+        }
+        if (cancelled) break;
+        warmDestinationSessionForAgent(id);
+      }
+    };
+    runWhenIdle(() => {
+      if (cancelled) return;
+      const workers = Array.from(
+        { length: Math.min(CONCURRENCY, prefetchAgentIds.length) },
+        () => worker(),
+      );
+      void Promise.all(workers);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [prefetchAgentIds, activeHistoryResolved, warmDestinationSessionForAgent]);
+
+  return { handleHoverPrefetch };
+}

--- a/interface/src/apps/agents/stores/agent-selectors.ts
+++ b/interface/src/apps/agents/stores/agent-selectors.ts
@@ -63,19 +63,50 @@ export function useSelectedAgent(): SelectedAgentSlice {
   );
 }
 
-/** Agents sorted by pinned first, then most-recent updates. */
+/**
+ * Returns agents in the order defined by normalizeAgentOrder:
+ * - When a custom drag order exists, agents appear in that order (unordered
+ *   ones appended at the end).
+ * - When no custom order is set, falls back to pinned-first then updated_at.
+ */
 export function useSortedAgents(): Agent[] {
   const agents = useAgentStore((s) => s.agents);
   const pinnedIds = useAgentStore((s) => s.pinnedAgentIds);
+  const orderIds = useAgentStore((s) => s.agentOrderIds);
   return useMemo(() => {
+    if (orderIds.length > 0) {
+      const agentById = new Map(agents.map((a) => [a.agent_id, a]));
+      const ordered = normalizeAgentOrder(
+        agents.map((a) => a.agent_id),
+        orderIds,
+      );
+      return ordered.map((id) => agentById.get(id)).filter((a): a is Agent => !!a);
+    }
     return [...agents].sort((a, b) => {
       const aPinned = a.is_pinned || pinnedIds.has(a.agent_id);
       const bPinned = b.is_pinned || pinnedIds.has(b.agent_id);
       if (aPinned !== bPinned) return aPinned ? -1 : 1;
       return b.updated_at.localeCompare(a.updated_at);
     });
-  }, [agents, pinnedIds]);
+  }, [agents, pinnedIds, orderIds]);
 }
+
+/**
+ * Filters the ordered IDs to only include known agents, then appends any
+ * agents not yet in the order at the end. Equivalent to normalizeProjectOrderIds.
+ */
+export function normalizeAgentOrder(
+  allAgentIds: string[],
+  orderedIds: string[],
+): string[] {
+  const available = new Set(allAgentIds);
+  const filtered = orderedIds.filter((id) => available.has(id));
+  const filteredSet = new Set(filtered);
+  const remaining = allAgentIds.filter((id) => !filteredSet.has(id));
+  return [...filtered, ...remaining];
+}
+
+
 
 export function useSuperAgent(): Agent | null {
   return useAgentStore((s) => s.agents.find((a) => isSuperAgent(a)) ?? null);

--- a/interface/src/apps/agents/stores/agent-store.ts
+++ b/interface/src/apps/agents/stores/agent-store.ts
@@ -25,6 +25,9 @@ type PersistedAgentState = {
   selectedAgentId: string | null;
   pinnedAgentIds: string[];
   favoriteAgentIds: string[];
+  agentOrderIds: string[];
+  /** project_id → ordered agent_id list. Shared by Projects and Tasks surfaces. null = no overrides. */
+  projectsAgentOrderIds: Record<string, string[]> | null;
 };
 
 const PINNED_KEY = "aura:pinnedAgentIds";
@@ -54,6 +57,11 @@ type AgentState = {
   pinnedAgentIds: Set<string>;
   favoriteAgentIds: Set<string>;
 
+  /** Explicit display order for the Agents app sidebar (agent IDs in order). */
+  agentOrderIds: string[];
+  /** Per-project overrides shared by both Projects and Tasks surfaces. null = no customisation. */
+  projectsAgentOrderIds: Record<string, string[]> | null;
+
   createAgentModalOpen: boolean;
   openCreateAgentModal: () => void;
   closeCreateAgentModal: () => void;
@@ -67,6 +75,8 @@ type AgentState = {
   setSelectedAgent: (agentId: string | null) => void;
   togglePin: (agentId: string) => void;
   toggleFavorite: (agentId: string) => void;
+  setAgentOrder: (ids: string[]) => void;
+  setProjectsAgentOrder: (projectId: string, ids: string[]) => void;
 };
 
 const HISTORY_TTL_MS = 30_000;
@@ -124,6 +134,9 @@ async function hydratePersistedAgentState(userId: string): Promise<void> {
     selectedAgentId: cached.selectedAgentId,
     pinnedAgentIds: new Set(cached.pinnedAgentIds),
     favoriteAgentIds: new Set(cached.favoriteAgentIds),
+    agentOrderIds: cached.agentOrderIds ?? [],
+    // Discard old flat-array format from before the per-project migration.
+    projectsAgentOrderIds: Array.isArray(cached.projectsAgentOrderIds) ? null : (cached.projectsAgentOrderIds ?? null),
   });
 }
 
@@ -141,6 +154,8 @@ export const useAgentStore = create<AgentState>()(
       selectedAgentId: null,
       pinnedAgentIds: readIdSet(PINNED_KEY),
       favoriteAgentIds: readIdSet(FAVORITE_KEY),
+      agentOrderIds: [],
+      projectsAgentOrderIds: null,
 
       createAgentModalOpen: false,
       openCreateAgentModal: () => set({ createAgentModalOpen: true }),
@@ -380,6 +395,17 @@ export const useAgentStore = create<AgentState>()(
           return { favoriteAgentIds: next };
         });
       },
+
+      setAgentOrder: (ids): void => {
+        // Persisted locally via the IndexedDB subscription below.
+        set({ agentOrderIds: ids });
+      },
+
+      setProjectsAgentOrder: (projectId, ids): void => {
+        set((s) => ({
+          projectsAgentOrderIds: { ...(s.projectsAgentOrderIds ?? {}), [projectId]: ids },
+        }));
+      },
     };
   }),
 );
@@ -400,6 +426,8 @@ useAuthStore.subscribe((state) => {
       selectedAgentId: null,
       pinnedAgentIds: new Set(),
       favoriteAgentIds: new Set(),
+      agentOrderIds: [],
+      projectsAgentOrderIds: null,
     });
     return;
   }
@@ -419,5 +447,7 @@ useAgentStore.subscribe((state) => {
     selectedAgentId: state.selectedAgentId,
     pinnedAgentIds: [...state.pinnedAgentIds],
     favoriteAgentIds: [...state.favoriteAgentIds],
+    agentOrderIds: state.agentOrderIds,
+    projectsAgentOrderIds: state.projectsAgentOrderIds,
   });
 });

--- a/interface/src/apps/agents/stores/index.ts
+++ b/interface/src/apps/agents/stores/index.ts
@@ -8,5 +8,6 @@ export {
   useIsAgentPinned,
   useIsAgentFavorite,
   useFavoriteAgents,
+  normalizeAgentOrder,
 } from "./agent-selectors";
 export { LAST_AGENT_ID_KEY, getLastSelectedAgentId } from "./last-selected-agent";

--- a/interface/src/apps/tasks/components/TasksProjectList/tasks-project-list-explorer-node.tsx
+++ b/interface/src/apps/tasks/components/TasksProjectList/tasks-project-list-explorer-node.tsx
@@ -88,26 +88,43 @@ export function buildTasksExplorerNode(
   statusMap: Record<string, string>,
   machineTypesMap: Record<string, string>,
   explorerStyles: ProjectExplorerNodeStyles,
+  getAgentOrder: (projectId: string) => string[] = () => [],
+  onTasksAgentReorder?: (projectId: string, orderedAgentIds: string[]) => void,
 ): ExplorerNodeWithSuffix {
   const projectAgents = data.agentsByProject[project.project_id];
+  const orderIds = getAgentOrder(project.project_id);
+
   // Mirror the Projects-app sidebar: hide infrastructure-role rows
   // (`Loop`, `Executor`) so each `run-once` task click does not stack
   // another duplicate "Run task" Executor in the Tasks-app sidebar.
-  const children =
-    projectAgents !== undefined
-      ? projectAgents
-          .filter(isUserFacingAgentInstance)
-          .map((agent) =>
-            buildTaskAgentNode(
-              agent,
-              project.project_id,
-              data,
-              statusMap,
-              machineTypesMap,
-              explorerStyles,
-            ),
-          )
-      : [{ id: `_load_${project.project_id}`, label: "Loading...", disabled: true }];
+  let children;
+  if (projectAgents === undefined) {
+    children = [{ id: `_load_${project.project_id}`, label: "Loading...", disabled: true }];
+  } else {
+    const userFacing = projectAgents.filter(isUserFacingAgentInstance);
+    const sorted = orderIds.length > 0
+      ? [...userFacing].sort((a, b) => {
+          const aIdx = orderIds.indexOf(a.agent_id);
+          const bIdx = orderIds.indexOf(b.agent_id);
+          return (aIdx === -1 ? Infinity : aIdx) - (bIdx === -1 ? Infinity : bIdx);
+        })
+      : userFacing;
+    children = sorted.map((agent) =>
+      buildTaskAgentNode(agent, project.project_id, data, statusMap, machineTypesMap, explorerStyles),
+    );
+  }
+
+  const instanceToAgentId = new Map(
+    (data.agentsByProject[project.project_id] ?? []).map((a) => [a.agent_instance_id, a.agent_id]),
+  );
+  const onChildReorder = onTasksAgentReorder
+    ? (orderedInstanceIds: string[]) => {
+        const orderedAgentIds = orderedInstanceIds
+          .map((id) => instanceToAgentId.get(id))
+          .filter((id): id is string => Boolean(id));
+        onTasksAgentReorder(project.project_id, orderedAgentIds);
+      }
+    : undefined;
 
   return {
     id: project.project_id,
@@ -117,7 +134,7 @@ export function buildTasksExplorerNode(
       data.actions.handleAddAgent,
       explorerStyles,
     ),
-    metadata: { type: "project" },
+    metadata: { type: "project", childDraggable: Boolean(onChildReorder), onChildReorder },
     children,
   };
 }

--- a/interface/src/apps/tasks/components/TasksProjectList/use-tasks-project-list-model.tsx
+++ b/interface/src/apps/tasks/components/TasksProjectList/use-tasks-project-list-model.tsx
@@ -8,6 +8,8 @@ import { buildLeftMenuEntries, useLeftMenuExpandedGroups } from "../../../../fea
 import type { ProjectExplorerNodeStyles } from "../../../../components/ProjectList/project-list-explorer-node";
 import { buildTasksExplorerNode } from "./tasks-project-list-explorer-node";
 import { useTasksProjectListEffects } from "./use-tasks-project-list-effects";
+import { useAgentStore } from "../../../../apps/agents/stores/agent-store";
+import { normalizeAgentOrder } from "../../../../apps/agents/stores";
 
 function useTaskAgentRegistration(
   agentsByProject: ReturnType<typeof useProjectListData>["agentsByProject"],
@@ -44,6 +46,28 @@ function useTaskExplorerData(
 ): ExplorerNode[] {
   const statusMap = useProfileStatusStore((s) => s.statuses);
   const machineTypesMap = useProfileStatusStore((s) => s.machineTypes);
+  const agentsAppOrder = useAgentStore((s) => s.agentOrderIds);
+  const projectsOrderMap = useAgentStore((s) => s.projectsAgentOrderIds);
+  const setProjectsAgentOrder = useAgentStore((s) => s.setProjectsAgentOrder);
+
+  const getAgentOrder = useCallback(
+    (projectId: string): string[] => projectsOrderMap?.[projectId] ?? agentsAppOrder,
+    [agentsAppOrder, projectsOrderMap],
+  );
+
+  const onTasksAgentReorder = useCallback(
+    (projectId: string, newProjectAgentIds: string[]) => {
+      const { projectsAgentOrderIds, agentOrderIds, agents } = useAgentStore.getState();
+      const currentOrder = projectsAgentOrderIds?.[projectId] ?? agentOrderIds;
+      const allAgentIds = agents.map((a) => a.agent_id);
+      const partialSet = new Set(newProjectAgentIds);
+      const remaining = normalizeAgentOrder(allAgentIds, currentOrder).filter(
+        (id) => !partialSet.has(id),
+      );
+      setProjectsAgentOrder(projectId, [...newProjectAgentIds, ...remaining]);
+    },
+    [setProjectsAgentOrder],
+  );
 
   return useMemo(
     () =>
@@ -56,9 +80,11 @@ function useTaskExplorerData(
             statusMap,
             machineTypesMap,
             explorerStyles,
+            getAgentOrder,
+            onTasksAgentReorder,
           ),
         ),
-    [data, explorerStyles, machineTypesMap, statusMap],
+    [data, explorerStyles, machineTypesMap, statusMap, getAgentOrder, onTasksAgentReorder],
   );
 }
 

--- a/interface/src/components/ProjectList/project-list-explorer-node.tsx
+++ b/interface/src/components/ProjectList/project-list-explorer-node.tsx
@@ -38,6 +38,10 @@ export interface ProjectExplorerBuildContext {
    */
   streamingAgentInstanceIds: string[];
   archivingAgentInstanceIds: string[];
+  /** Returns the resolved agent_id order for a specific project. */
+  getAgentOrder: (projectId: string) => string[];
+  /** Called when the user drags to reorder agents within a project. */
+  onProjectAgentReorder?: (projectId: string, orderedAgentIds: string[]) => void;
   handleQuickAddAgent: (projectId: string) => void;
   handleArchiveAgent: (agent: ProjectAgentNode) => void;
 }
@@ -208,9 +212,19 @@ function buildProjectChildren(
   // `crates/aura-os-agents/src/instance.rs`); without this filter
   // each click stacked another duplicate row in the project sidebar
   // because the ephemeral row clones the template's name verbatim.
-  const activeAgents = projectAgents.filter(
+  const rawActiveAgents = projectAgents.filter(
     (agent) => agent.status !== "archived" && isUserFacingAgentInstance(agent),
   );
+  // Then apply the user's per-project drag-order (unranked agents sort
+  // to the end, preserving their original relative order).
+  const orderIds = context.getAgentOrder(projectId);
+  const activeAgents = orderIds.length > 0
+    ? [...rawActiveAgents].sort((a, b) => {
+        const aIdx = orderIds.indexOf(a.agent_id);
+        const bIdx = orderIds.indexOf(b.agent_id);
+        return (aIdx === -1 ? Infinity : aIdx) - (bIdx === -1 ? Infinity : bIdx);
+      })
+    : rawActiveAgents;
 
   const children: ExplorerNode[] = [
     ...mobileChildren,
@@ -248,6 +262,17 @@ export function buildProjectExplorerNode(
   machineTypesMap: Record<string, string>,
   explorerStyles: ProjectExplorerNodeStyles,
 ): ExplorerNodeWithSuffix {
+  const projectAgents = context.agentsByProject[project.project_id] ?? [];
+  const instanceToAgentId = new Map(projectAgents.map((a) => [a.agent_instance_id, a.agent_id]));
+  const onChildReorder = context.onProjectAgentReorder
+    ? (orderedInstanceIds: string[]) => {
+        const orderedAgentIds = orderedInstanceIds
+          .map((id) => instanceToAgentId.get(id))
+          .filter((id): id is string => Boolean(id));
+        context.onProjectAgentReorder!(project.project_id, orderedAgentIds);
+      }
+    : undefined;
+
   return {
     id: project.project_id,
     label: project.name,
@@ -256,7 +281,7 @@ export function buildProjectExplorerNode(
       context,
       explorerStyles,
     ),
-    metadata: { type: "project" },
+    metadata: { type: "project", childDraggable: Boolean(onChildReorder), onChildReorder },
     children: buildProjectChildren(
       project.project_id,
       context,

--- a/interface/src/components/ProjectList/project-list-projects-explorer.tsx
+++ b/interface/src/components/ProjectList/project-list-projects-explorer.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { ExplorerNode } from "@cypher-asi/zui";
 import { useProfileStatusStore } from "../../stores/profile-status-store";
+import { useAgentStore } from "../../apps/agents/stores/agent-store";
+import { normalizeAgentOrder } from "../../apps/agents/stores";
 import {
   getMobileProjectDestination,
   projectAgentRoute,
@@ -120,6 +122,29 @@ function useProjectExplorerData(
   explorerData: ExplorerNode[];
   filteredExplorerData: ExplorerNode[];
 } {
+  const agentsAppOrder = useAgentStore((s) => s.agentOrderIds);
+  const projectsOrderMap = useAgentStore((s) => s.projectsAgentOrderIds);
+  const setProjectsAgentOrder = useAgentStore((s) => s.setProjectsAgentOrder);
+
+  const getAgentOrder = useCallback(
+    (projectId: string): string[] => projectsOrderMap?.[projectId] ?? agentsAppOrder,
+    [agentsAppOrder, projectsOrderMap],
+  );
+
+  const onProjectAgentReorder = useCallback(
+    (projectId: string, newProjectAgentIds: string[]) => {
+      const { projectsAgentOrderIds, agentOrderIds, agents } = useAgentStore.getState();
+      const currentOrder = projectsAgentOrderIds?.[projectId] ?? agentOrderIds;
+      const allAgentIds = agents.map((a) => a.agent_id);
+      const partialSet = new Set(newProjectAgentIds);
+      const remaining = normalizeAgentOrder(allAgentIds, currentOrder).filter(
+        (id) => !partialSet.has(id),
+      );
+      setProjectsAgentOrder(projectId, [...newProjectAgentIds, ...remaining]);
+    },
+    [setProjectsAgentOrder],
+  );
+
   const nodeBuildContext = useMemo(
     () => ({
       agentsByProject: data.agentsByProject,
@@ -128,10 +153,12 @@ function useProjectExplorerData(
       isMobileLayout: data.isMobileLayout,
       streamingAgentInstanceIds: data.sidekick.streamingAgentInstanceIds,
       archivingAgentInstanceIds: data.actions.archivingAgentInstanceIds,
+      getAgentOrder,
+      onProjectAgentReorder,
       handleQuickAddAgent: data.actions.handleQuickAddAgent,
       handleArchiveAgent: data.actions.handleArchiveAgent,
     }),
-    [data],
+    [data, getAgentOrder, onProjectAgentReorder],
   );
 
   const explorerData = useMemo(

--- a/interface/src/features/left-menu/LeftMenuTree/LeftMenuTreeRows.tsx
+++ b/interface/src/features/left-menu/LeftMenuTree/LeftMenuTreeRows.tsx
@@ -2,8 +2,27 @@ import {
   type KeyboardEvent,
   type MouseEvent,
   type PointerEvent as ReactPointerEvent,
+  useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { ChevronRight } from "lucide-react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import type {
   LeftMenuEmptyEntry,
   LeftMenuEntry,
@@ -66,6 +85,28 @@ function LeftMenuLeafRow({
   );
 }
 
+function SortableChildRow({ entry, depth }: { entry: LeftMenuEntry; depth: number }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: entry.id,
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0 : 1,
+        cursor: "grab",
+        touchAction: "none",
+      }}
+      {...attributes}
+      {...listeners}
+    >
+      <LeftMenuEntryRow entry={entry} depth={depth} />
+    </div>
+  );
+}
+
 function LeftMenuGroup({
   entry,
   depth,
@@ -75,6 +116,8 @@ function LeftMenuGroup({
   depth: number;
   rootReorderState?: RootReorderState;
 }) {
+  const [activeChildId, setActiveChildId] = useState<string | null>(null);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
   const isSection = entry.variant === "section";
   const isRootDraggable =
     depth === 0 && !isSection && rootReorderState?.draggableIds.has(entry.id);
@@ -165,6 +208,48 @@ function LeftMenuGroup({
         <div className={styles.childrenList} role="group">
           {entry.emptyState ? (
             <LeftMenuEmptyStateRow entry={entry.emptyState} />
+          ) : entry.childReorder && entry.children.length > 1 ? (
+            (() => {
+              const childIds = entry.children.map((c) => c.id);
+              const activeEntry = activeChildId
+                ? entry.children.find((c) => c.id === activeChildId) ?? null
+                : null;
+              const handleDragEnd = (event: DragEndEvent) => {
+                const { active, over } = event;
+                setActiveChildId(null);
+                if (!over || active.id === over.id) return;
+                const oldIndex = childIds.indexOf(String(active.id));
+                const newIndex = childIds.indexOf(String(over.id));
+                if (oldIndex === -1 || newIndex === -1) return;
+                entry.childReorder!.onReorder(arrayMove(childIds, oldIndex, newIndex));
+              };
+              return (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  modifiers={[restrictToVerticalAxis]}
+                  onDragStart={(e) => setActiveChildId(String(e.active.id))}
+                  onDragEnd={handleDragEnd}
+                  onDragCancel={() => setActiveChildId(null)}
+                >
+                  <SortableContext items={childIds} strategy={verticalListSortingStrategy}>
+                    {entry.children.map((childEntry) => (
+                      <SortableChildRow key={childEntry.id} entry={childEntry} depth={depth + 1} />
+                    ))}
+                  </SortableContext>
+                  {createPortal(
+                    <DragOverlay>
+                      {activeEntry ? (
+                        <div style={{ opacity: 0.85, background: "var(--color-overlay-subtle)", borderRadius: 4, boxShadow: "0 4px 16px rgba(0,0,0,0.3)" }}>
+                          <LeftMenuEntryRow entry={activeEntry} depth={depth + 1} />
+                        </div>
+                      ) : null}
+                    </DragOverlay>,
+                    document.body,
+                  )}
+                </DndContext>
+              );
+            })()
           ) : (
             entry.children.map((childEntry) => (
               <LeftMenuEntryRow key={childEntry.id} entry={childEntry} depth={depth + 1} />

--- a/interface/src/features/left-menu/build-left-menu-entries.ts
+++ b/interface/src/features/left-menu/build-left-menu-entries.ts
@@ -98,6 +98,11 @@ function buildGroupEntry(
           ),
     );
 
+  const childReorderFn =
+    node.metadata?.childDraggable && typeof node.metadata?.onChildReorder === "function"
+      ? (node.metadata.onChildReorder as (orderedIds: string[]) => void)
+      : undefined;
+
   return {
     kind: "group",
     id: node.id,
@@ -110,6 +115,7 @@ function buildGroupEntry(
     toggleMode: options.groupToggleMode ?? "activate",
     children: childEntries,
     emptyState: buildEmptyEntry(emptyNode, options.emptyTestIdPrefix, node.id),
+    childReorder: childReorderFn ? { onReorder: childReorderFn } : undefined,
     onActivate: () => options.onGroupActivate(node.id),
     onToggle: options.onGroupToggle
       ? () => options.onGroupToggle?.(node.id)

--- a/interface/src/features/left-menu/types.ts
+++ b/interface/src/features/left-menu/types.ts
@@ -31,6 +31,8 @@ export interface LeftMenuGroupEntry {
   toggleMode?: "activate" | "secondary";
   children: LeftMenuEntry[];
   emptyState?: LeftMenuEmptyEntry | null;
+  /** When set, children become drag-sortable and this callback fires with the new ordered child IDs. */
+  childReorder?: { onReorder: (orderedChildIds: string[]) => void };
   onActivate: () => void;
   onToggle?: () => void;
 }


### PR DESCRIPTION
Drag-to-reorder for agents in the Agents app, with the order propagated to the Projects and Tasks app explorers.

## Scope — independent & local-only
Order persists in the **existing per-user IndexedDB agent-state cache** (the same store that already holds pinned / favorite agents). It does **not** add server persistence and has **no** `/api/preferences/*` dependency — based directly on `main`, independent of the preferences skeleton.

- `agent-store`: `agentOrderIds` + `projectsAgentOrderIds` in state, written through the existing IndexedDB subscription and rehydrated on login. `setAgentOrder` / `setProjectsAgentOrder` update local state only.
- `AgentList` split into focused modules (`SortableAgentRow`, context menu, prefetch, menu items) with dnd-kit drag support.
- Projects / Tasks explorers consume the shared order via a local `getAgentOrder(projectId)` accessor.

## Not included (deliberately)
- **Server-backed cross-install sync.** Order is per-device via IndexedDB, consistent with how pins/favorites already persist. Server sync can be layered on later as a separate change if desired.
- No new server or Rust code.

## Verification
`tsc --noEmit` (interface) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)