### PR TITLE
Speed up nightly desktop release path

### DIFF
--- a/.github/workflows/ci-performance-benchmark.yml
+++ b/.github/workflows/ci-performance-benchmark.yml
@@ -219,12 +219,12 @@ jobs:
           name: ci-perf-interface-dist
           path: interface/dist
 
-      - name: Patch Cargo.toml version
+      - name: Write desktop release metadata
         if: inputs.platform == 'all' || inputs.platform == matrix.platform
         shell: bash
         run: |
-          sed -i.bak 's/^version = ".*"/version = "0.1.0-ci-perf.${{ github.run_number }}.1"/' apps/aura-os-desktop/Cargo.toml
-          rm -f apps/aura-os-desktop/Cargo.toml.bak
+          node scripts/ci/write-desktop-release-metadata.mjs \
+            --version "0.1.0-ci-perf.${{ github.run_number }}.1"
 
       - name: Build release binary
         if: inputs.platform == 'all' || inputs.platform == matrix.platform

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -221,6 +221,7 @@ jobs:
     env:
       CARGO_TARGET_DIR: ../.aura-shared-target
       AURA_RELEASE_DIR: ../.aura-shared-target/release
+      AURA_RELEASE_BINARY_CACHE_DIR: .ci-cache/desktop-release-bin
       MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
       MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
       MACOS_DEVELOPER_TEAM_ID: ${{ secrets.MACOS_DEVELOPER_TEAM_ID }}
@@ -309,9 +310,7 @@ jobs:
         id: desktop-release-binary-cache
         uses: actions/cache@v4
         with:
-          path: |
-            ../.aura-shared-target/release/aura-os-desktop
-            ../.aura-shared-target/release/aura-os-desktop.exe
+          path: .ci-cache/desktop-release-bin
           key: desktop-release-bin-v1-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '.github/actions/setup-rust-toolchain/**', 'apps/aura-os-desktop/Cargo.toml', 'apps/aura-os-desktop/build.rs', 'apps/aura-os-desktop/src/**/*.rs', 'apps/aura-os-desktop/assets/**', 'apps/aura-os-server/Cargo.toml', 'apps/aura-os-server/src/**/*.rs', 'apps/aura-os-ide/Cargo.toml', 'apps/aura-os-ide/src/**/*.rs', 'crates/**/Cargo.toml', 'crates/**/*.rs') }}-${{ steps.desktop-binary-cache-inputs.outputs.fingerprint }}
 
       - name: Install Rust toolchain
@@ -508,14 +507,32 @@ jobs:
         run: |
           cargo build --release --no-default-features --features stable-channel --package aura-os-desktop
 
-      - name: Validate cached release binary
+      - name: Store release binary for cache
+        if: steps.desktop-release-binary-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          binary_name="aura-os-desktop"
+          if [ "${{ matrix.target }}" = "windows" ]; then
+            binary_name="${binary_name}.exe"
+          fi
+          mkdir -p "$AURA_RELEASE_BINARY_CACHE_DIR"
+          cp "$AURA_RELEASE_DIR/$binary_name" "$AURA_RELEASE_BINARY_CACHE_DIR/$binary_name"
+          test -s "$AURA_RELEASE_BINARY_CACHE_DIR/$binary_name"
+
+      - name: Restore cached release binary
         if: steps.desktop-release-binary-cache.outputs.cache-hit == 'true'
         shell: bash
         run: |
-          binary="$AURA_RELEASE_DIR/aura-os-desktop"
+          binary_name="aura-os-desktop"
           if [ "${{ matrix.target }}" = "windows" ]; then
-            binary="${binary}.exe"
-          else
+            binary_name="${binary_name}.exe"
+          fi
+          cached_binary="$AURA_RELEASE_BINARY_CACHE_DIR/$binary_name"
+          binary="$AURA_RELEASE_DIR/$binary_name"
+          test -s "$cached_binary"
+          mkdir -p "$AURA_RELEASE_DIR"
+          cp "$cached_binary" "$binary"
+          if [ "${{ matrix.target }}" != "windows" ]; then
             chmod 755 "$binary"
           fi
           test -s "$binary"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -260,10 +260,65 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Compute desktop binary cache inputs
