### PR TITLE
Speed up and harden desktop release CI

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,13 +8,16 @@ description: |
   back to a direct download from nodejs.org. On a transient DNS / egress blip
   both lookups fail fast with `getaddrinfo ENOTFOUND` and the whole job dies on
   the very first attempt -- this is what took down the `build-sidecar` job on
-  the self-hosted Windows runner. The gate below polls both hosts with backoff
-  so a short-lived network hiccup is ridden out before setup-node runs.
+  the self-hosted Windows runner. The Windows-only gate below polls both hosts
+  with backoff so a short-lived network hiccup is ridden out before setup-node
+  runs.
 
   The gate is intentionally non-fatal: if the hosts are still unreachable after
   all attempts it emits a warning and lets setup-node run anyway, so the real
   underlying error is still surfaced in the logs (which also makes a genuine
-  runner network/egress misconfiguration obvious).
+  runner network/egress misconfiguration obvious). Linux/macOS skip it to avoid
+  adding retry latency for a runner-specific failure mode we have only seen on
+  Windows.
 
   This wraps (rather than replaces) actions/setup-node so its native npm cache
   restore and `post` cache-save step keep working unchanged.
@@ -37,6 +40,7 @@ runs:
   using: composite
   steps:
     - name: Wait for Node/GitHub registries
+      if: runner.os == 'Windows'
       shell: bash
       run: |
         set -uo pipefail

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,7 +1,7 @@
 name: Setup Node.js
 description: |
-  Installs Node.js via actions/setup-node with a registry-reachability retry
-  gate in front of it.
+  Installs Node.js via actions/setup-node with lightweight network hardening
+  around it.
 
   actions/setup-node resolves the requested version by first querying
   api.github.com (for the actions/node-versions manifest) and then falling
@@ -15,9 +15,14 @@ description: |
   The gate is intentionally non-fatal: if the hosts are still unreachable after
   all attempts it emits a warning and lets setup-node run anyway, so the real
   underlying error is still surfaced in the logs (which also makes a genuine
-  runner network/egress misconfiguration obvious). Linux/macOS skip it to avoid
-  adding retry latency for a runner-specific failure mode we have only seen on
-  Windows.
+  runner network/egress misconfiguration obvious). Linux/macOS skip this gate to
+  avoid adding retry latency for a runner-specific failure mode we have only
+  seen on Windows.
+
+  The setup-node invocation itself is retried for all platforms. Hosted runners
+  do not always have the exact requested version in the setup-node manifest or
+  tool cache, so a transient direct-download TLS failure can otherwise leave the
+  runner on its preinstalled Node version and fail later parity checks.
 
   This wraps (rather than replaces) actions/setup-node so its native npm cache
   restore and `post` cache-save step keep working unchanged.
@@ -69,8 +74,52 @@ runs:
         done
 
     - name: Install Node.js
+      id: setup_node_1
+      continue-on-error: true
       uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Back off before retrying Node.js install
+      if: steps.setup_node_1.outcome == 'failure'
+      shell: bash
+      run: sleep 5
+
+    - name: Install Node.js retry 2
+      id: setup_node_2
+      if: steps.setup_node_1.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Back off before final Node.js install retry
+      if: steps.setup_node_1.outcome == 'failure' && steps.setup_node_2.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
+    - name: Install Node.js retry 3
+      id: setup_node_3
+      if: steps.setup_node_1.outcome == 'failure' && steps.setup_node_2.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Verify Node.js version
+      shell: bash
+      run: |
+        set -euo pipefail
+        actual="$(node --version | sed 's/^v//')"
+        expected="${{ inputs.node-version }}"
+        if [ "$actual" != "$expected" ]; then
+          echo "::error::Expected Node.js ${expected}, but found ${actual} after setup-node retries."
+          exit 1
+        fi
+        echo "Node.js ${actual} is active."

--- a/.github/workflows/ci-performance-benchmark.yml
+++ b/.github/workflows/ci-performance-benchmark.yml
@@ -1,0 +1,426 @@
+name: CI Performance Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Benchmark scope"
+        required: true
+        default: desktop-build
+        type: choice
+        options:
+          - preflight
+          - interface
+          - desktop-build
+          - sidecar
+          - full-dry-run
+      platform:
+        description: "Desktop platform to run"
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - linux
+          - macos-aarch64
+          - macos-x86_64
+          - windows
+      cache_mode:
+        description: "Cache behavior"
+        required: true
+        default: warm
+        type: choice
+        options:
+          - warm
+          - cold-key
+          - no-target-cache
+      cargo_timings:
+        description: "Collect Cargo timings"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: ci-performance-benchmark-${{ github.ref }}-${{ inputs.mode }}-${{ inputs.platform }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  AURA_UPDATE_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+
+jobs:
+  preflight:
+    if: inputs.mode == 'preflight' || inputs.mode == 'full-dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/setup-rust-toolchain
+
+      - name: Run release preflight
+        run: node scripts/ci/perf-timer.mjs --label release-preflight --out ci-perf/steps.jsonl -- node scripts/ci/verify-release-preflight.mjs
+
+      - name: Summarize benchmark
+        if: always()
+        run: |
+          node scripts/ci/ci-perf-summary.mjs --dir ci-perf --out-dir ci-perf --title "CI Performance Benchmark: preflight"
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-perf-preflight
+          path: ci-perf
+
+  interface:
+    if: inputs.mode == 'interface' || inputs.mode == 'desktop-build' || inputs.mode == 'full-dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Node.js
+        uses: ./.github/actions/setup-node
+        with:
+          cache: npm
+          cache-dependency-path: interface/package-lock.json
+
+      - name: Build interface
+        working-directory: interface
+        env:
+          APP_VERSION: ci-perf.${{ github.run_number }}
+          APP_COMMIT: ${{ github.sha }}
+          APP_CHANNEL: nightly
+        run: |
+          node ../scripts/ci/perf-timer.mjs --label interface-npm-ci --out ../ci-perf/steps.jsonl -- npm ci
+          node ../scripts/ci/perf-timer.mjs --label interface-build --out ../ci-perf/steps.jsonl -- npm run build
+          node ../scripts/ci/perf-timer.mjs --label interface-assets-validate --out ../ci-perf/steps.jsonl -- node ../infra/scripts/release/desktop-frontend-assets-validate.mjs --dist dist
+
+      - name: Summarize benchmark
+        if: always()
+        run: |
+          node scripts/ci/ci-perf-summary.mjs --dir ci-perf --out-dir ci-perf --title "CI Performance Benchmark: interface"
+
+      - name: Upload interface dist
+        if: inputs.mode == 'desktop-build' || inputs.mode == 'full-dry-run'
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-perf-interface-dist
+          path: interface/dist
+          compression-level: 0
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-perf-interface
+          path: ci-perf
+
+  desktop-build:
+    if: inputs.mode == 'desktop-build' || inputs.mode == 'full-dry-run'
+    needs: interface
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            target: linux
+            arch: x86_64
+          - os: macos-latest
+            platform: macos-aarch64
+            target: macos
+            arch: aarch64
+          - os: macos-15-intel
+            platform: macos-x86_64
+            target: macos
+            arch: x86_64
+          - os: windows-latest
+            platform: windows
+            target: windows
+            arch: x86_64
+    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os == 'macos-latest' && 'macos-15-xlarge' || matrix.os }}
+    env:
+      CARGO_TARGET_DIR: ../.aura-shared-target
+      AURA_RELEASE_DIR: ../.aura-shared-target/release
+      AURA_NETWORK_URL: ${{ vars.AURA_NETWORK_URL }}
+      AURA_STORAGE_URL: ${{ vars.AURA_STORAGE_URL }}
+      AURA_INTEGRATIONS_URL: ${{ vars.AURA_INTEGRATIONS_URL }}
+      AURA_ROUTER_URL: ${{ vars.AURA_ROUTER_URL }}
+      Z_BILLING_URL: ${{ vars.Z_BILLING_URL }}
+      ORBIT_BASE_URL: ${{ vars.ORBIT_BASE_URL }}
+      SWARM_BASE_URL: ${{ vars.SWARM_BASE_URL }}
+      REQUIRE_ZERO_PRO: ${{ vars.REQUIRE_ZERO_PRO }}
+      AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN: ${{ vars.AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN }}
+      VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
+      Z_BILLING_API_KEY: ${{ secrets.Z_BILLING_API_KEY }}
+    steps:
+      - name: Skip non-selected platform
+        if: inputs.platform != 'all' && inputs.platform != matrix.platform
+        run: echo "Skipping ${{ matrix.platform }} because platform=${{ inputs.platform }}"
+
+      - uses: actions/checkout@v5
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+
+      - name: Install Rust toolchain
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+        uses: ./.github/actions/setup-rust-toolchain
+
+      - name: Restore desktop Rust cache
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && inputs.cache_mode != 'no-target-cache'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ inputs.cache_mode == 'cold-key' && format('ci-perf-desktop-cold-{0}-{1}-{2}', github.run_id, runner.os, runner.arch) || format('desktop-app-v3-{0}-{1}', runner.os, runner.arch) }}
+          workspaces: |
+            . -> ../.aura-shared-target
+          cache-on-failure: true
+
+      - name: Set up sccache
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+        id: sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Configure sccache backend
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sccache.outcome == 'success'
+        shell: bash
+        env:
+          DEPOT_CACHE_TOKEN: ${{ secrets.DEPOT_CACHE_TOKEN }}
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          if [ -n "$DEPOT_CACHE_TOKEN" ]; then
+            echo "SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev" >> "$GITHUB_ENV"
+            echo "SCCACHE_WEBDAV_TOKEN=$DEPOT_CACHE_TOKEN" >> "$GITHUB_ENV"
+          else
+            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install Linux dependencies
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang pkg-config libatomic1 libssl-dev libdbus-1-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev libpipewire-0.3-dev libgbm-dev libxdo-dev
+
+      - name: Install Node.js
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+        uses: ./.github/actions/setup-node
+
+      - name: Download interface dist
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+        uses: actions/download-artifact@v5
+        with:
+          name: ci-perf-interface-dist
+          path: interface/dist
+
+      - name: Patch Cargo.toml version
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+        shell: bash
+        run: |
+          sed -i.bak 's/^version = ".*"/version = "0.1.0-ci-perf.${{ github.run_number }}.1"/' apps/aura-os-desktop/Cargo.toml
+          rm -f apps/aura-os-desktop/Cargo.toml.bak
+
+      - name: Build release binary
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+        env:
+          AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1"
+          AURA_UPDATE_BASE_URL: ${{ env.AURA_UPDATE_BASE_URL }}
+          UPDATER_PUBLIC_KEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
+        shell: bash
+        run: |
+          args=(build --release --no-default-features --features stable-channel --package aura-os-desktop)
+          if [ "${{ inputs.cargo_timings }}" = "true" ]; then
+            args+=(--timings)
+          fi
+          node scripts/ci/perf-timer.mjs \
+            --label "desktop-build-${{ matrix.platform }}" \
+            --out "ci-perf/steps-${{ matrix.platform }}.jsonl" \
+            -- cargo "${args[@]}"
+
+      - name: Collect sccache stats
+        if: always() && (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sccache.outcome == 'success'
+        shell: bash
+        run: |
+          mkdir -p ci-perf
+          "${SCCACHE_PATH}" --show-stats --stats-format=json > "ci-perf/sccache-${{ matrix.platform }}.json" || true
+          "${SCCACHE_PATH}" --show-stats || true
+
+      - name: Stage Cargo timings
+        if: always() && (inputs.platform == 'all' || inputs.platform == matrix.platform)
+        shell: bash
+        run: |
+          if [ -d ../.aura-shared-target/cargo-timings ]; then
+            mkdir -p "ci-perf/cargo-timings-${{ matrix.platform }}"
+            cp -R ../.aura-shared-target/cargo-timings/. "ci-perf/cargo-timings-${{ matrix.platform }}/"
+          fi
+
+      - name: Summarize benchmark
+        if: always() && (inputs.platform == 'all' || inputs.platform == matrix.platform)
+        run: |
+          node scripts/ci/ci-perf-summary.mjs --dir ci-perf --out-dir ci-perf --title "CI Performance Benchmark: desktop-build ${{ matrix.platform }}"
+
+      - name: Upload benchmark artifacts
+        if: always() && (inputs.platform == 'all' || inputs.platform == matrix.platform)
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-perf-desktop-build-${{ matrix.platform }}
+          path: ci-perf
+
+  sidecar:
+    if: inputs.mode == 'sidecar' || inputs.mode == 'full-dry-run'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            target: linux
+            arch: x86_64
+          - os: macos-latest
+            platform: macos-aarch64
+            target: macos
+            arch: aarch64
+          - os: macos-15-intel
+            platform: macos-x86_64
+            target: macos
+            arch: x86_64
+          - os: windows-latest
+            platform: windows
+            target: windows
+            arch: x86_64
+    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os == 'macos-latest' && 'macos-15-xlarge' || matrix.os }}
+    env:
+      CARGO_TARGET_DIR: ../.aura-shared-target
+    steps:
+      - name: Skip non-selected platform
+        if: inputs.platform != 'all' && inputs.platform != matrix.platform
+        run: echo "Skipping ${{ matrix.platform }} because platform=${{ inputs.platform }}"
+
+      - uses: actions/checkout@v5
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+
+      - name: Prepare harness sibling workspace
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+        uses: ./.github/actions/setup-harness-sibling
+        with:
+          repository-owner: ${{ github.repository_owner }}
+          include-harness: "true"
+
+      - name: Restore bundled sidecar binary cache
+        if: inputs.platform == 'all' || inputs.platform == matrix.platform
+        id: sidecar-binary-cache
+        uses: actions/cache@v4
+        with:
+          path: apps/aura-os-desktop/resources/sidecar
+          key: ${{ inputs.cache_mode == 'cold-key' && format('desktop-sidecar-bin-cold-{0}-{1}-{2}', github.run_id, matrix.target, matrix.arch) || format('desktop-sidecar-bin-v1-{0}-{1}-{2}', matrix.target, matrix.arch, hashFiles('aura-harness/Cargo.lock', 'aura-harness/Cargo.toml', 'aura-harness/crates/**/Cargo.toml', 'aura-harness/crates/**/*.rs')) }}
+
+      - name: Validate cached sidecar binary
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          binary="apps/aura-os-desktop/resources/sidecar/aura-node"
+          if [ "${{ matrix.target }}" = "windows" ]; then
+            binary="${binary}.exe"
+          fi
+          test -s "$binary"
+
+      - name: Install Rust toolchain
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-rust-toolchain
+
+      - name: Restore sidecar Rust cache
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit != 'true' && inputs.cache_mode != 'no-target-cache'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ inputs.cache_mode == 'cold-key' && format('ci-perf-sidecar-cold-{0}-{1}-{2}', github.run_id, runner.os, runner.arch) || format('desktop-sidecar-v4-{0}-{1}', runner.os, runner.arch) }}
+          workspaces: |
+            ../aura-harness -> ../.aura-shared-target
+          cache-on-failure: true
+
+      - name: Set up sccache
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit != 'true'
+        id: sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
+
+      - name: Configure sccache backend
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit != 'true' && steps.sccache.outcome == 'success'
+        shell: bash
+        env:
+          DEPOT_CACHE_TOKEN: ${{ secrets.DEPOT_CACHE_TOKEN }}
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          if [ -n "$DEPOT_CACHE_TOKEN" ]; then
+            echo "SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev" >> "$GITHUB_ENV"
+            echo "SCCACHE_WEBDAV_TOKEN=$DEPOT_CACHE_TOKEN" >> "$GITHUB_ENV"
+          else
+            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install Linux runner dependencies
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit != 'true' && matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang pkg-config libatomic1 libssl-dev libdbus-1-dev libpipewire-0.3-dev
+
+      - name: Install Node.js
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-node
+
+      - name: Build bundled aura-node sidecar
+        if: (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit != 'true'
+        run: |
+          node scripts/ci/perf-timer.mjs \
+            --label "sidecar-build-${{ matrix.platform }}" \
+            --out "ci-perf/steps-${{ matrix.platform }}.jsonl" \
+            -- node infra/scripts/release/prepare-desktop-sidecar.mjs
+
+      - name: Collect sccache stats
+        if: always() && (inputs.platform == 'all' || inputs.platform == matrix.platform) && steps.sidecar-binary-cache.outputs.cache-hit != 'true' && steps.sccache.outcome == 'success'
+        shell: bash
+        run: |
+          mkdir -p ci-perf
+          "${SCCACHE_PATH}" --show-stats --stats-format=json > "ci-perf/sccache-${{ matrix.platform }}.json" || true
+          "${SCCACHE_PATH}" --show-stats || true
+
+      - name: Summarize benchmark
+        if: always() && (inputs.platform == 'all' || inputs.platform == matrix.platform)
+        run: |
+          node scripts/ci/ci-perf-summary.mjs --dir ci-perf --out-dir ci-perf --title "CI Performance Benchmark: sidecar ${{ matrix.platform }}"
+
+      - name: Upload benchmark artifacts
+        if: always() && (inputs.platform == 'all' || inputs.platform == matrix.platform)
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-perf-sidecar-${{ matrix.platform }}
+          path: ci-perf
+
+  summarize-run:
+    if: always()
+    needs: [preflight, interface, desktop-build, sidecar]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Summarize GitHub run timings
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/ci/gh-run-timing-summary.mjs \
+            --repo "${{ github.repository }}" \
+            --run-id "${{ github.run_id }}" \
+            --out-dir ci-run-timings \
+            --top-steps 25
+
+      - name: Upload run timing summary
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-run-timing-summary
+          path: ci-run-timings

--- a/.github/workflows/desktop-validate.yml
+++ b/.github/workflows/desktop-validate.yml
@@ -104,6 +104,7 @@ jobs:
           workspaces: |
             . -> ../.aura-shared-target
             ../aura-harness -> ../.aura-shared-target
+          cache-on-failure: true
 
       - name: Set up sccache
         id: sccache
@@ -161,7 +162,17 @@ jobs:
         if: always() && steps.sccache.outcome == 'success'
         shell: bash
         run: |
+          mkdir -p ci-cache
+          "${SCCACHE_PATH}" --show-stats --stats-format=json > "ci-cache/sccache-desktop-validate-${{ matrix.target }}.json" || true
           "${SCCACHE_PATH}" --show-stats || sccache --show-stats || true
+
+      - name: Upload cache telemetry
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-cache-desktop-validate-${{ matrix.target }}
+          path: ci-cache
+          if-no-files-found: ignore
 
       - name: Stage Cargo timings
         if: always() && (matrix.target == 'windows-x64' || matrix.target == 'macos-x64')

--- a/.github/workflows/release-mobile-nightly.yml
+++ b/.github/workflows/release-mobile-nightly.yml
@@ -25,7 +25,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: mobile-nightly-release
+  group: mobile-nightly-release-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -14,10 +14,11 @@ on:
         type: boolean
 
 permissions:
+  actions: read
   contents: write
 
 concurrency:
-  group: nightly-release
+  group: nightly-release-${{ github.ref_name }}
   cancel-in-progress: true
 
 env:
@@ -43,7 +44,53 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
+  release-preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/setup-rust-toolchain
+
+      - name: Install Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Run release preflight
+        run: node scripts/ci/verify-release-preflight.mjs
+
+  build-interface:
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Node.js
+        uses: ./.github/actions/setup-node
+        with:
+          cache: npm
+          cache-dependency-path: interface/package-lock.json
+
+      - name: Build interface
+        working-directory: interface
+        env:
+          APP_VERSION: ${{ needs.resolve-version.outputs.version }}
+          APP_COMMIT: ${{ github.sha }}
+          APP_CHANNEL: nightly
+        run: |
+          npm ci
+          npm run build
+          node ../infra/scripts/release/desktop-frontend-assets-validate.mjs --dist dist
+
+      - name: Upload interface dist
+        uses: actions/upload-artifact@v5
+        with:
+          name: interface-dist-nightly
+          path: interface/dist
+          compression-level: 0
+
   build-sidecar:
+    env:
+      CARGO_TARGET_DIR: ../.aura-shared-target
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +108,7 @@ jobs:
             target: windows
             arch: x86_64
 
-    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os }}
+    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os == 'macos-latest' && 'macos-15-xlarge' || matrix.os }}
 
     steps:
       - uses: actions/checkout@v5
