### PR TITLE
feat(appearance): icon-select accent for nav rail + sidekick tabs

### DIFF
--- a/interface/src/components/AppNavRail/AppNavRail.module.css
+++ b/interface/src/components/AppNavRail/AppNavRail.module.css
@@ -62,7 +62,7 @@
 }
 
 .navBtnSelected {
-  color: var(--color-text-primary);
+  color: var(--color-icon-selected, var(--color-text-primary));
   opacity: 1;
 }
 
@@ -202,7 +202,7 @@
 
 .taskbarBtn:not(:disabled)[aria-pressed="true"],
 .taskbarBtn:not(:disabled)[data-selected="true"] {
-  color: var(--color-accent);
+  color: var(--color-icon-selected, var(--color-accent));
   opacity: 1;
 }
 

--- a/interface/src/components/Sidekick/Sidekick.module.css
+++ b/interface/src/components/Sidekick/Sidekick.module.css
@@ -53,7 +53,7 @@
 }
 
 .sidekickTabBar button:not(:disabled)[aria-pressed="true"] {
-  color: var(--color-accent);
+  color: var(--color-icon-selected, var(--color-accent));
 }
 
 .sidekickTabBar button:focus-visible {

--- a/interface/src/lib/theme-overrides.test.ts
+++ b/interface/src/lib/theme-overrides.test.ts
@@ -77,6 +77,10 @@ describe("theme-overrides", () => {
     it("includes --color-modal-bg so the dual-mode editor can target it", () => {
       expect(EDITABLE_TOKENS).toContain("--color-modal-bg");
     });
+
+    it("includes --color-icon-selected so the selected-icon accent is editable", () => {
+      expect(EDITABLE_TOKENS).toContain("--color-icon-selected");
+    });
   });
 
   describe("applyOverridesToDocument", () => {

--- a/interface/src/lib/theme-overrides.ts
+++ b/interface/src/lib/theme-overrides.ts
@@ -19,6 +19,7 @@ export const EDITABLE_TOKENS = [
   "--color-titlebar-bg",
   "--color-accent",
   "--color-modal-bg",
+  "--color-icon-selected",
 ] as const;
 
 export type EditableToken = (typeof EDITABLE_TOKENS)[number];

--- a/interface/src/views/SettingsView/AppearanceSection/CustomTokensPanel/CustomTokensPanel.tsx
+++ b/interface/src/views/SettingsView/AppearanceSection/CustomTokensPanel/CustomTokensPanel.tsx
@@ -19,6 +19,7 @@ const TOKEN_LABELS: Record<EditableToken, string> = {
   "--color-titlebar-bg": "Titlebar background",
   "--color-accent": "Accent",
   "--color-modal-bg": "Modal background",
+  "--color-icon-selected": "Selected icon",
 };
 
 /**


### PR DESCRIPTION
Adds a **"Selected icon"** color to the existing `Settings → Appearance` custom-tokens editor. The selected icon in the app nav rail, bottom taskbar, and sidekick tabs picks up this color.

## Scope — intentionally minimal & independent
This rides entirely on the **existing** localStorage-backed theme-overrides framework. It does **not** add server persistence and does **not** introduce a `global` token slice — `--color-icon-selected` is a normal editable token stored per-resolved-theme in the current `{ dark, light }` shape, exactly like `--color-accent` and the other chrome tokens.

- `theme-overrides.ts`: add `--color-icon-selected` to `EDITABLE_TOKENS`.
- `CustomTokensPanel`: "Selected icon" label (renders as a normal active-theme row).
- `AppNavRail` + `Sidekick`: selected icons read `var(--color-icon-selected, <prior default>)` — appearance is unchanged until the user sets a value.

## Not included (deliberately)
- **Server persistence** of theme overrides is a separate concern, proposed independently so it can be evaluated on its own merits and rebased in later if accepted.
- No `/api/preferences/*` dependency — this PR is based directly on `main`.

## Diff size
4 files, +6/-3 (plus one test assertion).

## Verification
`tsc --noEmit` (interface) ✓ · `theme-overrides.test.ts` — 29 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)