+        id: desktop-binary-cache-inputs
+        shell: bash
+        env:
+          CACHE_UPDATER_PUBLIC_KEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
+          CACHE_AURA_UPDATE_BASE_URL: ${{ env.AURA_UPDATE_BASE_URL }}
+          CACHE_AURA_NETWORK_URL: ${{ vars.AURA_NETWORK_URL }}
+          CACHE_AURA_STORAGE_URL: ${{ vars.AURA_STORAGE_URL }}
+          CACHE_AURA_INTEGRATIONS_URL: ${{ vars.AURA_INTEGRATIONS_URL }}
+          CACHE_AURA_ROUTER_URL: ${{ vars.AURA_ROUTER_URL }}
+          CACHE_Z_BILLING_URL: ${{ vars.Z_BILLING_URL }}
+          CACHE_ORBIT_BASE_URL: ${{ vars.ORBIT_BASE_URL }}
+          CACHE_SWARM_BASE_URL: ${{ vars.SWARM_BASE_URL }}
+          CACHE_REQUIRE_ZERO_PRO: ${{ vars.REQUIRE_ZERO_PRO }}
+          CACHE_AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN: ${{ vars.AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN }}
+          CACHE_VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
+          CACHE_Z_BILLING_API_KEY: ${{ secrets.Z_BILLING_API_KEY }}
+        run: |
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const crypto = require("node:crypto");
+          const names = [
+            "CACHE_UPDATER_PUBLIC_KEY",
+            "CACHE_AURA_UPDATE_BASE_URL",
+            "CACHE_AURA_NETWORK_URL",
+            "CACHE_AURA_STORAGE_URL",
+            "CACHE_AURA_INTEGRATIONS_URL",
+            "CACHE_AURA_ROUTER_URL",
+            "CACHE_Z_BILLING_URL",
+            "CACHE_ORBIT_BASE_URL",
+            "CACHE_SWARM_BASE_URL",
+            "CACHE_REQUIRE_ZERO_PRO",
+            "CACHE_AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN",
+            "CACHE_VITE_MIXPANEL_TOKEN",
+            "CACHE_Z_BILLING_API_KEY",
+          ];
+          const hash = crypto.createHash("sha256");
+          for (const name of names) {
+            hash.update(name);
+            hash.update("\0");
+            hash.update(process.env[name] || "");
+            hash.update("\0");
+          }
+          console.log(`fingerprint=${hash.digest("hex")}`);
+          NODE
+
+      - name: Restore desktop release binary cache
+        id: desktop-release-binary-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ../.aura-shared-target/release/aura-os-desktop
+            ../.aura-shared-target/release/aura-os-desktop.exe
+          key: desktop-release-bin-v1-${{ matrix.target }}-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '.github/actions/setup-rust-toolchain/**', 'apps/aura-os-desktop/Cargo.toml', 'apps/aura-os-desktop/build.rs', 'apps/aura-os-desktop/src/**/*.rs', 'apps/aura-os-desktop/assets/**', 'apps/aura-os-server/Cargo.toml', 'apps/aura-os-server/src/**/*.rs', 'apps/aura-os-ide/Cargo.toml', 'apps/aura-os-ide/src/**/*.rs', 'crates/**/Cargo.toml', 'crates/**/*.rs') }}-${{ steps.desktop-binary-cache-inputs.outputs.fingerprint }}
+
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust-toolchain
 
       - name: Restore desktop Rust cache
+        if: steps.desktop-release-binary-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: desktop-app-v3-${{ runner.os }}-${{ runner.arch }}
@@ -272,12 +327,13 @@ jobs:
           cache-on-failure: true
 
       - name: Set up sccache
+        if: steps.desktop-release-binary-cache.outputs.cache-hit != 'true'
         id: sccache-package
         uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
 
       - name: Configure sccache backend
-        if: steps.sccache-package.outcome == 'success'
+        if: steps.desktop-release-binary-cache.outputs.cache-hit != 'true' && steps.sccache-package.outcome == 'success'
         shell: bash
         env:
           DEPOT_CACHE_TOKEN: ${{ secrets.DEPOT_CACHE_TOKEN }}
@@ -313,25 +369,17 @@ jobs:
       - name: Check desktop runtime parity
         run: node scripts/ci/check-runtime.mjs desktop
 
-      - name: Patch Cargo.toml version
+      - name: Write desktop release metadata
         shell: bash
         run: |