@@ -72,23 +119,44 @@ jobs:
           repository-owner: ${{ github.repository_owner }}
           include-harness: "true"
 
+      - name: Restore bundled sidecar binary cache
+        id: sidecar-binary-cache
+        uses: actions/cache@v4
+        with:
+          path: apps/aura-os-desktop/resources/sidecar
+          key: desktop-sidecar-bin-v1-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('aura-harness/Cargo.lock', 'aura-harness/Cargo.toml', 'aura-harness/crates/**/Cargo.toml', 'aura-harness/crates/**/*.rs') }}
+
+      - name: Validate cached sidecar binary
+        if: steps.sidecar-binary-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          binary="apps/aura-os-desktop/resources/sidecar/aura-node"
+          if [ "${{ matrix.target }}" = "windows" ]; then
+            binary="${binary}.exe"
+          fi
+          test -s "$binary"
+
       - name: Install Rust toolchain
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-rust-toolchain
 
       - name: Restore sidecar Rust cache
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: desktop-sidecar-v2-${{ runner.os }}-${{ runner.arch }}
+          shared-key: desktop-sidecar-v4-${{ runner.os }}-${{ runner.arch }}
           workspaces: |
-            ../aura-harness -> target
+            ../aura-harness -> ../.aura-shared-target
+          cache-on-failure: true
 
       - name: Set up sccache
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         id: sccache-sidecar
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
 
       - name: Configure sccache backend
-        if: steps.sccache-sidecar.outcome == 'success'
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true' && steps.sccache-sidecar.outcome == 'success'
         shell: bash
         env:
           DEPOT_CACHE_TOKEN: ${{ secrets.DEPOT_CACHE_TOKEN }}
@@ -102,16 +170,17 @@ jobs:
           fi
 
       - name: Install Linux runner dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true' && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential clang pkg-config libatomic1 libssl-dev libdbus-1-dev libpipewire-0.3-dev
 
       - name: Install Node.js
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-node
 
       - name: Verify runner architecture
-        if: matrix.target == 'linux'
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true' && matrix.target == 'linux'
         shell: bash
         run: |
           actual_arch="$(uname -m)"
@@ -122,21 +191,18 @@ jobs:
           fi
 
       - name: Check desktop runtime parity
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         run: node scripts/ci/check-runtime.mjs desktop --require-harness
 
       - name: Validate desktop auto-update sidecar contract
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         run: |
           node --test infra/scripts/release/prepare-desktop-sidecar.test.mjs
           node infra/scripts/release/prepare-desktop-sidecar.mjs --check
 
       - name: Build bundled aura-node sidecar
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         run: node infra/scripts/release/prepare-desktop-sidecar.mjs
-
-      - name: Show sccache stats
-        if: always() && steps.sccache-sidecar.outcome == 'success'
-        shell: bash
-        run: |
-          "${SCCACHE_PATH}" --show-stats || sccache --show-stats || true
 
       - name: Archive bundled sidecar
         shell: bash
@@ -150,11 +216,17 @@ jobs:
           path: desktop-sidecar.tar
           compression-level: 0
 
-  build-app:
-    needs: resolve-version
+  package:
+    needs: [resolve-version, release-preflight]
     env:
       CARGO_TARGET_DIR: ../.aura-shared-target
       AURA_RELEASE_DIR: ../.aura-shared-target/release
+      MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+      MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+      MACOS_DEVELOPER_TEAM_ID: ${{ secrets.MACOS_DEVELOPER_TEAM_ID }}
+      IOS_APP_STORE_CONNECT_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_KEY_ID }}
+      IOS_APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_ISSUER_ID }}
+      IOS_APP_STORE_CONNECT_KEY_BASE64: ${{ secrets.IOS_APP_STORE_CONNECT_KEY_BASE64 }}
       AURA_NETWORK_URL: ${{ vars.AURA_NETWORK_URL }}
       AURA_STORAGE_URL: ${{ vars.AURA_STORAGE_URL }}
       AURA_INTEGRATIONS_URL: ${{ vars.AURA_INTEGRATIONS_URL }}
@@ -183,7 +255,7 @@ jobs:
             target: windows
             arch: x86_64
 
-    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os }}
+    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os == 'macos-latest' && 'macos-15-xlarge' || matrix.os }}
 
     steps:
       - uses: actions/checkout@v5
@@ -194,17 +266,18 @@ jobs:
       - name: Restore desktop Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: desktop-app-v2-${{ runner.os }}-${{ runner.arch }}
+          shared-key: desktop-app-v3-${{ runner.os }}-${{ runner.arch }}
           workspaces: |
-            . -> target
+            . -> ../.aura-shared-target
+          cache-on-failure: true
 
       - name: Set up sccache
-        id: sccache-app
+        id: sccache-package
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
 
       - name: Configure sccache backend
-        if: steps.sccache-app.outcome == 'success'
+        if: steps.sccache-package.outcome == 'success'
         shell: bash
         env:
           DEPOT_CACHE_TOKEN: ${{ secrets.DEPOT_CACHE_TOKEN }}
@@ -216,160 +289,6 @@ jobs:
           else
             echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           fi
