### PR TITLE
fix(observability): publish live status snapshot

### DIFF
--- a/.github/workflows/aura-observability.yml
+++ b/.github/workflows/aura-observability.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   observability:
@@ -25,13 +25,13 @@ jobs:
         id: probes
         continue-on-error: true
         env:
-          AURA_STATUS_API_BASE_URL: ${{ secrets.AURA_STATUS_API_BASE_URL }}
-          AURA_STATUS_PUBLIC_BASE_URL: ${{ secrets.AURA_STATUS_PUBLIC_BASE_URL }}
+          AURA_STATUS_API_BASE_URL: ${{ secrets.AURA_STATUS_API_BASE_URL || vars.AURA_STATUS_API_BASE_URL || 'https://api.aura.ai' }}
+          AURA_STATUS_PUBLIC_BASE_URL: ${{ secrets.AURA_STATUS_PUBLIC_BASE_URL || vars.AURA_STATUS_PUBLIC_BASE_URL || 'https://aura.ai' }}
           AURA_STATUS_ACCESS_TOKEN: ${{ secrets.AURA_STATUS_ACCESS_TOKEN }}
           AURA_STATUS_USER_EMAIL: ${{ secrets.AURA_STATUS_USER_EMAIL }}
           AURA_STATUS_USER_PASSWORD: ${{ secrets.AURA_STATUS_USER_PASSWORD }}
-          AURA_STATUS_MODEL_IDS: ${{ vars.AURA_STATUS_MODEL_IDS }}
-          AURA_STATUS_IMAGE_MODEL: ${{ vars.AURA_STATUS_IMAGE_MODEL }}
+          AURA_STATUS_MODEL_IDS: ${{ secrets.AURA_STATUS_MODEL_IDS || vars.AURA_STATUS_MODEL_IDS }}
+          AURA_STATUS_IMAGE_MODEL: ${{ secrets.AURA_STATUS_IMAGE_MODEL || vars.AURA_STATUS_IMAGE_MODEL }}
           AURA_STATUS_ENVIRONMENT: production
         run: npm run status:probes
 
@@ -41,6 +41,24 @@ jobs:
           AURA_STATUS_ENVIRONMENT: production
           AURA_STATUS_SOURCE: github-actions
         run: npm run status:snapshot
+
+      - uses: actions/checkout@v5
+        if: always()
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+          path: pages
+
+      - name: Publish public observability snapshot
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p pages/observability
+          cp interface/public/observability/status.json pages/observability/status.json
+          bash infra/scripts/release/commit-gh-pages-with-retry.sh \
+            pages \
+            "Update observability status snapshot" \
+            observability/status.json
 
       - name: Upload observability snapshot
         if: always()

--- a/interface/src/api/marketing/status.ts
+++ b/interface/src/api/marketing/status.ts
@@ -57,10 +57,13 @@ export interface StatusSnapshot {
   readonly features: readonly StatusFeature[];
 }
 
-const STATUS_JSON_URL = "/observability/status.json";
+const LOCAL_STATUS_JSON_URL = "/observability/status.json";
+const PUBLISHED_STATUS_JSON_URL =
+  import.meta.env.VITE_AURA_STATUS_SNAPSHOT_URL ||
+  "https://cypher-asi.github.io/aura-os/observability/status.json";
 
-export async function getStatusSnapshot(): Promise<StatusSnapshot> {
-  const response = await fetch(STATUS_JSON_URL, {
+async function fetchStatusSnapshot(url: string): Promise<StatusSnapshot> {
+  const response = await fetch(url, {
     headers: { Accept: "application/json" },
     cache: "no-store",
   });
@@ -68,4 +71,19 @@ export async function getStatusSnapshot(): Promise<StatusSnapshot> {
     throw new Error(`Status snapshot failed with HTTP ${response.status}`);
   }
   return response.json() as Promise<StatusSnapshot>;
+}
+
+export async function getStatusSnapshot(): Promise<StatusSnapshot> {
+  try {
+    return await fetchStatusSnapshot(PUBLISHED_STATUS_JSON_URL);
+  } catch (publishedError) {
+    try {
+      return await fetchStatusSnapshot(LOCAL_STATUS_JSON_URL);
+    } catch (localError) {
+      const message =
+        publishedError instanceof Error ? publishedError.message : String(publishedError);
+      const localMessage = localError instanceof Error ? localError.message : String(localError);
+      throw new Error(`${message}; local fallback failed: ${localMessage}`);
+    }
+  }
 }

--- a/interface/src/views/marketing/StatusView/StatusView.test.tsx
+++ b/interface/src/views/marketing/StatusView/StatusView.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StatusView } from "./StatusView";
 import type { StatusSnapshot } from "../../../api/marketing/status";
 
+const PUBLISHED_STATUS_URL = "https://cypher-asi.github.io/aura-os/observability/status.json";
+
 const FIXTURE_SNAPSHOT: StatusSnapshot = {
   schemaVersion: 1,
   title: "Aura Observability",
@@ -93,7 +95,7 @@ const FIXTURE_SNAPSHOT: StatusSnapshot = {
 
 describe("StatusView", () => {
   beforeEach(() => {
-  vi.stubGlobal(
+    vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
@@ -118,7 +120,7 @@ describe("StatusView", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "/observability/status.json",
+      PUBLISHED_STATUS_URL,
       expect.objectContaining({
         cache: "no-store",
         headers: { Accept: "application/json" },
@@ -148,6 +150,39 @@ describe("StatusView", () => {
     expect(within(table).getByText("2/3")).toBeInTheDocument();
   });
 
+  it("falls back to the bundled snapshot when the published JSON is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          json: async () => ({}),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => FIXTURE_SNAPSHOT,
+        }),
+    );
+
+    render(<StatusView />);
+
+    await waitFor(() => {
+      expect(screen.getByText("github-actions")).toBeInTheDocument();
+    });
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      PUBLISHED_STATUS_URL,
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "/observability/status.json",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
   it("falls back to an unknown snapshot when the published JSON is unavailable", async () => {
     vi.stubGlobal(
       "fetch",
@@ -163,6 +198,7 @@ describe("StatusView", () => {
     await waitFor(() => {
       expect(screen.getByRole("status")).toHaveTextContent("HTTP 404");
     });
+    expect(fetch).toHaveBeenCalledTimes(2);
     expect(screen.getByText("No status snapshot has been published.")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- publish generated observability status snapshots to gh-pages
- fetch the public gh-pages snapshot before falling back to bundled JSON
- allow public status URL inputs to come from GitHub variables/defaults while keeping credentials secrets-only

## Testing
- npm test -- --run src/views/marketing/StatusView/StatusView.test.tsx
- npm run build
- node --check infra/evals/status/run-status-probes.mjs
- node --check infra/evals/status/build-status-snapshot.mjs
- ruby YAML parse for .github/workflows/aura-observability.yml