-          VERSION="${{ needs.resolve-version.outputs.version }}"
-          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" apps/aura-os-desktop/Cargo.toml
-          rm -f apps/aura-os-desktop/Cargo.toml.bak
+          node scripts/ci/write-desktop-release-metadata.mjs \
+            --version "${{ needs.resolve-version.outputs.version }}"
 
       - name: Install cargo-packager
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-packager
           version: 0.11.8
-
-      - name: Prepare packager config
-        shell: bash
-        run: |
-          node scripts/ci/patch-desktop-packager-config.mjs \
-            --binaries-dir "../../../.aura-shared-target/release" \
-            --strip-before-packaging
 
       - name: Disable Spotlight indexing for DMG packaging
         if: matrix.target == 'macos'
@@ -428,6 +476,73 @@ jobs:
               fh.write(f"MACOS_SIGNING_IDENTITY={signing_identity}\n")
           PY
 
+      - name: Wait for interface build artifact
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/ci/wait-gh-artifacts.mjs \
+            --artifact "interface-dist-nightly" \
+            --interval-seconds 5 \
+            --fail-job "build-interface"
+
+      - name: Download interface dist
+        uses: actions/download-artifact@v5
+        with:
+          name: interface-dist-nightly
+          path: interface/dist
+
+      - name: Validate interface resources
+        shell: bash
+        run: |
+          test -d interface/dist
+          node infra/scripts/release/desktop-frontend-assets-validate.mjs --dist interface/dist
+
+      - name: Build release binary
+        if: steps.desktop-release-binary-cache.outputs.cache-hit != 'true'
+        env:
+          AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1"
+          AURA_UPDATE_BASE_URL: ${{ env.AURA_UPDATE_BASE_URL }}
+          UPDATER_PUBLIC_KEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
+        shell: bash
+        run: |
+          cargo build --release --no-default-features --features stable-channel --package aura-os-desktop
+
+      - name: Validate cached release binary
+        if: steps.desktop-release-binary-cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          binary="$AURA_RELEASE_DIR/aura-os-desktop"
+          if [ "${{ matrix.target }}" = "windows" ]; then
+            binary="${binary}.exe"
+          else
+            chmod 755 "$binary"
+          fi
+          test -s "$binary"
+
+      - name: Verify release binary channel
+        shell: bash
+        run: |
+          node scripts/ci/verify-desktop-release-binary.mjs \
+            --release-dir "$AURA_RELEASE_DIR" \
+            --target "${{ matrix.target }}" \
+            --expected-channel Stable \
+            --expected-version "${{ needs.resolve-version.outputs.version }}"
+
+      - name: Patch Cargo.toml version
+        shell: bash
+        run: |
+          VERSION="${{ needs.resolve-version.outputs.version }}"
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" apps/aura-os-desktop/Cargo.toml
+          rm -f apps/aura-os-desktop/Cargo.toml.bak
+
+      - name: Prepare packager config
+        shell: bash
+        run: |
+          node scripts/ci/patch-desktop-packager-config.mjs \
+            --binaries-dir "../../../.aura-shared-target/release" \
+            --strip-before-packaging
+
       - name: Inject macOS signing identity into packager config
         if: matrix.target == 'macos'
         shell: bash
@@ -439,16 +554,14 @@ jobs:
         if: matrix.target == 'macos'
         run: cargo metadata --no-deps --manifest-path apps/aura-os-desktop/Cargo.toml > /dev/null
 
-      - name: Wait for platform build artifacts
+      - name: Wait for sidecar artifact
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           node scripts/ci/wait-gh-artifacts.mjs \
-            --artifact "interface-dist-nightly" \
             --artifact "sidecar-${{ matrix.target }}-${{ matrix.arch }}" \
             --interval-seconds 5 \
-            --fail-job "build-interface" \
             --fail-job "build-sidecar (${{ matrix.os }}, ${{ matrix.target }}, ${{ matrix.arch }})"
 
       - name: Download sidecar artifact
@@ -457,12 +570,6 @@ jobs:
           name: sidecar-${{ matrix.target }}-${{ matrix.arch }}
           path: downloaded-sidecar
 
-      - name: Download interface dist
-        uses: actions/download-artifact@v5
-        with:
-          name: interface-dist-nightly
-          path: interface/dist
-
       - name: Restore packaged resources
         shell: bash
         run: |