-
-      - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang pkg-config libatomic1 libssl-dev libdbus-1-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev libpipewire-0.3-dev libgbm-dev libxdo-dev
-
-      - name: Install Node.js
-        uses: ./.github/actions/setup-node
-        with:
-          cache: npm
-          cache-dependency-path: interface/package-lock.json
-
-      - name: Verify runner architecture
-        if: matrix.target == 'linux'
-        shell: bash
-        run: |
-          actual_arch="$(uname -m)"
-          expected_arch="${{ matrix.arch }}"
-          if [ "$actual_arch" != "$expected_arch" ]; then
-            echo "Expected Linux runner architecture $expected_arch but got $actual_arch" >&2
-            exit 1
-          fi
-
-      - name: Check desktop runtime parity
-        run: node scripts/ci/check-runtime.mjs desktop
-
-      - name: Patch Cargo.toml version
-        shell: bash
-        run: |
-          VERSION="${{ needs.resolve-version.outputs.version }}"
-          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" apps/aura-os-desktop/Cargo.toml
-          rm -f apps/aura-os-desktop/Cargo.toml.bak
-
-      - name: Build interface
-        working-directory: interface
-        env:
-          APP_VERSION: ${{ needs.resolve-version.outputs.version }}
-          APP_COMMIT: ${{ github.sha }}
-          APP_CHANNEL: nightly
-          # Cloud control-plane origin baked into the desktop bundle. The
-          # desktop talks to its bundled local server for everything except
-          # endpoints that must hit the single prod authority (Telegram channel
-          # link/list/disconnect), which `resolveControlPlaneUrl` routes here.
-          VITE_NATIVE_DEFAULT_HOST: ${{ vars.VITE_DESKTOP_CONTROL_PLANE_HOST || 'https://api.aura.ai' }}
-        run: |
-          npm ci
-          npm run build
-          node ../infra/scripts/release/desktop-frontend-assets-validate.mjs --dist dist
-
-      - name: Build release binary
-        env:
-          AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1"
-          AURA_UPDATE_BASE_URL: ${{ env.AURA_UPDATE_BASE_URL }}
-          UPDATER_PUBLIC_KEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
-          AURA_CARGO_TIMINGS: ${{ (matrix.target == 'windows' || (matrix.target == 'macos' && matrix.arch == 'x86_64')) && '1' || '' }}
-        shell: bash
-        # `--no-default-features --features stable-channel` is required: the
-        # default features on aura-os-desktop are `dev-channel`, so plain
-        # `cargo build` would produce a Dev binary. Combined with the
-        # `default-features = false` discipline on every internal
-        # `aura-os-core` dep + the `--print-channel` self-check in
-        # `scripts/ci/verify-desktop.mjs`, this guarantees the produced
-        # binary actually identifies as Stable at runtime — not the
-        # Dev-in-disguise build that shipped before the channel-selection
-        # bug was fixed (window title "AURA Dev",
-        # `aura-dev` data dir, dev ports, in-app updater disabled). The
-        # packaged installer ships the binary built here verbatim via the
-        # `binaries-dir` injection in the package job.
-        run: |
-          args=(build --release --no-default-features --features stable-channel --package aura-os-desktop)
-          if [ -n "$AURA_CARGO_TIMINGS" ]; then
-            args+=(--timings)
-          fi
-          cargo "${args[@]}"
-
-      - name: Show sccache stats
-        if: always() && steps.sccache-app.outcome == 'success'
-        shell: bash
-        run: |
-          "${SCCACHE_PATH}" --show-stats || sccache --show-stats || true
-
-      - name: Stage Cargo timings
-        if: always() && (matrix.target == 'windows' || (matrix.target == 'macos' && matrix.arch == 'x86_64'))
-        shell: bash
-        run: |
-          rm -rf cargo-timings-upload
-          if [ -d ../.aura-shared-target/cargo-timings ]; then
-            mkdir -p cargo-timings-upload
-            cp -R ../.aura-shared-target/cargo-timings/. cargo-timings-upload/
-          fi
-
-      - name: Upload Cargo timings
-        if: always() && (matrix.target == 'windows' || (matrix.target == 'macos' && matrix.arch == 'x86_64'))
-        uses: actions/upload-artifact@v5
-        with:
-          name: cargo-timings-nightly-build-app-${{ matrix.target }}-${{ matrix.arch }}
-          path: cargo-timings-upload
-          if-no-files-found: warn
-
-      - name: Archive desktop build inputs
-        shell: bash
-        run: |
-          mkdir -p build-inputs/prebuilt-binaries build-inputs/interface
-          binary_name="aura-os-desktop"
-          if [ "${{ matrix.target }}" = "windows" ]; then
-            binary_name="${binary_name}.exe"
-          fi
-          cp "$AURA_RELEASE_DIR/${binary_name}" "build-inputs/prebuilt-binaries/${binary_name}"
-          cp -R interface/dist build-inputs/interface/dist
-          tar -cf desktop-build-inputs.tar -C build-inputs .
-
-      - name: Upload desktop build inputs
-        uses: actions/upload-artifact@v5
-        with:
-          name: build-inputs-${{ matrix.target }}-${{ matrix.arch }}
-          path: desktop-build-inputs.tar
-          compression-level: 0
-
-  package:
-    needs: [resolve-version, build-sidecar, build-app]
-    env:
-      CARGO_TARGET_DIR: ../.aura-shared-target
-      AURA_RELEASE_DIR: ../.aura-shared-target/release
-      MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
-      MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
-      MACOS_DEVELOPER_TEAM_ID: ${{ secrets.MACOS_DEVELOPER_TEAM_ID }}
-      IOS_APP_STORE_CONNECT_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_KEY_ID }}
-      IOS_APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_ISSUER_ID }}
-      IOS_APP_STORE_CONNECT_KEY_BASE64: ${{ secrets.IOS_APP_STORE_CONNECT_KEY_BASE64 }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: linux
-            arch: x86_64
-          - os: macos-latest
-            target: macos
-            arch: aarch64
-          - os: macos-15-intel
-            target: macos
-            arch: x86_64
-          - os: windows-latest
-            target: windows
-            arch: x86_64
-
-    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: ./.github/actions/setup-rust-toolchain
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -407,59 +326,12 @@ jobs:
           crate: cargo-packager
           version: 0.11.8
 
-      - name: Download sidecar artifact
-        uses: actions/download-artifact@v5
-        with:
-          name: sidecar-${{ matrix.target }}-${{ matrix.arch }}
-          path: downloaded-sidecar
-
-      - name: Download desktop build inputs
-        uses: actions/download-artifact@v5
-        with:
-          name: build-inputs-${{ matrix.target }}-${{ matrix.arch }}
-          path: downloaded-build-inputs
-
-      - name: Restore packaged resources and prebuilt binary
+      - name: Prepare packager config
         shell: bash
         run: |
-          rm -rf apps/aura-os-desktop/resources/sidecar interface/dist prebuilt-binaries
-          mkdir -p apps/aura-os-desktop/resources
-          tar -xf downloaded-sidecar/desktop-sidecar.tar -C apps/aura-os-desktop/resources
-          tar -xf downloaded-build-inputs/desktop-build-inputs.tar
-          test -d apps/aura-os-desktop/resources/sidecar
-          test -d interface/dist
-          node infra/scripts/release/desktop-frontend-assets-validate.mjs --dist interface/dist
-          binary_name="aura-os-desktop"
-          if [ "${{ matrix.target }}" = "windows" ]; then
-            binary_name="${binary_name}.exe"
-          fi
-          test -f "prebuilt-binaries/${binary_name}"
-          if [ "${{ matrix.target }}" != "windows" ]; then
-            chmod 755 "prebuilt-binaries/${binary_name}"
-            chmod 755 apps/aura-os-desktop/resources/sidecar/aura-node
-          fi
-
-      - name: Inject prebuilt binaries dir into packager config
-        shell: bash
-        run: |
-          python3 <<'PY'
-          import re
-          from pathlib import Path
-
-          cargo_toml = Path("apps/aura-os-desktop/Cargo.toml")
-          text = cargo_toml.read_text(encoding="utf-8")
-          binaries_line = 'binaries-dir = "../../prebuilt-binaries"'
-
-          if "binaries-dir =" in text:
-              text = re.sub(r'^binaries-dir = ".*"$', binaries_line, text, flags=re.MULTILINE)
-          else:
-              marker = "[package.metadata.packager]\n"
-              if marker not in text:
-                  raise SystemExit("Missing [package.metadata.packager] section in Cargo.toml")
-              text = text.replace(marker, marker + binaries_line + "\n", 1)
-
-          cargo_toml.write_text(text, encoding="utf-8")
-          PY
+          node scripts/ci/patch-desktop-packager-config.mjs \
+            --binaries-dir "../../../.aura-shared-target/release" \
+            --strip-before-packaging
 
       - name: Disable Spotlight indexing for DMG packaging
         if: matrix.target == 'macos'
@@ -560,46 +432,66 @@ jobs:
         if: matrix.target == 'macos'
         shell: bash
         run: |
-          python3 <<'PY'
-          import os
-          import re
-          from pathlib import Path
-
-          cargo_toml = Path("apps/aura-os-desktop/Cargo.toml")
-          text = cargo_toml.read_text(encoding="utf-8")
-          escaped_identity = (
-              os.environ["MACOS_SIGNING_IDENTITY"]
-              .replace("\\", "\\\\")
-              .replace('"', '\\"')
-          )
-          identity_line = f'signing-identity = "{escaped_identity}"'
-
-          if "signing-identity =" in text:
-              text = re.sub(r'^signing-identity = ".*"$', identity_line, text, flags=re.MULTILINE)
-          else:
-              marker = "[package.metadata.packager.macos]\n"
-              if marker not in text:
-                  raise SystemExit("Missing [package.metadata.packager.macos] section in Cargo.toml")
-              text = text.replace(marker, marker + identity_line + "\n", 1)
-
-          cargo_toml.write_text(text, encoding="utf-8")
-          PY
+          node scripts/ci/patch-desktop-packager-config.mjs \
+            --macos-signing-identity-env MACOS_SIGNING_IDENTITY
 
       - name: Validate macOS packager manifest
         if: matrix.target == 'macos'
         run: cargo metadata --no-deps --manifest-path apps/aura-os-desktop/Cargo.toml > /dev/null
 
-      - name: Skip duplicate packager prebuild in CI
+      - name: Wait for platform build artifacts
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/ci/wait-gh-artifacts.mjs \
+            --artifact "interface-dist-nightly" \
+            --artifact "sidecar-${{ matrix.target }}-${{ matrix.arch }}" \
+            --interval-seconds 5 \
+            --fail-job "build-interface" \
+            --fail-job "build-sidecar (${{ matrix.os }}, ${{ matrix.target }}, ${{ matrix.arch }})"
+
+      - name: Download sidecar artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: sidecar-${{ matrix.target }}-${{ matrix.arch }}
+          path: downloaded-sidecar
+
+      - name: Download interface dist
+        uses: actions/download-artifact@v5
+        with:
+          name: interface-dist-nightly
+          path: interface/dist
+
+      - name: Restore packaged resources
         shell: bash
         run: |
-          python3 <<'PY'
-          from pathlib import Path
+          rm -rf apps/aura-os-desktop/resources/sidecar
+          mkdir -p apps/aura-os-desktop/resources
+          tar -xf downloaded-sidecar/desktop-sidecar.tar -C apps/aura-os-desktop/resources
+          test -d apps/aura-os-desktop/resources/sidecar
+          test -d interface/dist
+          node infra/scripts/release/desktop-frontend-assets-validate.mjs --dist interface/dist
+          if [ "${{ matrix.target }}" != "windows" ]; then
+            chmod 755 apps/aura-os-desktop/resources/sidecar/aura-node
+          fi
 
-          cargo_toml = Path("apps/aura-os-desktop/Cargo.toml")
-          lines = cargo_toml.read_text(encoding="utf-8").splitlines()
-          filtered = [line for line in lines if not line.strip().startswith("before-packaging-command = ")]
-          cargo_toml.write_text("\n".join(filtered) + "\n", encoding="utf-8")
-          PY
+      - name: Build release binary
+        env:
+          AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1"
+          AURA_UPDATE_BASE_URL: ${{ env.AURA_UPDATE_BASE_URL }}
+          UPDATER_PUBLIC_KEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
+        shell: bash
+        run: |
+          cargo build --release --no-default-features --features stable-channel --package aura-os-desktop
+
+      - name: Verify release binary channel
+        shell: bash
+        run: |
+          node scripts/ci/verify-desktop-release-binary.mjs \
+            --release-dir "$AURA_RELEASE_DIR" \
+            --target "${{ matrix.target }}" \
+            --expected-channel Stable
 
       - name: Package installer
         env:
@@ -612,10 +504,9 @@ jobs:
           package_once() {
             # cargo-packager 0.11.8 does not accept cargo build flags
             # (--no-default-features / --features) directly. The stable-channel
-            # binary is produced by the `build-app` job (which passes those
-            # flags to cargo build), uploaded as `desktop-build-inputs.tar`,
-            # and consumed here via the `binaries-dir = "../../prebuilt-binaries"`
-            # entry that the previous step injects into Cargo.toml. The
+            # binary is produced earlier in this package job, then consumed via
+            # the `binaries-dir = "../../../.aura-shared-target/release"` entry
+            # that the prepare-packager step injects into Cargo.toml. The
             # `before-packaging-command` line is stripped above so cargo-packager
             # does not redundantly rebuild on top of the prebuilt binary.
             cargo packager --release --packages aura-os-desktop 2>&1 | tee packager.log
@@ -631,6 +522,11 @@ jobs:
             fi
 
             if [ "${{ matrix.target }}" = "linux" ] \
+              && grep -Eq "ERROR .*: status code (429|5[0-9][0-9])" packager.log; then
+              return 0
+            fi
+
+            if [ "${{ matrix.target }}" = "windows" ] \
               && grep -Eq "ERROR .*: status code (429|5[0-9][0-9])" packager.log; then
               return 0
             fi
@@ -676,6 +572,9 @@ jobs:
           cp -R "$AURA_RELEASE_DIR"/bundle/*/*.app dist/ 2>/dev/null || true
           cp "$AURA_RELEASE_DIR"/bundle/*/*-setup*.exe dist/ 2>/dev/null || true
           cp "$AURA_RELEASE_DIR"/bundle/*/*.sig dist/ 2>/dev/null || true
+          if [ "${{ matrix.target }}" = "windows" ]; then
+            rm -f dist/aura-os-desktop.exe dist/aura-os-desktop.exe.sig
+          fi
           if [ "${{ matrix.target }}" = "macos" ]; then
             for bundle in dist/*.app.tar.gz; do
               [ -e "$bundle" ] || continue
@@ -722,112 +621,24 @@ jobs:
           mv dist/checksums.txt "dist/checksums-${{ matrix.target }}-${{ matrix.arch }}.txt"
           cat "dist/release-summary-${{ matrix.target }}-${{ matrix.arch }}.md" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Validate signed release artifacts
+        shell: bash
+        run: |
+          node infra/scripts/release/desktop-release-artifacts-validate.mjs \
+            --dist dist \
+            --channel nightly \
+            --version "${{ needs.resolve-version.outputs.version }}" \
+            --target "${{ matrix.target }}" \
+            --arch "${{ matrix.arch }}"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
         with:
           name: installers-${{ matrix.target }}-${{ matrix.arch }}
           path: dist/
 
-  package-android-apk:
-    needs: resolve-version
-    if: github.ref_name == 'main' || (github.event_name == 'workflow_dispatch' && inputs.publish_live)
-    runs-on: ubuntu-latest
-    env:
-      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-      ANDROID_PACKAGE_NAME: ${{ secrets.ANDROID_PACKAGE_NAME }}
-      ANDROID_VERSION_CODE: ${{ github.run_number }}
-      VITE_ANDROID_DEFAULT_HOST: ${{ vars.VITE_ANDROID_DEFAULT_HOST }}
-      VITE_NATIVE_DEFAULT_HOST: ${{ vars.VITE_NATIVE_DEFAULT_HOST }}
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Node.js
-        uses: ./.github/actions/setup-node
-        with:
-          cache: npm
-          cache-dependency-path: interface/package-lock.json
-
-      - name: Install Java 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "21"
-          cache: gradle
-
-      - name: Install Android SDK tools
-        uses: android-actions/setup-android@v4
-
-      - name: Install Android SDK packages
-        run: |
-          yes | sdkmanager --licenses >/dev/null
-          sdkmanager "platforms;android-36" "build-tools;36.0.0"
-
-      - name: Install Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "4.0.2"
-
-      - name: Check Android runtime parity
-        run: node scripts/ci/check-runtime.mjs android --native --ruby
-
-      - name: Install interface dependencies
-        working-directory: interface
-        run: npm ci
-
-      - name: Install fastlane gems
-        working-directory: interface/android
-        run: bundle install --jobs 4 --retry 3
-
-      - name: Resolve Android host defaults
-        shell: bash
-        run: |
-          DEFAULT_HOST="${VITE_NATIVE_DEFAULT_HOST:-https://aura-os-t565.onrender.com}"
-          echo "VITE_NATIVE_DEFAULT_HOST=${DEFAULT_HOST}" >> "$GITHUB_ENV"
-          echo "VITE_ANDROID_DEFAULT_HOST=${VITE_ANDROID_DEFAULT_HOST:-$DEFAULT_HOST}" >> "$GITHUB_ENV"
-
-      - name: Materialize Android upload keystore
-        run: |
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > /tmp/aura-android-upload.jks
-          echo "ANDROID_KEYSTORE_PATH=/tmp/aura-android-upload.jks" >> "$GITHUB_ENV"
-
-      - name: Build signed Android APK
-        working-directory: interface/android
-        env:
-          APP_VERSION: ${{ needs.resolve-version.outputs.version }}
-          APP_COMMIT: ${{ github.sha }}
-          APP_CHANNEL: nightly
-          ANDROID_VERSION_NAME: ${{ needs.resolve-version.outputs.version }}
-        run: bundle exec fastlane android github_release
-
-      - name: Collect Android APK artifact
-        shell: bash
-        run: |
-          mkdir -p dist
-          cp interface/android/app/build/outputs/apk/release/app-release.apk "dist/aura-os-android_${{ needs.resolve-version.outputs.version }}.apk"
-
-      - name: Generate Android artifact summary
-        shell: bash
-        run: |
-          node infra/scripts/release/mobile-release-summary.mjs \
-            --platform android \
-            --mode ship \
-            --output-dir mobile-release-summary \
-            --roots dist
-          mv mobile-release-summary/android-ship-summary.json "dist/release-summary-android-mobile.json"
-          mv mobile-release-summary/android-ship-summary.md "dist/release-summary-android-mobile.md"
-          cat "dist/release-summary-android-mobile.md" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload Android APK artifact
-        uses: actions/upload-artifact@v5
-        with:
-          name: installers-android-mobile
-          path: dist/
-
   release:
-    needs: [resolve-version, package, package-android-apk]
+    needs: [resolve-version, package]
     if: github.ref_name == 'main' || (github.event_name == 'workflow_dispatch' && inputs.publish_live)
     runs-on: ubuntu-latest
     steps:
@@ -946,16 +757,32 @@ jobs:
           done
 
   preview-manifests:
-    needs: [resolve-version, package]
+    needs: [resolve-version]
     if: github.ref_name != 'main' || (github.event_name == 'workflow_dispatch' && !inputs.publish_live)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Install Node.js
         uses: ./.github/actions/setup-node
+
+      - name: Wait for installer artifacts
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/ci/wait-gh-artifacts.mjs \
+            --artifact "installers-windows-x86_64" \
+            --artifact "installers-macos-aarch64" \
+            --artifact "installers-macos-x86_64" \
+            --artifact "installers-linux-x86_64" \
+            --interval-seconds 5 \
+            --fail-job "package (windows-latest, windows, x86_64)" \
+            --fail-job "package (macos-latest, macos, aarch64)" \
+            --fail-job "package (macos-15-intel, macos, x86_64)" \
+            --fail-job "package (ubuntu-latest, linux, x86_64)"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v5
@@ -972,6 +799,26 @@ jobs:
             --version "${{ needs.resolve-version.outputs.version }}" \
             --output-dir manifest-validation
 
+      - name: Dry-run release asset reconciliation
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash infra/scripts/release/upload-release-assets-with-retry.sh \
+            --dry-run \
+            "${{ github.repository }}" \
+            "${{ needs.resolve-version.outputs.tag }}" \
+            all-artifacts
+          bash infra/scripts/release/prune-release-assets-with-retry.sh \
+            --dry-run \
+            "${{ github.repository }}" \
+            nightly
+          bash infra/scripts/release/upload-release-assets-with-retry.sh \
+            --dry-run \
+            "${{ github.repository }}" \
+            nightly \
+            all-artifacts
+
       - name: Generate preview update manifests
         shell: bash
         run: |
@@ -981,7 +828,7 @@ jobs:
 
           generate_manifest() {
             local target=$1 arch=$2 filename=$3 format=$4
-            local sig_file="../all-artifacts/${filename}.sig"
+            local sig_file="all-artifacts/${filename}.sig"
             local signature='""'
             if [ -f "$sig_file" ]; then
               signature=$(jq -Rs . < "$sig_file")
@@ -1003,10 +850,44 @@ jobs:
           generate_manifest "macos" "x86_64" "aura-os-desktop_${VERSION}_x86_64.app.tar.gz" "app"
           generate_manifest "linux" "x86_64" "aura-os-desktop_${VERSION}_x86_64.AppImage" "appimage"
 
+          mkdir -p downloads
+          cat > downloads/nightly.json <<MANIFEST
+          {
+            "channel": "nightly",
+            "version": "${VERSION}",
+            "release_url": "https://github.com/${{ github.repository }}/releases/tag/${TAG}",
+            "generated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+            "desktop": {
+              "windows": {
+                "url": "https://github.com/${{ github.repository }}/releases/download/${TAG}/aura-os-desktop_${VERSION}_x64-setup.exe"
+              },
+              "mac": {
+                "apple-silicon": {
+                  "url": "https://github.com/${{ github.repository }}/releases/download/${TAG}/AURA_${VERSION}_aarch64.dmg"
+                },
+                "intel": {
+                  "url": "https://github.com/${{ github.repository }}/releases/download/${TAG}/AURA_${VERSION}_x64.dmg"
+                }
+              },
+              "linux": {
+                "url": "https://github.com/${{ github.repository }}/releases/download/${TAG}/aura-os-desktop_${VERSION}_x86_64.AppImage"
+              }
+            }
+          }
+          MANIFEST
+
       - name: Validate preview manifests
         run: |
           node infra/scripts/release/desktop-manifest-validate.mjs \
             --root-dir . \
+            --channel nightly \
+            --output-dir manifest-validation
+
+      - name: Validate preview download manifest
+        run: |
+          node infra/scripts/release/desktop-downloads-validate.mjs \
+            --manifest downloads/nightly.json \
+            --artifacts-dir all-artifacts \
             --channel nightly \
             --output-dir manifest-validation
 
@@ -1019,14 +900,18 @@ jobs:
             echo "- Publish skipped because this run was started in validation mode."
             echo ""
             cat manifest-validation/desktop-manifests-nightly.md
+            echo ""
+            cat manifest-validation/desktop-downloads-nightly.md
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload preview manifests
+        if: always()
         uses: actions/upload-artifact@v5
         with:
           name: nightly-preview-manifests
           path: |
             nightly/**
+            downloads/**
             manifest-validation/**
 
   publish-manifests:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -8,8 +8,14 @@ on:
       version:
         description: "Version to release (e.g. 1.0.0)"
         required: true
+      publish_live:
+        description: "Publish the GitHub stable release and gh-pages manifests"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
+  actions: read
   contents: write
 
 env:
@@ -17,7 +23,62 @@ env:
   AURA_UPDATE_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
 jobs:
+  release-preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/setup-rust-toolchain
+
+      - name: Install Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Run release preflight
+        run: node scripts/ci/verify-release-preflight.mjs
+
+  build-interface:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Node.js
+        uses: ./.github/actions/setup-node
+        with:
+          cache: npm
+          cache-dependency-path: interface/package-lock.json
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build interface
+        working-directory: interface
+        env:
+          APP_VERSION: ${{ steps.version.outputs.version }}
+          APP_COMMIT: ${{ github.sha }}
+          APP_CHANNEL: stable
+        run: |
+          npm ci
+          npm run build
+          node ../infra/scripts/release/desktop-frontend-assets-validate.mjs --dist dist
+
+      - name: Upload interface dist
+        uses: actions/upload-artifact@v5
+        with:
+          name: interface-dist-stable
+          path: interface/dist
+          compression-level: 0
+
   build-sidecar:
+    env:
+      CARGO_TARGET_DIR: ../.aura-shared-target
     strategy:
       fail-fast: false
       matrix:
@@ -35,7 +96,7 @@ jobs:
             target: windows
             arch: x86_64
 
-    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os }}
+    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os == 'macos-latest' && 'macos-15-xlarge' || matrix.os }}
 
     steps:
       - uses: actions/checkout@v5
@@ -46,23 +107,44 @@ jobs:
           repository-owner: ${{ github.repository_owner }}
           include-harness: "true"
 
+      - name: Restore bundled sidecar binary cache
+        id: sidecar-binary-cache
+        uses: actions/cache@v4
+        with:
+          path: apps/aura-os-desktop/resources/sidecar
+          key: desktop-sidecar-bin-v1-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('aura-harness/Cargo.lock', 'aura-harness/Cargo.toml', 'aura-harness/crates/**/Cargo.toml', 'aura-harness/crates/**/*.rs') }}
+
+      - name: Validate cached sidecar binary
+        if: steps.sidecar-binary-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          binary="apps/aura-os-desktop/resources/sidecar/aura-node"
+          if [ "${{ matrix.target }}" = "windows" ]; then
+            binary="${binary}.exe"
+          fi
+          test -s "$binary"
+
       - name: Install Rust toolchain
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-rust-toolchain
 
       - name: Restore sidecar Rust cache
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: desktop-sidecar-v2-${{ runner.os }}-${{ runner.arch }}
+          shared-key: desktop-sidecar-v4-${{ runner.os }}-${{ runner.arch }}
           workspaces: |
-            ../aura-harness -> target
+            ../aura-harness -> ../.aura-shared-target
+          cache-on-failure: true
 
       - name: Set up sccache
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         id: sccache-sidecar
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
 
       - name: Configure sccache backend
-        if: steps.sccache-sidecar.outcome == 'success'
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true' && steps.sccache-sidecar.outcome == 'success'
         shell: bash
         env:
           DEPOT_CACHE_TOKEN: ${{ secrets.DEPOT_CACHE_TOKEN }}
@@ -76,16 +158,17 @@ jobs:
           fi
 
       - name: Install Linux runner dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true' && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential clang pkg-config libatomic1 libssl-dev libdbus-1-dev libpipewire-0.3-dev
 
       - name: Install Node.js
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-node
 
       - name: Verify runner architecture
-        if: matrix.target == 'linux'
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true' && matrix.target == 'linux'
         shell: bash
         run: |
           actual_arch="$(uname -m)"
@@ -96,21 +179,18 @@ jobs:
           fi
 
       - name: Check desktop runtime parity
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         run: node scripts/ci/check-runtime.mjs desktop --require-harness
 
       - name: Validate desktop auto-update sidecar contract
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         run: |
           node --test infra/scripts/release/prepare-desktop-sidecar.test.mjs
           node infra/scripts/release/prepare-desktop-sidecar.mjs --check
 
       - name: Build bundled aura-node sidecar
+        if: steps.sidecar-binary-cache.outputs.cache-hit != 'true'
         run: node infra/scripts/release/prepare-desktop-sidecar.mjs
-
-      - name: Show sccache stats
-        if: always() && steps.sccache-sidecar.outcome == 'success'
-        shell: bash
-        run: |
-          "${SCCACHE_PATH}" --show-stats || sccache --show-stats || true
 
       - name: Archive bundled sidecar
         shell: bash
@@ -124,20 +204,28 @@ jobs:
           path: desktop-sidecar.tar
           compression-level: 0
 
-  build-app:
+  package:
+    needs: release-preflight
     env:
       CARGO_TARGET_DIR: ../.aura-shared-target
       AURA_RELEASE_DIR: ../.aura-shared-target/release
+      MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+      MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+      MACOS_DEVELOPER_TEAM_ID: ${{ secrets.MACOS_DEVELOPER_TEAM_ID }}
+      IOS_APP_STORE_CONNECT_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_KEY_ID }}
+      IOS_APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_ISSUER_ID }}
+      IOS_APP_STORE_CONNECT_KEY_BASE64: ${{ secrets.IOS_APP_STORE_CONNECT_KEY_BASE64 }}
       AURA_NETWORK_URL: ${{ vars.AURA_NETWORK_URL }}
       AURA_STORAGE_URL: ${{ vars.AURA_STORAGE_URL }}
       AURA_INTEGRATIONS_URL: ${{ vars.AURA_INTEGRATIONS_URL }}
       AURA_ROUTER_URL: ${{ vars.AURA_ROUTER_URL }}
       Z_BILLING_URL: ${{ vars.Z_BILLING_URL }}
