### PR TITLE
Fix chat prompt typing layout churn

### DIFF
--- a/interface/src/components/InputBarShell/InputBarShell.tsx
+++ b/interface/src/components/InputBarShell/InputBarShell.tsx
@@ -360,6 +360,29 @@ function InputBarShellInner(
     const el = textareaRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
     let lastWidth = el.clientWidth;
+    let frame: number | null = null;
+    let needsHeightOnly = false;
+    let needsFullResize = false;
+    const scheduleResize = (heightOnly: boolean) => {
+      if (heightOnly) {
+        needsHeightOnly = true;
+      } else {
+        needsFullResize = true;
+      }
+      if (frame != null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        const runFullResize = needsFullResize;
+        needsFullResize = false;
+        const runHeightOnly = needsHeightOnly;
+        needsHeightOnly = false;
+        if (runFullResize) {
+          autoResize();
+        } else if (runHeightOnly) {
+          applyHeightOnly();
+        }
+      });
+    };
     const ro = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const width = entry.contentRect.width;
@@ -374,15 +397,20 @@ function InputBarShellInner(
             // the anti-osc prediction by a sub-pixel. Consume the
             // lockout and only update the inline height.
             transitionLockoutRef.current--;
-            applyHeightOnly();
+            scheduleResize(true);
           } else {
-            autoResize();
+            scheduleResize(false);
           }
         }
       }
     });
     ro.observe(el);