@@ -470,28 +577,12 @@ jobs:
           mkdir -p apps/aura-os-desktop/resources
           tar -xf downloaded-sidecar/desktop-sidecar.tar -C apps/aura-os-desktop/resources
           test -d apps/aura-os-desktop/resources/sidecar
+          test -f apps/aura-os-desktop/resources/release.json
           test -d interface/dist
           node infra/scripts/release/desktop-frontend-assets-validate.mjs --dist interface/dist
           if [ "${{ matrix.target }}" != "windows" ]; then
             chmod 755 apps/aura-os-desktop/resources/sidecar/aura-node
           fi
-
-      - name: Build release binary
-        env:
-          AURA_DESKTOP_USE_PREBUILT_FRONTEND: "1"
-          AURA_UPDATE_BASE_URL: ${{ env.AURA_UPDATE_BASE_URL }}
-          UPDATER_PUBLIC_KEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
-        shell: bash
-        run: |
-          cargo build --release --no-default-features --features stable-channel --package aura-os-desktop
-
-      - name: Verify release binary channel
-        shell: bash
-        run: |
-          node scripts/ci/verify-desktop-release-binary.mjs \
-            --release-dir "$AURA_RELEASE_DIR" \
-            --target "${{ matrix.target }}" \
-            --expected-channel Stable
 
       - name: Package installer
         env:

