### PR TITLE
feat: add Claude Fable model support

### DIFF
--- a/interface/scripts/lib/benchmark-pricing.mjs
+++ b/interface/scripts/lib/benchmark-pricing.mjs
@@ -1,4 +1,10 @@
 const ANTHROPIC_MODEL_PRICING_PER_MTOK = {
+  "claude-fable-5": {
+    input: 10,
+    output: 50,
+    cacheWrite: 12.5,
+    cacheRead: 1,
+  },
   "claude-opus-4-8": {
     input: 5,
     output: 25,
@@ -296,6 +302,8 @@ function normalizeModelKey(model) {
   if (fireworksModel) return fireworksModel[1];
   const fireworksRouter = unprefixed.match(/^accounts\/fireworks\/routers\/(.+)$/);
   if (fireworksRouter) return fireworksRouter[1];
+  const auraClaude = unprefixed.match(/^aura-(claude-.+)$/);
+  if (auraClaude) return auraClaude[1];
   const auraFireworksModels = {
     "aura-kimi-k2-6": "kimi-k2p6",
     "aura-kimi-k2-5": "kimi-k2p5",

--- a/interface/src/constants/model-pricing.test.ts
+++ b/interface/src/constants/model-pricing.test.ts
@@ -11,6 +11,7 @@ import {
 describe("normalizePricingKey", () => {
   it("maps aura-managed ids to provider pricing keys", () => {
     expect(normalizePricingKey("aura-claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(normalizePricingKey("aura-claude-fable-5")).toBe("claude-fable-5");
     expect(normalizePricingKey("aura-gpt-5-5")).toBe("gpt-5.5");
     expect(normalizePricingKey("aura-gpt-5-4-mini")).toBe("gpt-5.4-mini");
     expect(normalizePricingKey("aura-kimi-k2-6")).toBe("kimi-k2p6");
@@ -51,6 +52,16 @@ describe("resolvePricing for Google Gemini", () => {
 });
 
 describe("getBilledPricing", () => {
+  it("resolves Claude Fable 5 at Anthropic's published rates", () => {
+    const base = resolvePricing("aura-claude-fable-5");
+    expect(base.provider).toBe("anthropic");
+    expect(base.model).toBe("claude-fable-5");
+    expect(base.input).toBe(10);
+    expect(base.output).toBe(50);
+    expect(base.cacheWrite).toBe(12.5);
+    expect(base.cacheRead).toBe(1);
+  });
+
   it("applies the 20% markup to base rates", () => {
     const base = resolvePricing("aura-claude-opus-4-8");
     const billed = getBilledPricing("aura-claude-opus-4-8");

--- a/interface/src/constants/model-pricing.ts
+++ b/interface/src/constants/model-pricing.ts
@@ -52,6 +52,7 @@ export interface SessionTokenUsage {
 }
 
 const ANTHROPIC_PRICING: Readonly<Record<string, ModelRates>> = {
+  "claude-fable-5": { input: 10, output: 50, cacheWrite: 12.5, cacheRead: 1 },
   "claude-opus-4-8": { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
   "claude-opus-4-7": { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
   "claude-opus-4-6": { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },

--- a/interface/src/constants/models.test.ts
+++ b/interface/src/constants/models.test.ts
@@ -115,6 +115,25 @@ describe("model persistence", () => {
     expect(loadPersistedModel("default", "gpt-5.5")).toBe("aura-gpt-5-5");
   });
 
+  it("normalizes raw Claude Fable 5 to the Aura-managed chat model", () => {
+    expect(loadPersistedModel("default", "claude-fable-5")).toBe(
+      "aura-claude-fable-5",
+    );
+  });
+
+  it("includes Claude Fable 5 in the Anthropic chat model list", () => {
+    const fable = availableModelsForAdapter("default").find(
+      (model) => model.id === "aura-claude-fable-5",
+    );
+
+    expect(fable).toMatchObject({
+      label: "Fable 5",
+      vendor: "anthropic",
+      creditMultiplier: 10,
+      contextWindow: 1_000_000,
+    });
+  });
+
   it("keeps image models out of the chat adapter model list", () => {
     expect(availableModelsForAdapter("default").map((m) => m.id)).not.toContain(
       "gpt-image-2",

--- a/interface/src/constants/models.ts
+++ b/interface/src/constants/models.ts
@@ -171,6 +171,21 @@ const LEGACY_HIDDEN_CHAT_MODELS: ModelOption[] = [
 export const AURA_MANAGED_CHAT_MODELS: ModelOption[] = [
   // ── Anthropic ───────────────────────────────────────────────
   {
+    id: "aura-claude-fable-5",
+    label: "Fable 5",
+    tier: "opus",
+    mode: "chat",
+    vendor: "anthropic",
+    creditMultiplier: 10,
+    contextWindow: 1_000_000,
+    efforts: ANTHROPIC_EFFORTS,
+    defaultEffort: "medium",
+    provider: "Anthropic",
+    description:
+      "Anthropic's Mythos-class model for demanding reasoning and long-horizon agentic work.",
+    featured: true,
+  },
+  {
     id: "aura-claude-opus-4-8",
     label: "Opus 4.8",
     tier: "opus",
@@ -843,6 +858,8 @@ const KNOWN_MODELS: ModelOption[] = [
 ];
 
 const LEGACY_AURA_MODEL_IDS: Record<string, string> = {
+  "claude-fable-5": "aura-claude-fable-5",
+  "aura-claude-fable-5": "aura-claude-fable-5",
   "aura-claude-opus-4-6": "aura-claude-opus-4-6",
   "claude-opus-4-8": "aura-claude-opus-4-8",
   "aura-claude-opus-4-8": "aura-claude-opus-4-8",

--- a/interface/src/lib/benchmark-pricing.test.ts
+++ b/interface/src/lib/benchmark-pricing.test.ts
@@ -16,6 +16,20 @@ describe("benchmark pricing", () => {
     expect(pricing.cacheRead).toBe(0.3);
   });
 
+  it("resolves Claude Fable 5 pricing for raw and Aura-managed ids", () => {
+    for (const model of ["claude-fable-5", "aura-claude-fable-5"]) {
+      const pricing = resolvePricing(model);
+
+      expect(pricing.provider).toBe("anthropic");
+      expect(pricing.source).toBe("anthropic-pricing");
+      expect(pricing.model).toBe("claude-fable-5");
+      expect(pricing.input).toBe(10);
+      expect(pricing.output).toBe(50);
+      expect(pricing.cacheWrite).toBe(12.5);
+      expect(pricing.cacheRead).toBe(1);
+    }
+  });
+
   it("marks unknown pricing explicitly instead of silently dropping it", () => {
     const pricing = resolvePricing("claude-unknown-next", "anthropic");
 


### PR DESCRIPTION
## Summary
- add Claude Fable 5 as an Aura-managed Anthropic model with 1M context and high-capability tiering
- add UI/model pricing for claude-fable-5 at $10 input / $50 output / $12.50 cache write / $1 cache read per MTok
- normalize Aura Claude IDs in benchmark pricing so aura-claude-fable-5 resolves correctly

## Research
- Anthropic docs list Claude Fable 5 as generally available on June 9, 2026 with API model ID `claude-fable-5`, 1M context, up to 128k output, and always-on adaptive thinking.
- Anthropic pricing lists Claude Fable 5 at $10/MTok input, $50/MTok output, $12.50/MTok 5m cache write, and $1/MTok cache hit.

## Tests
- `npm run test -- --run src/constants/models.test.ts src/constants/model-pricing.test.ts src/lib/benchmark-pricing.test.ts`