-    return () => ro.disconnect();
+    return () => {
+      if (frame != null) {
+        window.cancelAnimationFrame(frame);
+      }
+      ro.disconnect();
+    };
   }, [autoResize, applyHeightOnly]);
 
   useEffect(() => {

--- a/interface/src/features/chat-ui/ChatInputBar/ChatInputBar.test.tsx
+++ b/interface/src/features/chat-ui/ChatInputBar/ChatInputBar.test.tsx
@@ -150,6 +150,39 @@ describe("ChatInputBar", () => {
     expect(onInputChange).toHaveBeenCalled();
   });
 
+  it("opens slash commands only for the trailing token", () => {
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = vi.fn();
+    const onInputChange = vi.fn();
+    try {
+      render(<ChatInputBar {...makeProps({ onInputChange })} />);
+
+      const textarea = screen.getByPlaceholderText("/ for commands, @ for context");
+      const promptWithPath = "inspect src/foo/bar";
+      fireEvent.change(textarea, {
+        target: {
+          value: promptWithPath,
+          selectionStart: promptWithPath.length,
+          selectionEnd: promptWithPath.length,
+        },
+      });
+      expect(screen.queryByText("Record Demo")).not.toBeInTheDocument();
+
+      const promptWithCommand = "please /rec";
+      fireEvent.change(textarea, {
+        target: {
+          value: promptWithCommand,
+          selectionStart: promptWithCommand.length,
+          selectionEnd: promptWithCommand.length,
+        },
+      });
+      expect(screen.getByText("Record Demo")).toBeInTheDocument();
+      expect(onInputChange).toHaveBeenLastCalledWith(promptWithCommand);
+    } finally {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
   it("calls onSend on Enter key (without shift)", async () => {
     const user = userEvent.setup();
     const onSend = vi.fn();

--- a/interface/src/features/chat-ui/ChatInputBar/ChatInputBar.tsx
+++ b/interface/src/features/chat-ui/ChatInputBar/ChatInputBar.tsx
@@ -80,6 +80,25 @@ export interface ChatInputBarHandle {
   isFocused?: () => boolean;
 }
 
+function getTrailingTriggerQuery(
+  value: string,
+  cursor: number,
+  trigger: "/" | "@",
+): { start: number; query: string } | null {
+  let tokenStart = cursor;
+  while (tokenStart > 0) {
+    const code = value.charCodeAt(tokenStart - 1);
+    if (code === 32 || code === 9 || code === 10 || code === 13) break;
+    tokenStart--;
+  }
+
+  if (value.charAt(tokenStart) !== trigger) return null;
+  return {
+    start: tokenStart,
+    query: value.slice(tokenStart + 1, cursor),
+  };
+}
+
 /**
  * Lazily fetches the rendered text the harness counted for each static
  * context bucket. Built by the surface that owns the chat (agent- vs
@@ -649,11 +668,10 @@ export const DesktopChatInputBar = memo(
         const el = shellRef.current?.getTextarea();
         if (!el) return;
         const cursor = el.selectionStart;
-        const textBefore = value.slice(0, cursor);
-        const slashMatch = textBefore.match(/(^|\s)\/(\S*)$/);
+        const slashMatch = getTrailingTriggerQuery(value, cursor, "/");
         if (slashMatch) {
-          slashStartRef.current = textBefore.lastIndexOf("/");
-          setSlashQuery(slashMatch[2]);
+          slashStartRef.current = slashMatch.start;
+          setSlashQuery(slashMatch.query);
           setSlashMenuOpen(true);
         } else if (slashMenuOpen) {
           setSlashMenuOpen(false);
@@ -667,11 +685,11 @@ export const DesktopChatInputBar = memo(
         // in practice — `@` and `/` are different leading tokens — so
         // no tie-breaking is needed here.
         if (canUseMentions) {
-          const mentionMatch = textBefore.match(/(^|\s)@(\S*)$/);
+          const mentionMatch = getTrailingTriggerQuery(value, cursor, "@");
           if (mentionMatch) {
             const wasClosed = !mentionMenuOpen;
-            mentionStartRef.current = textBefore.lastIndexOf("@");
-            setMentionQuery(mentionMatch[2]);
+            mentionStartRef.current = mentionMatch.start;
+            setMentionQuery(mentionMatch.query);
             setMentionMenuOpen(true);
             // Refresh the file listing the moment the menu opens so
             // newly-created files show up without waiting for the

--- a/interface/src/features/chat-ui/ChatPanel/ChatSurface.tsx
+++ b/interface/src/features/chat-ui/ChatPanel/ChatSurface.tsx
@@ -361,15 +361,24 @@ export function ChatSurface({
     const GAP_PX = 5;
     const INDICATOR_PX = 68;
     const pill = inputBar.querySelector<HTMLElement>('[data-input-pill="true"]');
+    let frame: number | null = null;
+    let lastIndicatorBottom: number | null = null;
+    let lastClearance: number | null = null;
+    let lastMaskCutoff: number | null = null;
     const apply = () => {
+      frame = null;
       const height = inputBar.getBoundingClientRect().height;
       if (height <= 0) return;
       const bottom = Math.round(height + GAP_PX);
-      area.style.setProperty("--streaming-indicator-bottom", `${bottom}px`);
-      area.style.setProperty(
-        "--chat-input-clearance",
-        `${bottom + INDICATOR_PX}px`,
-      );
+      const clearance = bottom + INDICATOR_PX;
+      if (lastIndicatorBottom !== bottom) {
+        area.style.setProperty("--streaming-indicator-bottom", `${bottom}px`);
+        lastIndicatorBottom = bottom;
+      }
+      if (lastClearance !== clearance) {
+        area.style.setProperty("--chat-input-clearance", `${clearance}px`);
+        lastClearance = clearance;
+      }
       // Clip the transcript at the actual input pill's vertical midline
       // (not the whole input section). Measured from the panel bottom so
       // the mask in `.messageArea` cuts content exactly through the middle
@@ -380,15 +389,23 @@ export function ChatSurface({
         const midFromBottom = Math.round(
           areaRect.bottom - (pillRect.top + pillRect.height / 2),
         );
-        if (midFromBottom > 0) {
+        if (midFromBottom > 0 && lastMaskCutoff !== midFromBottom) {
           area.style.setProperty("--chat-input-mask-cutoff", `${midFromBottom}px`);
+          lastMaskCutoff = midFromBottom;
         }
       }
     };
-    apply();
-    const ro = new ResizeObserver(apply);
+    const scheduleApply = () => {
+      if (frame != null) return;
+      frame = window.requestAnimationFrame(apply);
+    };
+    scheduleApply();
+    const ro = new ResizeObserver(scheduleApply);
     ro.observe(inputBar);
     return () => {
+      if (frame != null) {
+        window.cancelAnimationFrame(frame);
+      }
       ro.disconnect();
       area.style.removeProperty("--streaming-indicator-bottom");
       area.style.removeProperty("--chat-input-clearance");


### PR DESCRIPTION
## Summary
- Coalesce textarea and chat-surface ResizeObserver work into requestAnimationFrame so prompt typing does not trigger repeated synchronous layout work.
- Avoid redundant chat-surface CSS variable writes when measured values have not changed.
- Replace full-prefix slash/@ regex scans with a trailing-token parser, so paths like `src/foo/bar` do not churn command matching while typing.
- Add a regression test for slash command detection on trailing tokens only.

## Validation
- `npm run build`
- `npm test -- InputBarShell ChatInputBar --testNamePattern "opens slash commands only for the trailing token|InputBarShell"`
- Browser validation on `http://127.0.0.1:5173/chat?agent=552416d2-710c-4e74-b535-e13a23918732`: typed a 195-character prompt in the enabled remote-agent input; focus stayed in the textarea, it expanded to multiline, and no new warning/error logs appeared during typing.
- Browser validation for trigger parsing: `inspect src/foo/bar` did not open slash commands; `inspect src/foo/bar /rec` did open slash commands; no new warning/error logs appeared.

## Notes
- `npm run lint` still fails on the repository baseline (246 errors / 50 warnings), including pre-existing `react-hooks/refs` findings in `ChatSurface` and pre-existing hook dependency warnings in `ChatInputBar`. The changed hunks are not the source of those lint findings.
- The local dev server had older pre-fix ResizeObserver warnings and HMR noise in its historical log; the browser validation above filtered to logs produced during the post-fix typing windows.