-      Z_BILLING_API_KEY: ${{ secrets.Z_BILLING_API_KEY }}
       ORBIT_BASE_URL: ${{ vars.ORBIT_BASE_URL }}
       SWARM_BASE_URL: ${{ vars.SWARM_BASE_URL }}
       REQUIRE_ZERO_PRO: ${{ vars.REQUIRE_ZERO_PRO }}
       AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN: ${{ vars.AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN }}
+      VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
+      Z_BILLING_API_KEY: ${{ secrets.Z_BILLING_API_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +243,7 @@ jobs:
             target: windows
             arch: x86_64
 
-    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os }}
+    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os == 'macos-latest' && 'macos-15-xlarge' || matrix.os }}
 
     steps:
       - uses: actions/checkout@v5
@@ -166,17 +254,18 @@ jobs:
       - name: Restore desktop Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: desktop-app-v2-${{ runner.os }}-${{ runner.arch }}
+          shared-key: desktop-app-v3-${{ runner.os }}-${{ runner.arch }}
           workspaces: |
-            . -> target
+            . -> ../.aura-shared-target
+          cache-on-failure: true
 
       - name: Set up sccache
-        id: sccache-app
+        id: sccache-package
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
 
       - name: Configure sccache backend
-        if: steps.sccache-app.outcome == 'success'
+        if: steps.sccache-package.outcome == 'success'
         shell: bash
         env:
           DEPOT_CACHE_TOKEN: ${{ secrets.DEPOT_CACHE_TOKEN }}
@@ -188,174 +277,6 @@ jobs:
           else
             echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           fi
