### PR TITLE
Preserve Google OAuth fields on integration updates

### DIFF
--- a/apps/aura-os-server/src/dto.rs
+++ b/apps/aura-os-server/src/dto.rs
@@ -548,17 +548,35 @@ pub(crate) struct CreateOrgIntegrationRequest {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct UpdateOrgIntegrationRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<aura_os_core::OrgIntegrationKind>,
-    #[serde(default, deserialize_with = "deserialize_patch_option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_patch_option"
+    )]
     pub default_model: Option<Option<String>>,
-    #[serde(default, deserialize_with = "deserialize_patch_option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_patch_option"
+    )]
     pub provider_config: Option<Option<serde_json::Value>>,
-    #[serde(default, deserialize_with = "deserialize_patch_option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_patch_option"
+    )]
     pub api_key: Option<Option<String>>,
-    #[serde(default, deserialize_with = "deserialize_patch_option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_patch_option"
+    )]
     pub enabled: Option<Option<bool>>,
 }
 
@@ -641,6 +659,56 @@ impl AuthSessionResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn update_integration_serializes_absent_patch_fields_as_omitted() {
+        let req = UpdateOrgIntegrationRequest {
+            name: Some("Google".to_string()),
+            provider: Some("google".to_string()),
+            kind: Some(aura_os_core::OrgIntegrationKind::WorkspaceIntegration),
+            default_model: None,
+            provider_config: None,
+            api_key: None,
+            enabled: None,
+        };
+
+        let body = serde_json::to_value(req).expect("serialize update request");
+
+        assert_eq!(
+            body,
+            json!({
+                "name": "Google",
+                "provider": "google",
+                "kind": "workspace_integration"
+            })
+        );
+    }
+
+    #[test]
+    fn update_integration_serializes_explicit_null_patch_fields() {
+        let req = UpdateOrgIntegrationRequest {
+            name: None,
+            provider: None,
+            kind: None,
+            default_model: Some(None),
+            provider_config: Some(None),
+            api_key: Some(None),
+            enabled: Some(None),
+        };
+
+        let body = serde_json::to_value(req).expect("serialize update request");
+
+        assert_eq!(
+            body,
+            json!({
+                "default_model": null,
+                "provider_config": null,
+                "api_key": null,
+                "enabled": null
+            })
+        );
+    }
 
     /// Frontend client (`interface/src/shared/api/tasks.ts`) and the
     /// aura-os-server integration tests POST `{ new_status: "..." }`.

--- a/interface/src/components/IntegrationEditor/IntegrationEditor.test.tsx
+++ b/interface/src/components/IntegrationEditor/IntegrationEditor.test.tsx
@@ -1,0 +1,93 @@
+import type { ComponentPropsWithoutRef, HTMLAttributes } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntegrationEditor } from "./IntegrationEditor";
+import type { OrgIntegration } from "../../shared/types";
+
+vi.mock("@cypher-asi/zui", () => ({
+  Button: ({ children, ...props }: ComponentPropsWithoutRef<"button">) => (
+    <button {...props}>{children}</button>
+  ),
+  Input: ({ ...props }: ComponentPropsWithoutRef<"input">) => (
+    <input {...props} />
+  ),
+  Text: ({ children, ...props }: HTMLAttributes<HTMLParagraphElement>) => (
+    <p {...props}>{children}</p>
+  ),
+}));
+
+function googleIntegration(overrides: Partial<OrgIntegration> = {}): OrgIntegration {
+  return {
+    integration_id: "int-google",
+    org_id: "org-1",
+    name: "Google",
+    provider: "google",
+    kind: "workspace_integration",
+    default_model: null,
+    has_secret: true,
+    enabled: true,
+    secret_last4: null,
+    provider_config: {
+      accountEmail: "google-user@example.com",
+      ownerUserId: "user-1",
+    },
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("IntegrationEditor", () => {
+  it("saves connected Google integrations without clearing OAuth credentials", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn().mockResolvedValue(null);
+
+    render(
+      <IntegrationEditor
+        provider="google"
+        integration={googleIntegration()}
+        canManage
+        busyId={null}
+        onCreate={vi.fn().mockResolvedValue(null)}
+        onUpdate={onUpdate}
+        onDelete={vi.fn().mockResolvedValue(undefined)}
+        onConnectGoogle={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    await user.clear(screen.getByLabelText(/Integration name for Google/i));
+    await user.type(screen.getByLabelText(/Integration name for Google/i), "My Google");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onUpdate).toHaveBeenCalledWith("int-google", {
+      name: "My Google",
+      provider: "google",
+      kind: "workspace_integration",
+      default_model: null,
+    });
+  });
+
+  it("starts Google reconnect without saving form fields", async () => {
+    const user = userEvent.setup();
+    const onConnectGoogle = vi.fn().mockResolvedValue(true);
+    const onUpdate = vi.fn().mockResolvedValue(null);
+
+    render(
+      <IntegrationEditor
+        provider="google"
+        integration={googleIntegration()}
+        canManage
+        busyId={null}
+        onCreate={vi.fn().mockResolvedValue(null)}
+        onUpdate={onUpdate}
+        onDelete={vi.fn().mockResolvedValue(undefined)}
+        onConnectGoogle={onConnectGoogle}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reconnect Google" }));
+
+    expect(onConnectGoogle).toHaveBeenCalledOnce();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/interface/tests/e2e/google-integration-ui.spec.ts
+++ b/interface/tests/e2e/google-integration-ui.spec.ts
@@ -89,6 +89,49 @@ test("connected Google integration clearly shows account, capabilities, and reco
   });
 });
 
+test("saving a connected Google integration preserves OAuth fields", async ({
+  page,
+}) => {
+  await mockAuthenticatedApp(page, {
+    integrations: [googleIntegration],
+    lastAppId: "integrations",
+  });
+
+  let updateBody: Record<string, unknown> | null = null;
+  await page.route("**/api/orgs/org-1/integrations/int-google-1", async (route) => {
+    if (route.request().method() !== "PUT") {
+      await route.fallback();
+      return;
+    }
+
+    updateBody = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...googleIntegration,
+        name: String(updateBody?.name ?? googleIntegration.name),
+        updated_at: "2026-06-06T02:00:00.000Z",
+      }),
+    });
+  });
+
+  await page.goto("/integrations/google");
+
+  await page.getByLabel("Integration name for Google").fill("My Google");
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect
+    .poll(() => updateBody)
+    .toEqual({
+      name: "My Google",
+      provider: "google",
+      kind: "workspace_integration",
+      default_model: null,
+    });
+  await expect(page.getByText("google-user@example.com").first()).toBeVisible();
+});
+
 test("chat renders Google Gmail and Calendar tool usage with readable labels", async ({
   page,
 }, testInfo) => {


### PR DESCRIPTION
## Summary
- omit absent integration patch fields when Aura OS forwards updates to the canonical integrations service
- keep explicit null semantics for intentional clears
- add unit, component, and e2e coverage for connected Google Save preserving OAuth metadata/secret fields

## Tests
- `cargo test -p aura-os-server update_integration_serializes -- --nocapture`
- `npm --prefix interface test -- --run src/components/IntegrationEditor/IntegrationEditor.test.tsx src/components/OrgSettingsIntegrations.test.tsx`
- `npm --prefix interface run test:e2e -- tests/e2e/google-integration-ui.spec.ts`