--- a/apps/aura-os-desktop/src/handlers.rs
+++ b/apps/aura-os-desktop/src/handlers.rs
@@ -321,7 +321,7 @@ pub(crate) async fn get_update_status(
     Json(serde_json::json!({
         "update": *status,
         "channel": *channel,
-        "current_version": env!("CARGO_PKG_VERSION"),
+        "current_version": crate::release_version::current_version(),
         "supported": crate::updater::updater_supported(),
         "update_base_url": crate::updater::update_base_url(),
         "endpoint_template": endpoint_template,

--- a/apps/aura-os-desktop/src/harness/binary.rs
+++ b/apps/aura-os-desktop/src/harness/binary.rs
@@ -79,7 +79,7 @@ fn staged_harness_binary_name(source: &Path) -> String {
         .unwrap_or("aura-node");
     let suffix = format!(
         "{stem}-{}-{byte_len}-{modified_secs}",
-        env!("CARGO_PKG_VERSION")
+        crate::release_version::current_version()
     );
     match source.extension().and_then(|value| value.to_str()) {
         Some(ext) if !ext.is_empty() => format!("{suffix}.{ext}"),

--- a/apps/aura-os-desktop/src/init/cli.rs
+++ b/apps/aura-os-desktop/src/init/cli.rs
@@ -44,7 +44,8 @@ pub(crate) fn channel_report() -> String {
         Channel::Dev => "Dev",
     };
     format!(
-        "channel={label} data_dir={data} skills_home={skills} window_title=\"{title}\" mutex={mutex} desktop_port={port} updater_enabled={updater}",
+        "channel={label} version={version} data_dir={data} skills_home={skills} window_title=\"{title}\" mutex={mutex} desktop_port={port} updater_enabled={updater}",
+        version = crate::release_version::current_version(),
         data = channel.data_dir_name(),
         skills = channel.skills_home_name(),
         title = channel.window_title(),

--- a/apps/aura-os-desktop/src/main.rs
+++ b/apps/aura-os-desktop/src/main.rs
@@ -12,6 +12,7 @@ mod handlers;
 mod harness;
 mod init;
 mod net;
+mod release_version;
 mod route_state;
 mod ui;
 mod updater;

--- a/apps/aura-os-desktop/src/release_version.rs
+++ b/apps/aura-os-desktop/src/release_version.rs
@@ -1,0 +1,113 @@
+//! Runtime release version lookup.
+//!
+//! CI packages a small `resources/release.json` file with the installer version.
+//! Reading it at runtime keeps updater semantics tied to the shipped artifact
+//! version without forcing a full desktop binary rebuild for every nightly run
+//! number. Local/dev builds fall back to Cargo's package version.
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tracing::warn;
+
+#[derive(Debug, Deserialize)]
+struct ReleaseMetadata {
+    version: String,
+}
+
+static CURRENT_VERSION: OnceLock<String> = OnceLock::new();
+
+pub(crate) fn current_version() -> &'static str {
+    CURRENT_VERSION
+        .get_or_init(|| {
+            read_release_version().unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
+        })
+        .as_str()
+}
+
+fn read_release_version() -> Option<String> {
+    if let Ok(version) = std::env::var("AURA_DESKTOP_RELEASE_VERSION") {
+        let version = version.trim();
+        if !version.is_empty() {
+            return Some(version.to_string());
+        }
+    }
+
+    for path in release_metadata_candidates() {
+        if !path.is_file() {
+            continue;
+        }
+
+        match parse_release_metadata(&path) {
+            Ok(version) => return Some(version),
+            Err(error) => {
+                warn!(
+                    path = %path.display(),
+                    error = %error,
+                    "failed to read desktop release metadata; falling back to Cargo package version"
+                );
+            }
+        }
+    }
+
+    None
+}
+
+fn parse_release_metadata(path: &Path) -> Result<String, String> {
+    let bytes =
+        std::fs::read(path).map_err(|error| format!("failed to read release metadata: {error}"))?;
+    let metadata: ReleaseMetadata = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("failed to parse release metadata json: {error}"))?;
+    let version = metadata.version.trim();
+    if version.is_empty() {
+        return Err("release metadata version is empty".into());
+    }
+    Ok(version.to_string())
+}
+
+fn release_metadata_candidates() -> Vec<PathBuf> {
+    let mut candidates = vec![
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/release.json"),
+        PathBuf::from("apps/aura-os-desktop/resources/release.json"),
+        PathBuf::from("resources/release.json"),
+    ];
+
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(exe_dir) = current_exe.parent() {
+            candidates.push(exe_dir.join("release.json"));
+            candidates.push(exe_dir.join("resources/release.json"));
+            if let Some(contents_dir) = exe_dir.parent() {
+                candidates.push(contents_dir.join("Resources/release.json"));
+                candidates.push(contents_dir.join("Resources/resources/release.json"));
+            }
+        }
+    }
+
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_release_metadata;
+
+    #[test]
+    fn parses_release_metadata_version() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("release.json");
+        std::fs::write(&path, r#"{ "version": "0.1.0-nightly.620.1" }"#).expect("write");
+
+        assert_eq!(
+            parse_release_metadata(&path).expect("parse"),
+            "0.1.0-nightly.620.1"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_release_metadata_version() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("release.json");
+        std::fs::write(&path, r#"{ "version": " " }"#).expect("write");
+
+        assert!(parse_release_metadata(&path).is_err());
+    }
+}

--- a/apps/aura-os-desktop/src/updater/check.rs
+++ b/apps/aura-os-desktop/src/updater/check.rs
@@ -21,7 +21,7 @@ pub(super) fn check_for_available_update(
         .replace("{{arch}}", std::env::consts::ARCH);
     info!(
         %endpoint,
-        current_version = env!("CARGO_PKG_VERSION"),
+        current_version = crate::release_version::current_version(),
         %channel,
         "checking for updates"
     );

--- a/apps/aura-os-desktop/src/updater/endpoint.rs
+++ b/apps/aura-os-desktop/src/updater/endpoint.rs
@@ -81,7 +81,7 @@ fn updater_config(channel: UpdateChannel) -> Result<PackagerUpdaterConfig, Strin
 pub(super) fn build_updater(
     channel: UpdateChannel,
 ) -> Result<cargo_packager_updater::Updater, String> {
-    let current_version = SemverVersion::parse(env!("CARGO_PKG_VERSION"))
+    let current_version = SemverVersion::parse(crate::release_version::current_version())
         .map_err(|e| format!("invalid current version: {e}"))?;
     let config = updater_config(channel)?;
     UpdaterBuilder::new(current_version, config)

--- a/apps/aura-os-desktop/src/updater/mod.rs
+++ b/apps/aura-os-desktop/src/updater/mod.rs
@@ -178,7 +178,7 @@ impl UpdateState {
             data_dir: Arc::new(data_dir.to_path_buf()),
             shutdown_hook: Arc::new(RwLock::new(None)),
         };
-        reconcile::reconcile_persisted_state(&state, env!("CARGO_PKG_VERSION"));
+        reconcile::reconcile_persisted_state(&state, crate::release_version::current_version());
         state
     }
 

--- a/scripts/ci/verify-desktop-release-binary.mjs
+++ b/scripts/ci/verify-desktop-release-binary.mjs
@@ -9,6 +9,7 @@ function parseArgs(argv) {
     releaseDir: process.env.AURA_RELEASE_DIR || "",
     target: "",
     expectedChannel: "Stable",
+    expectedVersion: "",
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -29,9 +30,14 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (arg === "--expected-version") {
+      options.expectedVersion = next || "";
+      index += 1;
+      continue;
+    }
     if (arg === "--help") {
       console.log(
-        "Usage: node scripts/ci/verify-desktop-release-binary.mjs --release-dir DIR --target linux|macos|windows [--expected-channel Stable]",
+        "Usage: node scripts/ci/verify-desktop-release-binary.mjs --release-dir DIR --target linux|macos|windows [--expected-channel Stable] [--expected-version VERSION]",
       );
       process.exit(0);
     }
@@ -95,6 +101,9 @@ if (!report.startsWith(expectedPrefix)) {
 assertContains(report, "updater_enabled=true");
 assertContains(report, "data_dir=aura");
 assertContains(report, 'window_title="AURA"');
+if (options.expectedVersion) {
+  assertContains(report, `version=${options.expectedVersion}`);
+}
 
 console.log(
   JSON.stringify(

--- a/scripts/ci/verify-release-preflight.mjs
+++ b/scripts/ci/verify-release-preflight.mjs
@@ -27,6 +27,10 @@ run("node", ["--check", "scripts/ci/verify-desktop-release-binary.mjs"], {
   cwd: repoRoot,
   label: "preflight:desktop-release-binary-validator-syntax",
 });
+run("node", ["--check", "scripts/ci/write-desktop-release-metadata.mjs"], {
+  cwd: repoRoot,
+  label: "preflight:desktop-release-metadata-writer-syntax",
+});
 run("node", ["--test", "infra/scripts/release/desktop-frontend-assets-validate.test.mjs"], {
   cwd: repoRoot,
   label: "preflight:frontend-assets-test",

--- a/scripts/ci/write-desktop-release-metadata.mjs
+++ b/scripts/ci/write-desktop-release-metadata.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const options = {
+    version: "",
+    out: path.join("apps", "aura-os-desktop", "resources", "release.json"),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--version") {
+      options.version = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--out") {
+      options.out = next || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--help") {
+      console.log(
+        "Usage: node scripts/ci/write-desktop-release-metadata.mjs --version VERSION [--out apps/aura-os-desktop/resources/release.json]",
+      );
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  options.version = options.version.trim();
+  if (!options.version) {
+    throw new Error("--version is required");
+  }
+  if (!options.out) {
+    throw new Error("--out is required");
+  }
+  return options;
+}
+
+const options = parseArgs(process.argv.slice(2));
+const outputPath = path.resolve(options.out);
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify({ version: options.version }, null, 2)}\n`);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      version: options.version,
+      outputPath,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## Summary
- overlap desktop binary builds with sidecar builds instead of waiting for sidecar first
- add a versioned desktop release metadata resource so nightly run numbers do not force a binary rebuild
- add a platform desktop binary cache and verify cached/built binaries report the expected release version before packaging
- update the CI performance benchmark to measure the new version-resource path

## Verification
- `actionlint .github/workflows/release-nightly.yml .github/workflows/ci-performance-benchmark.yml`
- `node scripts/ci/verify-release-preflight.mjs`
- `cargo test -p aura-os-desktop release_version -- --nocapture`
- `AURA_DESKTOP_RELEASE_VERSION=0.1.0-nightly.smoke.1 AURA_DESKTOP_USE_PREBUILT_FRONTEND=1 cargo run --quiet --no-default-features --features stable-channel --package aura-os-desktop -- --print-channel`
- generated `resources/release.json` smoke with `verify-desktop-release-binary.mjs --expected-version`

## Notes
- CLI workflow dispatch is blocked for my token with HTTP 403, so this branch still needs a hosted dry-run dispatch from the GitHub UI.
- First run on `main` can still be a cache-miss run because branch caches generally do not warm `main`; this PR reduces that cold path by overlapping sidecar and desktop build work, then makes same-source reruns eligible for the binary-cache fast path.