-
-      - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang pkg-config libatomic1 libssl-dev libdbus-1-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev libpipewire-0.3-dev libgbm-dev libxdo-dev
-
-      - name: Install Node.js
-        uses: ./.github/actions/setup-node
-        with:
-          cache: npm
-          cache-dependency-path: interface/package-lock.json
-
-      - name: Verify runner architecture
-        if: matrix.target == 'linux'
-        shell: bash
-        run: |
-          actual_arch="$(uname -m)"
-          expected_arch="${{ matrix.arch }}"
-          if [ "$actual_arch" != "$expected_arch" ]; then
-            echo "Expected Linux runner architecture $expected_arch but got $actual_arch" >&2
-            exit 1
-          fi
-
-      - name: Check desktop runtime parity
-        run: node scripts/ci/check-runtime.mjs desktop
-
-      - name: Determine version
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Patch Cargo.toml version
-        shell: bash
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" apps/aura-os-desktop/Cargo.toml
-          rm -f apps/aura-os-desktop/Cargo.toml.bak
-
-      - name: Build interface
-        working-directory: interface
-        env:
-          APP_VERSION: ${{ steps.version.outputs.version }}
-          APP_COMMIT: ${{ github.sha }}
-          APP_CHANNEL: stable
-          # Cloud control-plane origin baked into the desktop bundle. The
-          # desktop talks to its bundled local server for everything except
-          # endpoints that must hit the single prod authority (Telegram channel
-          # link/list/disconnect), which `resolveControlPlaneUrl` routes here.
-          VITE_NATIVE_DEFAULT_HOST: ${{ vars.VITE_DESKTOP_CONTROL_PLANE_HOST || 'https://api.aura.ai' }}
-        run: |
-          npm ci
-          npm run build
-          node ../infra/scripts/release/desktop-frontend-assets-validate.mjs --dist dist
-
-      - name: Build release binary
-        env:
-          AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1"
-          AURA_UPDATE_BASE_URL: ${{ env.AURA_UPDATE_BASE_URL }}
-          UPDATER_PUBLIC_KEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
-          AURA_CARGO_TIMINGS: ${{ (matrix.target == 'windows' || (matrix.target == 'macos' && matrix.arch == 'x86_64')) && '1' || '' }}
-        shell: bash
-        # `--no-default-features --features stable-channel` is required: the
-        # default features on aura-os-desktop are `dev-channel`, so plain
-        # `cargo build` would produce a Dev binary (window title "AURA Dev",
-        # `aura-dev` data dir, dev ports, in-app updater disabled). The
-        # packaged installer ships the binary built here verbatim via the
-        # `binaries-dir` injection in the package job.
-        #
-        # The flag alone is not sufficient: every library crate must also
-        # depend on `aura-os-core` with `default-features = false`, and
-        # `aura-os-core` itself must have no default channel. Otherwise
-        # Cargo feature unification re-activates `dev-channel` through a
-        # transitive dep and produces a Dev-in-disguise stable binary.
-        # `scripts/ci/verify-desktop.mjs` invokes the just-built binary
-        # with `--print-channel` and fails the lane if it doesn't report
-        # `channel=Stable`, so a regression here turns the release red
-        # instead of shipping silently.
-        run: |
-          args=(build --release --no-default-features --features stable-channel --package aura-os-desktop)
-          if [ -n "$AURA_CARGO_TIMINGS" ]; then
-            args+=(--timings)
-          fi
-          cargo "${args[@]}"
-
-      - name: Show sccache stats
-        if: always() && steps.sccache-app.outcome == 'success'
-        shell: bash
-        run: |
-          "${SCCACHE_PATH}" --show-stats || sccache --show-stats || true
-
-      - name: Stage Cargo timings
-        if: always() && (matrix.target == 'windows' || (matrix.target == 'macos' && matrix.arch == 'x86_64'))
-        shell: bash
-        run: |
-          rm -rf cargo-timings-upload
-          if [ -d ../.aura-shared-target/cargo-timings ]; then
-            mkdir -p cargo-timings-upload
-            cp -R ../.aura-shared-target/cargo-timings/. cargo-timings-upload/
-          fi
-
-      - name: Upload Cargo timings
-        if: always() && (matrix.target == 'windows' || (matrix.target == 'macos' && matrix.arch == 'x86_64'))
-        uses: actions/upload-artifact@v5
-        with:
-          name: cargo-timings-stable-build-app-${{ matrix.target }}-${{ matrix.arch }}
-          path: cargo-timings-upload
-          if-no-files-found: warn
-
-      - name: Archive desktop build inputs
-        shell: bash
-        run: |
-          mkdir -p build-inputs/prebuilt-binaries build-inputs/interface
-          binary_name="aura-os-desktop"
-          if [ "${{ matrix.target }}" = "windows" ]; then
-            binary_name="${binary_name}.exe"
-          fi
-          cp "$AURA_RELEASE_DIR/${binary_name}" "build-inputs/prebuilt-binaries/${binary_name}"
-          cp -R interface/dist build-inputs/interface/dist
-          tar -cf desktop-build-inputs.tar -C build-inputs .
-
-      - name: Upload desktop build inputs
-        uses: actions/upload-artifact@v5
-        with:
-          name: build-inputs-${{ matrix.target }}-${{ matrix.arch }}
-          path: desktop-build-inputs.tar
-          compression-level: 0
-
-  package:
-    needs: [build-sidecar, build-app]
-    env:
-      CARGO_TARGET_DIR: ../.aura-shared-target
-      AURA_RELEASE_DIR: ../.aura-shared-target/release
-      MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
-      MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
-      MACOS_DEVELOPER_TEAM_ID: ${{ secrets.MACOS_DEVELOPER_TEAM_ID }}
-      IOS_APP_STORE_CONNECT_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_KEY_ID }}
-      IOS_APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_ISSUER_ID }}
-      IOS_APP_STORE_CONNECT_KEY_BASE64: ${{ secrets.IOS_APP_STORE_CONNECT_KEY_BASE64 }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: linux
-            arch: x86_64
-          - os: macos-latest
-            target: macos
-            arch: aarch64
-          - os: macos-15-intel
-            target: macos
-            arch: x86_64
-          - os: windows-latest
-            target: windows
-            arch: x86_64
-
-    runs-on: ${{ matrix.os == 'windows-latest' && 'aura-os-windows-x64-large' || matrix.os == 'ubuntu-latest' && 'aura-os-linux-x64-large' || matrix.os == 'macos-15-intel' && 'macos-15-large' || matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: ./.github/actions/setup-rust-toolchain
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -403,59 +324,12 @@ jobs:
           crate: cargo-packager
           version: 0.11.8
 
-      - name: Download sidecar artifact
-        uses: actions/download-artifact@v5
-        with:
-          name: sidecar-${{ matrix.target }}-${{ matrix.arch }}
-          path: downloaded-sidecar
-
-      - name: Download desktop build inputs
-        uses: actions/download-artifact@v5
-        with:
-          name: build-inputs-${{ matrix.target }}-${{ matrix.arch }}
-          path: downloaded-build-inputs
-
-      - name: Restore packaged resources and prebuilt binary
+      - name: Prepare packager config
         shell: bash
         run: |
-          rm -rf apps/aura-os-desktop/resources/sidecar interface/dist prebuilt-binaries
-          mkdir -p apps/aura-os-desktop/resources
-          tar -xf downloaded-sidecar/desktop-sidecar.tar -C apps/aura-os-desktop/resources
-          tar -xf downloaded-build-inputs/desktop-build-inputs.tar
-          test -d apps/aura-os-desktop/resources/sidecar
-          test -d interface/dist
-          node infra/scripts/release/desktop-frontend-assets-validate.mjs --dist interface/dist
-          binary_name="aura-os-desktop"
-          if [ "${{ matrix.target }}" = "windows" ]; then
-            binary_name="${binary_name}.exe"
-          fi
-          test -f "prebuilt-binaries/${binary_name}"
-          if [ "${{ matrix.target }}" != "windows" ]; then
-            chmod 755 "prebuilt-binaries/${binary_name}"
-            chmod 755 apps/aura-os-desktop/resources/sidecar/aura-node
-          fi
-
-      - name: Inject prebuilt binaries dir into packager config
-        shell: bash
-        run: |
-          python3 <<'PY'
-          import re
-          from pathlib import Path
-
-          cargo_toml = Path("apps/aura-os-desktop/Cargo.toml")
-          text = cargo_toml.read_text(encoding="utf-8")
-          binaries_line = 'binaries-dir = "../../prebuilt-binaries"'
-
-          if "binaries-dir =" in text:
-              text = re.sub(r'^binaries-dir = ".*"$', binaries_line, text, flags=re.MULTILINE)
-          else:
-              marker = "[package.metadata.packager]\n"
-              if marker not in text:
-                  raise SystemExit("Missing [package.metadata.packager] section in Cargo.toml")
-              text = text.replace(marker, marker + binaries_line + "\n", 1)
-
-          cargo_toml.write_text(text, encoding="utf-8")
-          PY
+          node scripts/ci/patch-desktop-packager-config.mjs \
+            --binaries-dir "../../../.aura-shared-target/release" \
+            --strip-before-packaging
 
       - name: Disable Spotlight indexing for DMG packaging
         if: matrix.target == 'macos'
@@ -556,46 +430,66 @@ jobs:
         if: matrix.target == 'macos'
         shell: bash
         run: |
-          python3 <<'PY'
-          import os
-          import re
-          from pathlib import Path
-
-          cargo_toml = Path("apps/aura-os-desktop/Cargo.toml")
-          text = cargo_toml.read_text(encoding="utf-8")
-          escaped_identity = (
-              os.environ["MACOS_SIGNING_IDENTITY"]
-              .replace("\\", "\\\\")
-              .replace('"', '\\"')
-          )
-          identity_line = f'signing-identity = "{escaped_identity}"'
-
-          if "signing-identity =" in text:
-              text = re.sub(r'^signing-identity = ".*"$', identity_line, text, flags=re.MULTILINE)
-          else:
-              marker = "[package.metadata.packager.macos]\n"
-              if marker not in text:
-                  raise SystemExit("Missing [package.metadata.packager.macos] section in Cargo.toml")
-              text = text.replace(marker, marker + identity_line + "\n", 1)
-
-          cargo_toml.write_text(text, encoding="utf-8")
-          PY
+          node scripts/ci/patch-desktop-packager-config.mjs \
+            --macos-signing-identity-env MACOS_SIGNING_IDENTITY
 
       - name: Validate macOS packager manifest
         if: matrix.target == 'macos'
         run: cargo metadata --no-deps --manifest-path apps/aura-os-desktop/Cargo.toml > /dev/null
 
-      - name: Skip duplicate packager prebuild in CI
+      - name: Wait for platform build artifacts
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/ci/wait-gh-artifacts.mjs \
+            --artifact "interface-dist-stable" \
+            --artifact "sidecar-${{ matrix.target }}-${{ matrix.arch }}" \
+            --interval-seconds 5 \
+            --fail-job "build-interface" \
+            --fail-job "build-sidecar (${{ matrix.os }}, ${{ matrix.target }}, ${{ matrix.arch }})"
+
+      - name: Download sidecar artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: sidecar-${{ matrix.target }}-${{ matrix.arch }}
+          path: downloaded-sidecar
+
+      - name: Download interface dist
+        uses: actions/download-artifact@v5
+        with:
+          name: interface-dist-stable
+          path: interface/dist
+
+      - name: Restore packaged resources
         shell: bash
         run: |
-          python3 <<'PY'
-          from pathlib import Path
+          rm -rf apps/aura-os-desktop/resources/sidecar
+          mkdir -p apps/aura-os-desktop/resources
+          tar -xf downloaded-sidecar/desktop-sidecar.tar -C apps/aura-os-desktop/resources
+          test -d apps/aura-os-desktop/resources/sidecar
+          test -d interface/dist
+          node infra/scripts/release/desktop-frontend-assets-validate.mjs --dist interface/dist
+          if [ "${{ matrix.target }}" != "windows" ]; then
+            chmod 755 apps/aura-os-desktop/resources/sidecar/aura-node
+          fi
 
-          cargo_toml = Path("apps/aura-os-desktop/Cargo.toml")
-          lines = cargo_toml.read_text(encoding="utf-8").splitlines()
-          filtered = [line for line in lines if not line.strip().startswith("before-packaging-command = ")]
-          cargo_toml.write_text("\n".join(filtered) + "\n", encoding="utf-8")
-          PY
+      - name: Build release binary
+        env:
+          AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1"
+          AURA_UPDATE_BASE_URL: ${{ env.AURA_UPDATE_BASE_URL }}
+          UPDATER_PUBLIC_KEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
+        shell: bash
+        run: |
+          cargo build --release --no-default-features --features stable-channel --package aura-os-desktop
+
+      - name: Verify release binary channel
+        shell: bash
+        run: |
+          node scripts/ci/verify-desktop-release-binary.mjs \
+            --release-dir "$AURA_RELEASE_DIR" \
+            --target "${{ matrix.target }}" \
+            --expected-channel Stable
 
       - name: Package installer
         env:
@@ -608,10 +502,9 @@ jobs:
           package_once() {
             # cargo-packager 0.11.8 does not accept cargo build flags
             # (--no-default-features / --features) directly. The stable-channel
-            # binary is produced by the `build-app` job (which passes those
-            # flags to cargo build), uploaded as `desktop-build-inputs.tar`,
-            # and consumed here via the `binaries-dir = "../../prebuilt-binaries"`
-            # entry that the previous step injects into Cargo.toml. The
+            # binary is produced earlier in this package job, then consumed via
+            # the `binaries-dir = "../../../.aura-shared-target/release"` entry
+            # that the prepare-packager step injects into Cargo.toml. The
             # `before-packaging-command` line is stripped above so cargo-packager
             # does not redundantly rebuild on top of the prebuilt binary.
             cargo packager --release --packages aura-os-desktop 2>&1 | tee packager.log
@@ -627,6 +520,11 @@ jobs:
             fi
 
             if [ "${{ matrix.target }}" = "linux" ] \
+              && grep -Eq "ERROR .*: status code (429|5[0-9][0-9])" packager.log; then
+              return 0
+            fi
+
+            if [ "${{ matrix.target }}" = "windows" ] \
               && grep -Eq "ERROR .*: status code (429|5[0-9][0-9])" packager.log; then
               return 0
             fi
@@ -672,6 +570,9 @@ jobs:
           cp -R "$AURA_RELEASE_DIR"/bundle/*/*.app dist/ 2>/dev/null || true
           cp "$AURA_RELEASE_DIR"/bundle/*/*-setup*.exe dist/ 2>/dev/null || true
           cp "$AURA_RELEASE_DIR"/bundle/*/*.sig dist/ 2>/dev/null || true
+          if [ "${{ matrix.target }}" = "windows" ]; then
+            rm -f dist/aura-os-desktop.exe dist/aura-os-desktop.exe.sig
+          fi
           if [ "${{ matrix.target }}" = "macos" ]; then
             for bundle in dist/*.app.tar.gz; do
               [ -e "$bundle" ] || continue
@@ -718,14 +619,158 @@ jobs:
           mv dist/checksums.txt "dist/checksums-${{ matrix.target }}-${{ matrix.arch }}.txt"
           cat "dist/release-summary-${{ matrix.target }}-${{ matrix.arch }}.md" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Validate signed release artifacts
+        shell: bash
+        run: |
+          node infra/scripts/release/desktop-release-artifacts-validate.mjs \
+            --dist dist \
+            --channel stable \
+            --version "${{ steps.version.outputs.version }}" \
+            --target "${{ matrix.target }}" \
+            --arch "${{ matrix.arch }}"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
         with:
           name: installers-${{ matrix.target }}-${{ matrix.arch }}
           path: dist/
 
+  validate-artifacts:
+    needs: package
+    if: github.event_name == 'workflow_dispatch' && !inputs.publish_live
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Install Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: installers-*
+          path: all-artifacts
+          merge-multiple: true
+
+      - name: Validate artifact versions
+        run: |
+          node infra/scripts/release/validate-release-artifact-versions.mjs \
+            --artifacts-dir all-artifacts \
+            --channel stable \
+            --version "${{ github.event.inputs.version }}" \
+            --output-dir validation
+
+      - name: Dry-run release asset reconciliation
+        shell: bash
+        run: |
+          bash infra/scripts/release/upload-release-assets-with-retry.sh \
+            --dry-run \
+            "${{ github.repository }}" \
+            "v${{ github.event.inputs.version }}" \
+            all-artifacts
+
+      - name: Generate preview update manifests
+        shell: bash
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          TAG="v${VERSION}"
+          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
+
+          generate_manifest() {
+            local target=$1 arch=$2 filename=$3 format=$4
+            local sig_file="all-artifacts/${filename}.sig"
+            local signature='""'
+            if [ -f "$sig_file" ]; then
+              signature=$(jq -Rs . < "$sig_file")
+            fi
+
+            mkdir -p "stable/${target}"
+            cat > "stable/${target}/${arch}.json" <<MANIFEST
+          {
+            "version": "${VERSION}",
+            "url": "${BASE_URL}/${filename}",
+            "signature": ${signature},
+            "format": "${format}"
+          }
+          MANIFEST
+          }
+
+          generate_manifest "windows" "x86_64" "aura-os-desktop_${VERSION}_x64-setup.exe" "nsis"
+          generate_manifest "macos" "aarch64" "aura-os-desktop_${VERSION}_aarch64.app.tar.gz" "app"
+          generate_manifest "macos" "x86_64" "aura-os-desktop_${VERSION}_x86_64.app.tar.gz" "app"
+          generate_manifest "linux" "x86_64" "aura-os-desktop_${VERSION}_x86_64.AppImage" "appimage"
+
+          mkdir -p downloads
+          cat > downloads/stable.json <<MANIFEST
+          {
+            "channel": "stable",
+            "version": "${VERSION}",
+            "release_url": "https://github.com/${{ github.repository }}/releases/tag/${TAG}",
+            "generated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+            "desktop": {
+              "windows": {
+                "url": "https://github.com/${{ github.repository }}/releases/download/${TAG}/aura-os-desktop_${VERSION}_x64-setup.exe"
+              },
+              "mac": {
+                "apple-silicon": {
+                  "url": "https://github.com/${{ github.repository }}/releases/download/${TAG}/AURA_${VERSION}_aarch64.dmg"
+                },
+                "intel": {
+                  "url": "https://github.com/${{ github.repository }}/releases/download/${TAG}/AURA_${VERSION}_x64.dmg"
+                }
+              },
+              "linux": {
+                "url": "https://github.com/${{ github.repository }}/releases/download/${TAG}/aura-os-desktop_${VERSION}_x86_64.AppImage"
+              }
+            }
+          }
+          MANIFEST
+
+      - name: Validate preview manifests
+        run: |
+          node infra/scripts/release/desktop-manifest-validate.mjs \
+            --root-dir . \
+            --channel stable \
+            --output-dir validation
+
+      - name: Validate preview download manifest
+        run: |
+          node infra/scripts/release/desktop-downloads-validate.mjs \
+            --manifest downloads/stable.json \
+            --artifacts-dir all-artifacts \
+            --channel stable \
+            --output-dir validation
+
+      - name: Attach validation summary
+        shell: bash
+        run: |
+          {
+            echo "## Stable Validation Mode"
+            echo ""
+            echo "- Publish skipped because this manual run used publish_live=false."
+            echo ""
+            cat validation/artifact-versions-stable.md
+            echo ""
+            cat validation/desktop-manifests-stable.md
+            echo ""
+            cat validation/desktop-downloads-stable.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload validation manifests
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: stable-validation-manifests
+          path: |
+            stable/**
+            downloads/**
+            validation/**
+
   release:
     needs: package
+    if: github.event_name != 'workflow_dispatch' || inputs.publish_live
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -804,6 +849,7 @@ jobs:
 
   publish-manifests:
     needs: [package, release]
+    if: github.event_name != 'workflow_dispatch' || inputs.publish_live
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/apps/aura-os-server/Cargo.toml
+++ b/apps/aura-os-server/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[package]
+[package]
 name = "aura-os-server"
 version = "0.1.0"
 edition.workspace = true

--- a/crates/aura-os-harness/Cargo.toml
+++ b/crates/aura-os-harness/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[package]
+[package]
 name = "aura-os-harness"
 version = "0.1.0"
 edition.workspace = true

--- a/crates/aura-os-integrations/Cargo.toml
+++ b/crates/aura-os-integrations/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[package]
+[package]
 name = "aura-os-integrations"
 version = "0.1.0"
 edition.workspace = true

--- a/infra/scripts/release/desktop-release-artifacts-validate.mjs
+++ b/infra/scripts/release/desktop-release-artifacts-validate.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const SIGNED_SUFFIXES = [
+  ".app.tar.gz",
+  ".AppImage",
+  ".deb",
+  ".dmg",
+  ".exe",
+  ".msi",
+];
+
+function parseArgs(argv) {
+  const options = {
+    dist: "",
+    channel: "",
+    version: "",
+    target: "",
+    arch: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--dist") {
+      options.dist = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--channel") {
+      options.channel = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--version") {
+      options.version = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--target") {
+      options.target = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--arch") {
+      options.arch = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--help") {
+      console.log(
+        "Usage: node infra/scripts/release/desktop-release-artifacts-validate.mjs --dist DIR --channel nightly|stable --version VERSION --target linux|macos|windows --arch ARCH",
+      );
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  for (const [key, value] of Object.entries(options)) {
+    if (!value) {
+      throw new Error(`--${key.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)} is required`);
+    }
+  }
+
+  return options;
+}
+
+function isSignedArtifact(name) {
+  if (name.endsWith(".sig")) return false;
+  return SIGNED_SUFFIXES.some((suffix) => name.endsWith(suffix));
+}
+
+function assert(condition, message, errors) {
+  if (!condition) {
+    errors.push(message);
+  }
+}
+
+function readSummary(distDir, target, arch) {
+  const summaryName = `release-summary-${target}-${arch}.json`;
+  const summaryPath = path.join(distDir, summaryName);
+  if (!fs.existsSync(summaryPath)) {
+    return { summaryName, summaryPath, summary: null };
+  }
+
+  return {
+    summaryName,
+    summaryPath,
+    summary: JSON.parse(fs.readFileSync(summaryPath, "utf8")),
+  };
+}
+
+function expectedPrimaryArtifact({ target, arch, version }) {
+  if (target === "windows") {
+    return `aura-os-desktop_${version}_x64-setup.exe`;
+  }
+  if (target === "linux") {
+    return `aura-os-desktop_${version}_x86_64.AppImage`;
+  }
+  if (target === "macos") {
+    return `aura-os-desktop_${version}_${arch}.app.tar.gz`;
+  }
+  return null;
+}
+
+const options = parseArgs(process.argv.slice(2));
+const distDir = path.resolve(options.dist);
+const errors = [];
+
+assert(fs.existsSync(distDir), `artifact directory does not exist: ${distDir}`, errors);
+
+const entries = fs.existsSync(distDir)
+  ? fs.readdirSync(distDir, { withFileTypes: true }).filter((entry) => entry.isFile())
+  : [];
+const files = new Map(entries.map((entry) => [entry.name, path.join(distDir, entry.name)]));
+const signedArtifacts = [...files.keys()].filter(isSignedArtifact).sort();
+const signatures = [...files.keys()].filter((name) => name.endsWith(".sig")).sort();
+const primaryArtifact = expectedPrimaryArtifact(options);
+
+assert(signedArtifacts.length > 0, "no signed desktop artifacts were found", errors);
+if (primaryArtifact) {
+  assert(files.has(primaryArtifact), `missing primary updater artifact ${primaryArtifact}`, errors);
+}
+
+if (options.target === "windows") {
+  assert(!files.has("aura-os-desktop.exe"), "raw Windows binary leaked into release artifacts", errors);
+  assert(!files.has("aura-os-desktop.exe.sig"), "raw Windows binary signature leaked into release artifacts", errors);
+}
+
+for (const name of signedArtifacts) {
+  const filePath = files.get(name);
+  const size = fs.statSync(filePath).size;
+  assert(size > 0, `${name} is empty`, errors);
+  assert(name.includes(options.version), `${name} does not include version ${options.version}`, errors);
+  assert(files.has(`${name}.sig`), `${name} is missing updater signature ${name}.sig`, errors);
+}
+
+for (const name of signatures) {
+  const filePath = files.get(name);
+  const size = fs.statSync(filePath).size;
+  assert(size > 0, `${name} is empty`, errors);
+  assert(files.has(name.slice(0, -4)), `${name} does not have a matching artifact`, errors);
+}
+
+const { summaryName, summary, summaryPath } = readSummary(distDir, options.target, options.arch);
+assert(summary !== null, `missing ${summaryName}`, errors);
+if (summary) {
+  assert(summary.channel === options.channel, `${summaryName} channel is ${summary.channel ?? "missing"}`, errors);
+  assert(summary.version === options.version, `${summaryName} version is ${summary.version ?? "missing"}`, errors);
+  const summaryNames = new Set((summary.artifacts ?? []).map((artifact) => artifact.name));
+  for (const name of signedArtifacts) {
+    assert(summaryNames.has(name), `${summaryName} does not include ${name}`, errors);
+  }
+  for (const name of signatures) {
+    assert(summaryNames.has(name), `${summaryName} does not include ${name}`, errors);
+  }
+}
+
+const checksumName = `checksums-${options.target}-${options.arch}.txt`;
+const checksumPath = path.join(distDir, checksumName);
+assert(files.has(checksumName), `missing ${checksumName}`, errors);
+if (files.has(checksumName)) {
+  const checksums = fs.readFileSync(checksumPath, "utf8");
+  for (const name of signedArtifacts) {
+    assert(checksums.includes(`  ${name}`), `${checksumName} does not include ${name}`, errors);
+  }
+}
+
+const result = {
+  ok: errors.length === 0,
+  channel: options.channel,
+  version: options.version,
+  target: options.target,
+  arch: options.arch,
+  distDir,
+  signedArtifacts,
+  signatures,
+  summaryPath,
+  checksumPath,
+  errors,
+};
+
+console.log(JSON.stringify(result, null, 2));
+
+if (errors.length > 0) {
+  process.exit(1);
+}

--- a/infra/scripts/release/prepare-desktop-sidecar.mjs
+++ b/infra/scripts/release/prepare-desktop-sidecar.mjs
@@ -124,14 +124,14 @@ function sidecarBuildEnv() {
 function printBuildEnv(env) {
   console.log(JSON.stringify({
     sidecarBuildEnv: {
-      rustc: env.RUSTC ?? null,
-      cargo: env.CARGO ?? null,
-      rustcWrapper: env.RUSTC_WRAPPER ?? null,
-      cargoBuildRustcWrapper: env.CARGO_BUILD_RUSTC_WRAPPER ?? null,
-      sccachePath: env.SCCACHE_PATH ?? null,
-      cargoTargetDir: env.CARGO_TARGET_DIR ?? null,
-      sccacheGhaEnabled: env.SCCACHE_GHA_ENABLED ?? null,
-      sccacheWebdavEndpoint: env.SCCACHE_WEBDAV_ENDPOINT ?? null,
+      rustcSet: Boolean(env.RUSTC),
+      cargoSet: Boolean(env.CARGO),
+      rustcWrapperSet: Boolean(env.RUSTC_WRAPPER),
+      cargoBuildRustcWrapperSet: Boolean(env.CARGO_BUILD_RUSTC_WRAPPER),
+      sccachePathSet: Boolean(env.SCCACHE_PATH),
+      cargoTargetDirSet: Boolean(env.CARGO_TARGET_DIR),
+      sccacheGhaEnabledSet: Boolean(env.SCCACHE_GHA_ENABLED),
+      sccacheWebdavEndpointSet: Boolean(env.SCCACHE_WEBDAV_ENDPOINT),
     },
   }, null, 2));
 }

--- a/infra/scripts/release/prepare-desktop-sidecar.mjs
+++ b/infra/scripts/release/prepare-desktop-sidecar.mjs
@@ -98,6 +98,44 @@ function run(command, args, options = {}) {
   }
 }
 
+export function normalizeSccacheWrapperPath(wrapperPath, platform = process.platform) {
+  if (!wrapperPath || platform !== "win32") {
+    return wrapperPath;
+  }
+
+  let normalized = wrapperPath.replaceAll("/", "\\");
+  if (!normalized.toLowerCase().endsWith(".exe")) {
+    normalized = `${normalized}.exe`;
+  }
+  return path.win32.normalize(normalized);
+}
+
+function sidecarBuildEnv() {
+  const env = { ...process.env };
+  if (env.SCCACHE_PATH && env.RUSTC_WRAPPER === "sccache") {
+    env.RUSTC_WRAPPER = normalizeSccacheWrapperPath(env.SCCACHE_PATH);
+  }
+  if (env.RUSTC_WRAPPER && !env.CARGO_BUILD_RUSTC_WRAPPER) {
+    env.CARGO_BUILD_RUSTC_WRAPPER = env.RUSTC_WRAPPER;
+  }
+  return env;
+}
+
+function printBuildEnv(env) {
+  console.log(JSON.stringify({
+    sidecarBuildEnv: {
+      rustc: env.RUSTC ?? null,
+      cargo: env.CARGO ?? null,
+      rustcWrapper: env.RUSTC_WRAPPER ?? null,
+      cargoBuildRustcWrapper: env.CARGO_BUILD_RUSTC_WRAPPER ?? null,
+      sccachePath: env.SCCACHE_PATH ?? null,
+      cargoTargetDir: env.CARGO_TARGET_DIR ?? null,
+      sccacheGhaEnabled: env.SCCACHE_GHA_ENABLED ?? null,
+      sccacheWebdavEndpoint: env.SCCACHE_WEBDAV_ENDPOINT ?? null,
+    },
+  }, null, 2));
+}
+
 function parseArgs(argv) {
   return {
     checkOnly: argv.includes("--check"),
@@ -131,6 +169,9 @@ function main() {
     return;
   }
 
+  const buildEnv = sidecarBuildEnv();
+  printBuildEnv(buildEnv);
+
   run(
     "cargo",
     [
@@ -145,7 +186,7 @@ function main() {
     ],
     {
       cwd: harnessDir,
-      env: process.env,
+      env: buildEnv,
     },
   );
 

--- a/infra/scripts/release/prepare-desktop-sidecar.test.mjs
+++ b/infra/scripts/release/prepare-desktop-sidecar.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveSidecarPackage } from "./prepare-desktop-sidecar.mjs";
+import {
+  normalizeSccacheWrapperPath,
+  resolveSidecarPackage,
+} from "./prepare-desktop-sidecar.mjs";
 
 function metadataWithPackage(packageName, targetName = "aura-node") {
   return {
@@ -44,5 +47,19 @@ test("rejects ambiguous aura-node binary owners", () => {
   assert.throws(
     () => resolveSidecarPackage(metadata, "aura-node"),
     /multiple harness packages expose bin aura-node: aura-runtime, aura-node/,
+  );
+});
+
+test("normalizes Windows sccache wrapper path to executable form", () => {
+  assert.equal(
+    normalizeSccacheWrapperPath("C:\\hostedtoolcache\\windows\\sccache\\0.15.0\\x64/sccache", "win32"),
+    "C:\\hostedtoolcache\\windows\\sccache\\0.15.0\\x64\\sccache.exe",
+  );
+});
+
+test("leaves non-Windows sccache wrapper path unchanged", () => {
+  assert.equal(
+    normalizeSccacheWrapperPath("/opt/sccache/sccache", "linux"),
+    "/opt/sccache/sccache",
   );
 });

--- a/infra/scripts/release/prune-release-assets-with-retry.sh
+++ b/infra/scripts/release/prune-release-assets-with-retry.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+dry_run=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=1
+  shift
+fi
+
 if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <repo> <tag>" >&2
+  echo "Usage: $0 [--dry-run] <repo> <tag>" >&2
   exit 2
 fi
 
@@ -68,6 +74,12 @@ if [[ -z "$release_id" ]]; then
 fi
 
 asset_ids="$(gh_api_with_retry --paginate "repos/${repo}/releases/${release_id}/assets" --jq '.[].id')"
+if (( dry_run == 1 )); then
+  count="$(grep -cve '^[[:space:]]*$' <<<"$asset_ids" || true)"
+  echo "Dry run: would prune ${count} asset(s) from release ${tag} in ${repo}."
+  exit 0
+fi
+
 while read -r asset_id; do
   [[ -n "$asset_id" ]] || continue
   delete_release_asset "$asset_id"

--- a/infra/scripts/release/upload-release-assets-with-retry.sh
+++ b/infra/scripts/release/upload-release-assets-with-retry.sh
@@ -8,8 +8,14 @@ set -euo pipefail
 # missing or whose remote size does not match the local file, using
 # `gh release upload --clobber`.
 
+dry_run=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=1
+  shift
+fi
+
 if [[ $# -ne 3 ]]; then
-  echo "Usage: $0 <repo> <tag> <source-dir>" >&2
+  echo "Usage: $0 [--dry-run] <repo> <tag> <source-dir>" >&2
   exit 2
 fi
 
@@ -81,10 +87,36 @@ upload_asset_with_retry() {
   done
 }
 
-release_id="$(gh api "repos/${repo}/releases/tags/${tag}" --jq '.id' 2>/dev/null || true)"
-if [[ -z "$release_id" ]]; then
-  echo "No release found for tag ${tag}; cannot reconcile assets." >&2
-  exit 1
+if (( dry_run == 1 )); then
+  manifest="$(mktemp)"
+  trap 'rm -f "$manifest"' EXIT
+  count=0
+  while IFS= read -r -d '' file; do
+    name="$(basename "$file")"
+    printf '%s\t%s\t%s\n' "$name" "$(local_size "$file")" "$file" >> "$manifest"
+    count=$(( count + 1 ))
+  done < <(find "$source_dir" -type f -print0)
+
+  if (( count == 0 )); then
+    echo "No local files under ${source_dir}; nothing to reconcile."
+    exit 0
+  fi
+
+  duplicates="$(cut -f1 "$manifest" | sort | uniq -d || true)"
+  if [[ -n "$duplicates" ]]; then
+    echo "Refusing to reconcile: duplicate asset basenames detected under ${source_dir}:" >&2
+    while read -r name; do
+      [[ -n "$name" ]] || continue
+      printf '  %s\n' "$name" >&2
+    done <<<"$duplicates"
+    exit 2
+  fi
+
+  echo "Dry run: would reconcile ${count} asset(s) on release ${tag} in ${repo}."
+  sort "$manifest" | while IFS=$'\t' read -r name size _file; do
+    printf '  %s (%s bytes)\n' "$name" "$size"
+  done
+  exit 0
 fi
 
 declare -A local_files=()
@@ -108,6 +140,12 @@ fi
 if (( ${#local_files[@]} == 0 )); then
   echo "No local files under ${source_dir}; nothing to reconcile."
   exit 0
+fi
+
+release_id="$(gh api "repos/${repo}/releases/tags/${tag}" --jq '.id' 2>/dev/null || true)"
+if [[ -z "$release_id" ]]; then
+  echo "No release found for tag ${tag}; cannot reconcile assets." >&2
+  exit 1
 fi
 
 declare -A remote_sizes=()

--- a/scripts/ci/ci-perf-summary.mjs
+++ b/scripts/ci/ci-perf-summary.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const options = {
+    dir: "ci-perf",
+    outDir: "ci-perf",
+    title: "CI Performance Summary",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--dir") {
+      options.dir = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--out-dir") {
+      options.outDir = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--title") {
+      options.title = next || "";
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function walkFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return walkFiles(fullPath);
+    if (entry.isFile()) return [fullPath];
+    return [];
+  });
+}
+
+function readJsonLines(filePath) {
+  return fs.readFileSync(filePath, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function readSccacheStats(filePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    const stats = parsed.stats || parsed;
+    const hits = Object.values(stats.cache_hits?.counts || {}).reduce((sum, value) => sum + value, 0);
+    const misses = Object.values(stats.cache_misses?.counts || {}).reduce((sum, value) => sum + value, 0);
+    const total = hits + misses;
+    return {
+      file: path.basename(filePath),
+      compileRequests: stats.compile_requests ?? null,
+      hits,
+      misses,
+      hitRate: total > 0 ? hits / total : null,
+      cacheReadHitSeconds: stats.cache_read_hit_duration?.secs ?? null,
+      cacheWriteSeconds: stats.cache_write_duration?.secs ?? null,
+      compilerWriteSeconds: stats.compiler_write_duration?.secs ?? null,
+      cacheWrites: stats.cache_writes ?? null,
+      cacheWriteErrors: stats.cache_write_errors ?? null,
+      cacheLocation: parsed.cache_location || "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function seconds(ms) {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function percent(value) {
+  return value == null ? "" : `${(value * 100).toFixed(1)}%`;
+}
+
+function markdownTable(headers, rows) {
+  if (rows.length === 0) return "";
+  const header = `| ${headers.join(" | ")} |`;
+  const divider = `| ${headers.map(() => "---").join(" | ")} |`;
+  const body = rows.map((row) => `| ${row.join(" | ")} |`);
+  return [header, divider, ...body].join("\n");
+}
+
+const options = parseArgs(process.argv.slice(2));
+const files = walkFiles(options.dir);
+const stepRecords = files
+  .filter((file) => file.endsWith(".jsonl"))
+  .flatMap(readJsonLines)
+  .sort((left, right) => left.startedAt.localeCompare(right.startedAt));
+const sccacheRecords = files
+  .filter((file) => file.endsWith(".json") && path.basename(file).includes("sccache"))
+  .map(readSccacheStats)
+  .filter(Boolean);
+
+const totalDurationMs = stepRecords.reduce((sum, record) => sum + record.durationMs, 0);
+const failedSteps = stepRecords.filter((record) => record.status !== "success");
+const summary = {
+  generatedAt: new Date().toISOString(),
+  title: options.title,
+  totalMeasuredSeconds: Number((totalDurationMs / 1000).toFixed(3)),
+  stepCount: stepRecords.length,
+  failedStepCount: failedSteps.length,
+  steps: stepRecords,
+  sccache: sccacheRecords,
+};
+
+fs.mkdirSync(options.outDir, { recursive: true });
+fs.writeFileSync(path.join(options.outDir, "summary.json"), JSON.stringify(summary, null, 2), "utf8");
+
+const lines = [
+  `## ${options.title}`,
+  "",
+  `- Generated: ${summary.generatedAt}`,
+  `- Steps measured: ${summary.stepCount}`,
+  `- Total measured command time: ${(summary.totalMeasuredSeconds / 60).toFixed(2)} min`,
+  `- Failed steps: ${summary.failedStepCount}`,
+  "",
+];
+
+lines.push(markdownTable(
+  ["Step", "Duration", "Status", "Runner"],
+  stepRecords.map((record) => [
+    record.label,
+    seconds(record.durationMs),
+    record.status,
+    `${record.runner.os}/${record.runner.arch}`,
+  ]),
+));
+
+if (sccacheRecords.length > 0) {
+  lines.push("", "### sccache", "");
+  lines.push(markdownTable(
+    ["File", "Requests", "Hits", "Misses", "Hit Rate", "Read Hit", "Write", "Compiler"],
+    sccacheRecords.map((record) => [
+      record.file,
+      record.compileRequests ?? "",
+      record.hits,
+      record.misses,
+      percent(record.hitRate),
+      record.cacheReadHitSeconds == null ? "" : `${record.cacheReadHitSeconds}s`,
+      record.cacheWriteSeconds == null ? "" : `${record.cacheWriteSeconds}s`,
+      record.compilerWriteSeconds == null ? "" : `${record.compilerWriteSeconds}s`,
+    ]),
+  ));
+}
+
+const markdown = `${lines.filter((line) => line != null).join("\n")}\n`;
+fs.writeFileSync(path.join(options.outDir, "summary.md"), markdown, "utf8");
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${markdown}`, "utf8");
+}
+
+console.log(markdown);

--- a/scripts/ci/gh-run-timing-summary.mjs
+++ b/scripts/ci/gh-run-timing-summary.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const options = {
+    repo: process.env.GITHUB_REPOSITORY || "",
+    runId: process.env.GITHUB_RUN_ID || "",
+    outDir: "ci-run-timings",
+    topSteps: 20,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--repo") {
+      options.repo = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--run-id") {
+      options.runId = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--out-dir") {
+      options.outDir = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--top-steps") {
+      options.topSteps = Number(next);
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  if (!options.repo) {
+    throw new Error("--repo or GITHUB_REPOSITORY is required");
+  }
+  if (!options.runId) {
+    throw new Error("--run-id or GITHUB_RUN_ID is required");
+  }
+  if (!options.outDir) {
+    throw new Error("--out-dir is required");
+  }
+  if (!Number.isFinite(options.topSteps) || options.topSteps < 1) {
+    throw new Error("--top-steps must be a positive number");
+  }
+
+  return options;
+}
+
+function tokenFromGhCli() {
+  const result = spawnSync("gh", ["auth", "token"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0) return "";
+  return result.stdout.trim();
+}
+
+function resolveToken() {
+  return process.env.GITHUB_TOKEN || process.env.GH_TOKEN || tokenFromGhCli();
+}
+
+async function githubApi(pathname, query = {}) {
+  const apiBase = process.env.GITHUB_API_URL || "https://api.github.com";
+  const token = resolveToken();
+  if (!token) {
+    throw new Error("GITHUB_TOKEN/GH_TOKEN is required, or authenticate gh CLI first");
+  }
+
+  const url = new URL(`${apiBase}${pathname}`);
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, String(value));
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      Accept: "application/vnd.github+json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${response.status} for ${url}: ${body}`);
+  }
+
+  return response.json();
+}
+
+async function listAll(pathname, key) {
+  const items = [];
+  for (let page = 1; ; page += 1) {
+    const payload = await githubApi(pathname, { per_page: 100, page });
+    const pageItems = payload[key] ?? [];
+    items.push(...pageItems);
+    if (pageItems.length < 100) {
+      return items;
+    }
+  }
+}
+
+function parseTime(value) {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function durationMs(startedAt, completedAt) {
+  const startedMs = parseTime(startedAt);
+  const completedMs = parseTime(completedAt);
+  if (startedMs == null || completedMs == null || completedMs < startedMs) {
+    return null;
+  }
+  return completedMs - startedMs;
+}
+
+function formatDuration(ms) {
+  if (ms == null) return "";
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.floor(ms / 60_000)}m ${Math.round((ms % 60_000) / 1000)}s`;
+}
+
+function markdownTable(headers, rows) {
+  if (rows.length === 0) return "";
+  const header = `| ${headers.join(" | ")} |`;
+  const divider = `| ${headers.map(() => "---").join(" | ")} |`;
+  const body = rows.map((row) => `| ${row.join(" | ")} |`);
+  return [header, divider, ...body].join("\n");
+}
+
+function stepSummary(job) {
+  return (job.steps ?? []).map((step) => {
+    const ms = durationMs(step.started_at, step.completed_at);
+    return {
+      name: step.name,
+      number: step.number,
+      status: step.status,
+      conclusion: step.conclusion,
+      startedAt: step.started_at,
+      completedAt: step.completed_at,
+      durationMs: ms,
+      durationSeconds: ms == null ? null : Number((ms / 1000).toFixed(3)),
+    };
+  });
+}
+
+const options = parseArgs(process.argv.slice(2));
+const run = await githubApi(`/repos/${options.repo}/actions/runs/${options.runId}`);
+const jobs = await listAll(`/repos/${options.repo}/actions/runs/${options.runId}/jobs`, "jobs");
+
+const jobRecords = jobs.map((job) => {
+  const ms = durationMs(job.started_at, job.completed_at);
+  const steps = stepSummary(job);
+  const longestStep = steps
+    .filter((step) => step.durationMs != null)
+    .sort((left, right) => right.durationMs - left.durationMs)[0] ?? null;
+
+  return {
+    id: job.id,
+    name: job.name,
+    status: job.status,
+    conclusion: job.conclusion,
+    runnerName: job.runner_name || "",
+    runnerGroupName: job.runner_group_name || "",
+    labels: job.labels || [],
+    startedAt: job.started_at,
+    completedAt: job.completed_at,
+    durationMs: ms,
+    durationSeconds: ms == null ? null : Number((ms / 1000).toFixed(3)),
+    htmlUrl: job.html_url,
+    longestStep,
+    steps,
+  };
+});
+
+const wallMs = durationMs(run.created_at, run.updated_at);
+const allSteps = jobRecords.flatMap((job) =>
+  job.steps.map((step) => ({
+    job: job.name,
+    name: step.name,
+    conclusion: step.conclusion,
+    durationMs: step.durationMs,
+  }))
+).filter((step) => step.durationMs != null);
+const slowestSteps = allSteps
+  .sort((left, right) => right.durationMs - left.durationMs)
+  .slice(0, options.topSteps);
+const slowestJobs = [...jobRecords]
+  .filter((job) => job.durationMs != null)
+  .sort((left, right) => right.durationMs - left.durationMs);
+
+const summary = {
+  generatedAt: new Date().toISOString(),
+  repository: options.repo,
+  run: {
+    id: run.id,
+    name: run.name,
+    displayTitle: run.display_title,
+    event: run.event,
+    headBranch: run.head_branch,
+    headSha: run.head_sha,
+    status: run.status,
+    conclusion: run.conclusion,
+    createdAt: run.created_at,
+    updatedAt: run.updated_at,
+    wallDurationMs: wallMs,
+    wallDurationSeconds: wallMs == null ? null : Number((wallMs / 1000).toFixed(3)),
+    htmlUrl: run.html_url,
+  },
+  jobs: jobRecords,
+  slowestSteps,
+};
+
+fs.mkdirSync(options.outDir, { recursive: true });
+fs.writeFileSync(path.join(options.outDir, "summary.json"), JSON.stringify(summary, null, 2), "utf8");
+
+const lines = [
+  `## GitHub Run Timing Summary`,
+  "",
+  `- Run: [${run.name} #${run.run_number}](${run.html_url})`,
+  `- Title: ${run.display_title}`,
+  `- Status: ${run.status}/${run.conclusion ?? ""}`,
+  `- Wall time: ${formatDuration(wallMs)}`,
+  `- Head: ${run.head_branch} @ ${String(run.head_sha || "").slice(0, 12)}`,
+  `- Generated: ${summary.generatedAt}`,
+  "",
+  "### Longest Jobs",
+  "",
+  markdownTable(
+    ["Job", "Duration", "Conclusion", "Longest Step", "Runner"],
+    slowestJobs.map((job) => [
+      job.name,
+      formatDuration(job.durationMs),
+      job.conclusion ?? "",
+      job.longestStep ? `${job.longestStep.name} (${formatDuration(job.longestStep.durationMs)})` : "",
+      job.runnerName,
+    ]),
+  ),
+  "",
+  `### Slowest ${slowestSteps.length} Steps`,
+  "",
+  markdownTable(
+    ["Step", "Job", "Duration", "Conclusion"],
+    slowestSteps.map((step) => [
+      step.name,
+      step.job,
+      formatDuration(step.durationMs),
+      step.conclusion ?? "",
+    ]),
+  ),
+  "",
+];
+
+const markdown = `${lines.filter(Boolean).join("\n")}\n`;
+fs.writeFileSync(path.join(options.outDir, "summary.md"), markdown, "utf8");
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${markdown}`, "utf8");
+}
+
+console.log(markdown);

--- a/scripts/ci/patch-desktop-packager-config.mjs
+++ b/scripts/ci/patch-desktop-packager-config.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+const { values } = parseArgs({
+  options: {
+    "cargo-toml": { type: "string", default: "apps/aura-os-desktop/Cargo.toml" },
+    "binaries-dir": { type: "string" },
+    "strip-before-packaging": { type: "boolean", default: false },
+    "macos-signing-identity": { type: "string" },
+    "macos-signing-identity-env": { type: "string" },
+  },
+});
+
+const cargoTomlPath = values["cargo-toml"];
+let text = await readFile(cargoTomlPath, "utf8");
+let changed = false;
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function tomlString(value) {
+  return `"${String(value).replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+function upsertStringKey({ marker, key, value }) {
+  const line = `${key} = ${tomlString(value)}`;
+  const keyPattern = new RegExp(`^${escapeRegExp(key)}\\s*=\\s*".*"$`, "m");
+
+  if (keyPattern.test(text)) {
+    text = text.replace(keyPattern, line);
+    changed = true;
+    return;
+  }
+
+  if (!text.includes(marker)) {
+    throw new Error(`Missing ${marker.trim()} section in ${cargoTomlPath}`);
+  }
+
+  text = text.replace(marker, `${marker}${line}\n`);
+  changed = true;
+}
+
+if (values["binaries-dir"]) {
+  upsertStringKey({
+    marker: "[package.metadata.packager]\n",
+    key: "binaries-dir",
+    value: values["binaries-dir"],
+  });
+}
+
+if (values["strip-before-packaging"]) {
+  const next = text
+    .split(/\r?\n/)
+    .filter((line) => !line.trim().startsWith("before-packaging-command = "))
+    .join("\n");
+  if (next !== text.replace(/\r\n/g, "\n")) {
+    text = next;
+    changed = true;
+  }
+}
+
+const signingIdentityEnv = values["macos-signing-identity-env"];
+const signingIdentity =
+  values["macos-signing-identity"] ??
+  (signingIdentityEnv ? process.env[signingIdentityEnv] : undefined);
+
+if (signingIdentity) {
+  upsertStringKey({
+    marker: "[package.metadata.packager.macos]\n",
+    key: "signing-identity",
+    value: signingIdentity,
+  });
+}
+
+if (!changed) {
+  throw new Error("No packager config changes were requested or applied");
+}
+
+if (!text.endsWith("\n")) {
+  text += "\n";
+}
+
+await writeFile(cargoTomlPath, text, "utf8");

--- a/scripts/ci/perf-timer.mjs
+++ b/scripts/ci/perf-timer.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const options = {
+    label: "",
+    out: "ci-perf/steps.jsonl",
+    cwd: process.cwd(),
+    command: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--label") {
+      options.label = next || "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--out") {
+      options.out = next || "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--cwd") {
+      options.cwd = next || "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--") {
+      options.command = argv.slice(index + 1);
+      break;
+    }
+
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  if (!options.label) {
+    throw new Error("--label is required");
+  }
+  if (!options.out) {
+    throw new Error("--out is required");
+  }
+  if (options.command.length === 0) {
+    throw new Error("command is required after --");
+  }
+
+  return options;
+}
+
+function appendJsonLine(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function formatSeconds(ms) {
+  return (ms / 1000).toFixed(1);
+}
+
+const options = parseArgs(process.argv.slice(2));
+const startedAtMs = Date.now();
+const startedAt = new Date(startedAtMs).toISOString();
+const rendered = options.command.join(" ");
+
+console.log(`\n[ci-perf] ${options.label}: ${rendered}`);
+
+const result = spawnSync(options.command[0], options.command.slice(1), {
+  cwd: options.cwd,
+  env: process.env,
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+const completedAtMs = Date.now();
+const durationMs = completedAtMs - startedAtMs;
+const exitCode = result.status ?? (result.error ? 1 : 0);
+const record = {
+  label: options.label,
+  command: options.command,
+  cwd: path.resolve(options.cwd),
+  startedAt,
+  completedAt: new Date(completedAtMs).toISOString(),
+  durationMs,
+  durationSeconds: Number((durationMs / 1000).toFixed(3)),
+  exitCode,
+  status: exitCode === 0 ? "success" : "failure",
+  runner: {
+    os: process.env.RUNNER_OS || process.platform,
+    arch: process.env.RUNNER_ARCH || process.arch,
+    name: process.env.RUNNER_NAME || "",
+  },
+  github: {
+    workflow: process.env.GITHUB_WORKFLOW || "",
+    runId: process.env.GITHUB_RUN_ID || "",
+    job: process.env.GITHUB_JOB || "",
+    sha: process.env.GITHUB_SHA || "",
+    ref: process.env.GITHUB_REF || "",
+  },
+};
+
+appendJsonLine(options.out, record);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `- ${options.label}: ${formatSeconds(durationMs)}s (${record.status})\n`,
+    "utf8",
+  );
+}
+
+if (result.error) {
+  console.error(`[ci-perf] ${options.label} failed: ${result.error.message}`);
+}
+
+process.exit(exitCode);

--- a/scripts/ci/verify-desktop-release-binary.mjs
+++ b/scripts/ci/verify-desktop-release-binary.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const options = {
+    releaseDir: process.env.AURA_RELEASE_DIR || "",
+    target: "",
+    expectedChannel: "Stable",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--release-dir") {
+      options.releaseDir = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--target") {
+      options.target = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--expected-channel") {
+      options.expectedChannel = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--help") {
+      console.log(
+        "Usage: node scripts/ci/verify-desktop-release-binary.mjs --release-dir DIR --target linux|macos|windows [--expected-channel Stable]",
+      );
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  if (!options.releaseDir || !options.target || !options.expectedChannel) {
+    throw new Error("--release-dir, --target, and --expected-channel are required");
+  }
+
+  return options;
+}
+
+function fail(message) {
+  console.error(`\n[release-binary] ${message}`);
+  process.exit(1);
+}
+
+function assertContains(report, expected) {
+  if (!report.includes(expected)) {
+    fail(`channel report is missing ${expected}: ${report}`);
+  }
+}
+
+const options = parseArgs(process.argv.slice(2));
+const binaryName = options.target === "windows" ? "aura-os-desktop.exe" : "aura-os-desktop";
+const binaryPath = path.resolve(options.releaseDir, binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  fail(`expected release binary does not exist: ${binaryPath}`);
+}
+
+const stat = fs.statSync(binaryPath);
+if (!stat.isFile() || stat.size <= 0) {
+  fail(`expected release binary to be a non-empty file: ${binaryPath}`);
+}
+
+const result = spawnSync(binaryPath, ["--print-channel"], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+  env: {
+    ...process.env,
+    AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1",
+  },
+});
+
+if (result.error) {
+  fail(`unable to run ${binaryPath} --print-channel: ${result.error.message}`);
+}
+
+const report = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+if (result.status !== 0) {
+  fail(report || `${binaryPath} --print-channel exited with code ${result.status ?? 1}`);
+}
+
+const expectedPrefix = `channel=${options.expectedChannel} `;
+if (!report.startsWith(expectedPrefix)) {
+  fail(`expected channel report to start with ${expectedPrefix}, got: ${report}`);
+}
+
+assertContains(report, "updater_enabled=true");
+assertContains(report, "data_dir=aura");
+assertContains(report, 'window_title="AURA"');
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      binary: binaryPath,
+      sizeBytes: stat.size,
+      report,
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/ci/verify-release-preflight.mjs
+++ b/scripts/ci/verify-release-preflight.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  assertDesktopRuntime,
+  repoRoot,
+  run,
+} from "./lib/utils.mjs";
+
+const args = new Set(process.argv.slice(2));
+const withCargoCheck = args.has("--cargo-check");
+
+assertDesktopRuntime({ requireHarness: false });
+
+run("node", ["--check", "infra/scripts/release/desktop-local-auto-update-smoke.mjs"], {
+  cwd: repoRoot,
+  label: "preflight:desktop-auto-update-smoke-syntax",
+});
+run("node", ["--check", "infra/scripts/release/desktop-release-artifacts-validate.mjs"], {
+  cwd: repoRoot,
+  label: "preflight:desktop-artifact-validator-syntax",
+});
+run("node", ["--check", "scripts/ci/verify-desktop-release-binary.mjs"], {
+  cwd: repoRoot,
+  label: "preflight:desktop-release-binary-validator-syntax",
+});
+run("node", ["--test", "infra/scripts/release/desktop-frontend-assets-validate.test.mjs"], {
+  cwd: repoRoot,
+  label: "preflight:frontend-assets-test",
+});
+run("node", ["--test", "infra/scripts/release/prepare-desktop-sidecar.test.mjs"], {
+  cwd: repoRoot,
+  label: "preflight:sidecar-contract-test",
+});
+run("node", ["--test", "infra/scripts/release/desktop-manifest-validate.test.mjs"], {
+  cwd: repoRoot,
+  label: "preflight:manifest-test",
+});
+run("node", ["--test", "infra/scripts/release/desktop-downloads-validate.test.mjs"], {
+  cwd: repoRoot,
+  label: "preflight:downloads-test",
+});
+run(
+  "cargo",
+  [
+    "metadata",
+    "--format-version",
+    "1",
+    "--no-deps",
+    "--manifest-path",
+    "apps/aura-os-desktop/Cargo.toml",
+  ],
+  {
+    cwd: repoRoot,
+    label: "preflight:desktop-cargo-metadata",
+    stdio: ["ignore", "ignore", "inherit"],
+  },
+);
+
+if (withCargoCheck) {
+  const placeholderDist = resolve(repoRoot, "interface", "dist");
+  mkdirSync(placeholderDist, { recursive: true });
+  writeFileSync(
+    resolve(placeholderDist, "index.html"),
+    "<!doctype html><meta charset=\"utf-8\"><title>AURA CI preflight</title>\n",
+  );
+
+  run(
+    "cargo",
+    [
+      "check",
+      "--release",
+      "--no-default-features",
+      "--features",
+      "stable-channel",
+      "--package",
+      "aura-os-desktop",
+      "--target-dir",
+      "../.aura-preflight-target",
+    ],
+    {
+      cwd: repoRoot,
+      label: "preflight:desktop-cargo-check",
+      env: {
+        ...process.env,
+        AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1",
+      },
+    },
+  );
+}

--- a/scripts/ci/wait-gh-artifacts.mjs
+++ b/scripts/ci/wait-gh-artifacts.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+const args = process.argv.slice(2);
+
+const artifacts = [];
+const failJobs = [];
+let intervalMs = 15_000;
+let timeoutMs = 45 * 60_000;
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+  const value = args[index + 1];
+  if (arg === "--artifact") {
+    artifacts.push(value);
+    index += 1;
+  } else if (arg === "--fail-job") {
+    failJobs.push(value);
+    index += 1;
+  } else if (arg === "--interval-seconds") {
+    intervalMs = Number(value) * 1000;
+    index += 1;
+  } else if (arg === "--timeout-seconds") {
+    timeoutMs = Number(value) * 1000;
+    index += 1;
+  } else {
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+}
+
+if (artifacts.length === 0) {
+  throw new Error("At least one --artifact is required");
+}
+
+const repository = process.env.GITHUB_REPOSITORY;
+const runId = process.env.GITHUB_RUN_ID;
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const apiBase = process.env.GITHUB_API_URL || "https://api.github.com";
+
+if (!repository || !runId || !token) {
+  throw new Error("GITHUB_REPOSITORY, GITHUB_RUN_ID, and GITHUB_TOKEN/GH_TOKEN are required");
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function githubApi(pathname, query = {}) {
+  const url = new URL(`${apiBase}${pathname}`);
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, String(value));
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      Accept: "application/vnd.github+json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${response.status} for ${url}: ${body}`);
+  }
+
+  return response.json();
+}
+
+async function listAll(pathname, key) {
+  const items = [];
+  for (let page = 1; ; page += 1) {
+    const payload = await githubApi(pathname, { per_page: 100, page });
+    const pageItems = payload[key] ?? [];
+    items.push(...pageItems);
+    if (pageItems.length < 100) {
+      return items;
+    }
+  }
+}
+
+async function snapshot() {
+  const [artifactItems, jobItems] = await Promise.all([
+    listAll(`/repos/${repository}/actions/runs/${runId}/artifacts`, "artifacts"),
+    listAll(`/repos/${repository}/actions/runs/${runId}/jobs`, "jobs"),
+  ]);
+
+  const artifactNames = new Set(
+    artifactItems.filter((artifact) => !artifact.expired).map((artifact) => artifact.name),
+  );
+  const jobsByName = new Map(jobItems.map((job) => [job.name, job]));
+
+  return { artifactNames, jobsByName };
+}
+
+const deadline = Date.now() + timeoutMs;
+let lastStatus = "";
+
+while (Date.now() < deadline) {
+  const { artifactNames, jobsByName } = await snapshot();
+  const missingArtifacts = artifacts.filter((name) => !artifactNames.has(name));
+  const failedJobs = failJobs
+    .map((name) => jobsByName.get(name))
+    .filter((job) => job?.status === "completed" && job.conclusion !== "success" && job.conclusion !== "skipped");
+
+  if (failedJobs.length > 0) {
+    for (const job of failedJobs) {
+      console.error(`Required producer job failed: ${job.name} (${job.conclusion})`);
+    }
+    process.exit(1);
+  }
+
+  if (missingArtifacts.length === 0) {
+    console.log(`Found required artifacts: ${artifacts.join(", ")}`);
+    process.exit(0);
+  }
+
+  const producerStatus = failJobs
+    .map((name) => {
+      const job = jobsByName.get(name);
+      return `${name}: ${job?.status ?? "not-created"}${job?.conclusion ? `/${job.conclusion}` : ""}`;
+    })
+    .join("; ");
+  const status = `Waiting for artifacts: ${missingArtifacts.join(", ")}. ${producerStatus}`;
+  if (status !== lastStatus) {
+    console.log(status);
+    lastStatus = status;
+  }
+  await sleep(intervalMs);
+}
+
+console.error(`Timed out waiting for artifacts: ${artifacts.join(", ")}`);
+process.exit(1);


### PR DESCRIPTION
## Summary
- speed up desktop nightly/stable release CI by reusing prebuilt desktop binaries in package lanes and removing redundant desktop app builds
- split mobile nightly release out of the desktop release path and scope nightly concurrency by ref
- add validation-only/dry-run release checks for binaries, artifacts, update manifests, and release asset reconciliation
- add a manual CI performance benchmark workflow and timing helpers for repeatable measurements without publishing releases

## Verification
- actionlint .github/workflows/release-nightly.yml .github/workflows/release-stable.yml .github/workflows/release-mobile-nightly.yml .github/workflows/ci-performance-benchmark.yml .github/workflows/desktop-validate.yml
- node scripts/ci/verify-release-preflight.mjs
- branch proof Desktop Nightly Release run completed successfully in about 4m33 during iteration

## Notes
- This is a clean single-commit branch from latest origin/main; temporary benchmark trigger commits were intentionally left out.
- Release publishing remains gated; validation/dry-run paths can be exercised without updating gh-pages or publishing a live release.