### PR TITLE
Fix observability health check coverage

### DIFF
--- a/.github/workflows/aura-observability.yml
+++ b/.github/workflows/aura-observability.yml
@@ -41,8 +41,9 @@ jobs:
             marketplace-agents,harness-health,active-streams,debug-projects,
             feedback-list,bug-reports-mine,feed-list,leaderboard,platform-stats,
             remote-agent-create,remote-agent-state,remote-agent-runtime,
-            image-generation-stream,live-benchmark-hello-world,eval-summary-artifacts,
-            public-setup,public-chat-stream,public-feedback-api,public-models-api,
+            image-generation-stream,model3d-generation-stream,video-generation-stream,
+            live-benchmark-hello-world,eval-summary-artifacts,
+            public-setup,public-chat-stream,public-feedback-api,
             public-blog-api,public-x402-models,public-x402-payment-challenge,
             public-observability-page,public-models-page,public-marketing-pages
         run: npm run status:probes

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -224,6 +224,7 @@ jobs:
 
   package:
     needs: [resolve-version, release-preflight]
+    environment: production
     env:
       CARGO_TARGET_DIR: ../.aura-shared-target
       AURA_RELEASE_DIR: ../.aura-shared-target/release
@@ -612,6 +613,7 @@ jobs:
           fi
 
       - name: Run desktop release observability probes
+        id: desktop_observability
         if: matrix.target == 'macos' && matrix.arch == 'aarch64'
         continue-on-error: true
         env:
@@ -626,12 +628,14 @@ jobs:
         run: |
           if [ -z "$AURA_STATUS_USER_EMAIL" ] || [ -z "$AURA_STATUS_USER_PASSWORD" ]; then
             echo "Skipping desktop observability probes because AURA_STATUS_USER_EMAIL/AURA_STATUS_USER_PASSWORD are not configured."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "ran=true" >> "$GITHUB_OUTPUT"
           npm run status:desktop-release
 
       - name: Upload desktop observability artifacts
-        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64'
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         uses: actions/upload-artifact@v5
         with:
           name: desktop-observability-nightly-${{ matrix.target }}-${{ matrix.arch }}
@@ -641,7 +645,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Build merged desktop observability snapshot
-        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64'
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         env:
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
           AURA_STATUS_PREVIOUS_SNAPSHOT: infra/evals/reports/status/previous/status.json
@@ -656,14 +660,14 @@ jobs:
           npm run status:snapshot
 
       - uses: actions/checkout@v5
-        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64'
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         with:
           ref: gh-pages
           fetch-depth: 0
           path: desktop-observability-pages
 
       - name: Publish merged desktop observability snapshot
-        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64'
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         shell: bash
         run: |
           mkdir -p desktop-observability-pages/observability

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -212,6 +212,7 @@ jobs:
 
   package:
     needs: release-preflight
+    environment: production
     env:
       CARGO_TARGET_DIR: ../.aura-shared-target
       AURA_RELEASE_DIR: ../.aura-shared-target/release
@@ -501,6 +502,7 @@ jobs:
             --expected-channel Stable
 
       - name: Run desktop release observability probes
+        id: desktop_observability
         if: matrix.target == 'macos' && matrix.arch == 'aarch64'
         continue-on-error: true
         env:
@@ -515,12 +517,14 @@ jobs:
         run: |
           if [ -z "$AURA_STATUS_USER_EMAIL" ] || [ -z "$AURA_STATUS_USER_PASSWORD" ]; then
             echo "Skipping desktop observability probes because AURA_STATUS_USER_EMAIL/AURA_STATUS_USER_PASSWORD are not configured."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "ran=true" >> "$GITHUB_OUTPUT"
           npm run status:desktop-release
 
       - name: Upload desktop observability artifacts
-        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64'
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         uses: actions/upload-artifact@v5
         with:
           name: desktop-observability-stable-${{ matrix.target }}-${{ matrix.arch }}
@@ -530,7 +534,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Build merged desktop observability snapshot
-        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64'
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         env:
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
           AURA_STATUS_PREVIOUS_SNAPSHOT: infra/evals/reports/status/previous/status.json
@@ -545,14 +549,14 @@ jobs:
           npm run status:snapshot
 
       - uses: actions/checkout@v5
-        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64'
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         with:
           ref: gh-pages
           fetch-depth: 0
           path: desktop-observability-pages
 
       - name: Publish merged desktop observability snapshot
-        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64'
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         shell: bash
         run: |
           mkdir -p desktop-observability-pages/observability

--- a/docs/aura-feature-health.md
+++ b/docs/aura-feature-health.md
@@ -97,12 +97,12 @@ the goal is to validate local `aura-network`, `aura-storage`, `orbit`, or local
 database behavior. Remote-agent checks should run through the hybrid or
 production path so local harness execution cannot mask deployed swarm failures.
 
-Default probe runs skip only high-cost optional media checks
-(`video-generation-stream`, `model3d-generation-stream`, and public equivalents
-if added). Run a deeper media sweep with:
+Default probe runs include every implemented check unless `--checks` is used to
+select a smaller set. The production browser/API lane runs media generation
+checks directly, including image, 3D, and video streams:
 
 ```sh
-npm run status:probes -- --base-url http://127.0.0.1:3190 --token "$AURA_STATUS_ACCESS_TOKEN" --include-expensive
+npm run status:probes -- --base-url http://127.0.0.1:3190 --token "$AURA_STATUS_ACCESS_TOKEN"
 ```
 
 For AURA OS public-mode page checks against the frontend dev server:
@@ -133,10 +133,10 @@ unknown state.
 be triggered manually. It runs probes with production secrets, builds the
 snapshot even when probes fail, and uploads the generated JSON/check artifacts.
 This scheduled workflow uses `AURA_STATUS_CHECKS` to restrict itself to checks
-that can be truthfully exercised against deployed website/API surfaces. It does
-not run desktop-loopback checks such as `local-agent-runtime`,
-`workspace-defaults`, `terminal-list`, or the local `model-matrix`; those belong
-to `status:desktop-release`.
+that can be truthfully exercised against deployed website/API surfaces. It runs
+the public media generation checks, but it does not run desktop-loopback checks
+such as `local-agent-runtime`, `workspace-defaults`, `terminal-list`, or the
+local `model-matrix`; those belong to `status:desktop-release`.
 
 The browser/API and desktop lanes publish to the same public path:
 `/observability/status.json`. Each lane first reads the previously published

--- a/infra/evals/status/check-expectations.json
+++ b/infra/evals/status/check-expectations.json
@@ -19,11 +19,10 @@
       "requiredEvidence": ["keys"]
     },
     "auth-validate": {
-      "description": "Auth validation refresh returns a user id and access state.",
-      "requiredEvidence": ["userIdPresent", "accessGranted"],
+      "description": "Auth validation refresh returns a user id.",
+      "requiredEvidence": ["userIdPresent"],
       "assertions": [
-        { "path": "userIdPresent", "equals": true },
-        { "path": "accessGranted", "equals": true }
+        { "path": "userIdPresent", "equals": true }
       ]
     },
     "orgs-list": {
@@ -58,11 +57,6 @@
     "public-feedback-api": {
       "description": "Public feedback API returns a list count.",
       "requiredEvidence": ["count"]
-    },
-    "public-models-api": {
-      "description": "Public models API returns a list count.",
-      "requiredEvidence": ["count"],
-      "assertions": [{ "path": "count", "min": 1 }]
     },
     "public-blog-api": {
       "description": "Public blog API returns a list count.",

--- a/infra/evals/status/features.json
+++ b/infra/evals/status/features.json
@@ -44,7 +44,6 @@
         { "id": "public-setup", "required": true, "staleAfterMinutes": 20, "warningLatencyMs": 3000, "outageLatencyMs": 10000 },
         { "id": "public-chat-stream", "required": false, "staleAfterMinutes": 30, "warningLatencyMs": 25000, "outageLatencyMs": 90000 },
         { "id": "public-feedback-api", "required": false, "staleAfterMinutes": 30, "warningLatencyMs": 4000, "outageLatencyMs": 12000 },
-        { "id": "public-models-api", "required": false, "staleAfterMinutes": 30, "warningLatencyMs": 4000, "outageLatencyMs": 12000 },
         { "id": "public-blog-api", "required": false, "staleAfterMinutes": 30, "warningLatencyMs": 4000, "outageLatencyMs": 12000 },
         { "id": "public-x402-models", "required": false, "staleAfterMinutes": 30, "warningLatencyMs": 4000, "outageLatencyMs": 12000 },
         { "id": "public-x402-payment-challenge", "required": false, "staleAfterMinutes": 30, "warningLatencyMs": 4000, "outageLatencyMs": 12000 }
@@ -133,7 +132,7 @@
       "description": "Image, 3D, and video generation stream routers, progress frames, completion payloads, and artifact URLs.",
       "publicSummary": "Media generation streams can complete with generated artifacts.",
       "checks": [
-        { "id": "image-generation-stream", "required": true, "staleAfterMinutes": 30, "warningLatencyMs": 45000, "outageLatencyMs": 120000 },
+        { "id": "image-generation-stream", "required": true, "staleAfterMinutes": 30, "warningLatencyMs": 120000, "outageLatencyMs": 300000 },
         { "id": "model3d-generation-stream", "required": false, "staleAfterMinutes": 240, "warningLatencyMs": 90000, "outageLatencyMs": 240000 },
         { "id": "video-generation-stream", "required": false, "staleAfterMinutes": 240, "warningLatencyMs": 120000, "outageLatencyMs": 300000 }
       ],

--- a/infra/evals/status/lib/status-policy.test.mjs
+++ b/infra/evals/status/lib/status-policy.test.mjs
@@ -211,7 +211,7 @@ test("aggregateFeature reports the active severity reason before missing optiona
     category: "website",
     checks: [
       { id: "public-setup", required: true, staleAfterMinutes: 10 },
-      { id: "public-models-api", required: false, staleAfterMinutes: 10 },
+      { id: "public-blog-api", required: false, staleAfterMinutes: 10 },
     ],
     degradedAfterFailures: 1,
     outageAfterFailures: 2,
@@ -220,9 +220,9 @@ test("aggregateFeature reports the active severity reason before missing optiona
     feature,
     new Map([
       [
-        "public-models-api",
+        "public-blog-api",
         {
-          checkId: "public-models-api",
+          checkId: "public-blog-api",
           status: CHECK_STATUS.FAIL,
           message: "count expected >= 1 but got 0",
           endedAt: GENERATED_AT,

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -16,13 +16,6 @@ const DEFAULT_MODELS = [
   "aura-gpt-5-5",
   "aura-gemini-3-pro",
 ];
-const EXPENSIVE_CHECKS = new Set([
-  "video-generation-stream",
-  "model3d-generation-stream",
-  "public-video-generation-stream",
-  "public-model3d-generation-stream",
-]);
-
 function parseArgs(argv) {
   const args = {
     baseUrl: process.env.AURA_STATUS_API_BASE_URL || "http://127.0.0.1:3190",
@@ -37,7 +30,6 @@ function parseArgs(argv) {
     checks: (process.env.AURA_STATUS_CHECKS || "").split(",").map((v) => v.trim()).filter(Boolean),
     models: (process.env.AURA_STATUS_MODEL_IDS || "").split(",").map((v) => v.trim()).filter(Boolean),
     keepEntities: process.env.AURA_STATUS_KEEP_ENTITIES === "1",
-    includeExpensive: process.env.AURA_STATUS_INCLUDE_EXPENSIVE === "1",
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -57,9 +49,8 @@ function parseArgs(argv) {
     else if (arg === "--checks") args.checks = next().split(",").map((v) => v.trim()).filter(Boolean);
     else if (arg === "--models") args.models = next().split(",").map((v) => v.trim()).filter(Boolean);
     else if (arg === "--keep-entities") args.keepEntities = true;
-    else if (arg === "--include-expensive") args.includeExpensive = true;
     else if (arg === "--help") {
-      process.stdout.write("Usage: node infra/evals/status/run-status-probes.mjs [--base-url URL] [--token TOKEN] [--checks a,b] [--include-expensive]\n");
+      process.stdout.write("Usage: node infra/evals/status/run-status-probes.mjs [--base-url URL] [--token TOKEN] [--checks a,b]\n");
       process.exit(0);
     } else {
       throw new Error(`Unknown argument: ${arg}`);
@@ -413,7 +404,7 @@ async function waitForRemoteReady(args, agentId) {
 
 async function runChecks(args) {
   const checks = [];
-  const selected = (id) => (args.checks ? args.checks.has(id) : args.includeExpensive || !EXPENSIVE_CHECKS.has(id));
+  const selected = (id) => (args.checks ? args.checks.has(id) : true);
 
   if (selected("api-health")) {
     checks.push(await probe("api-health", "core-api", "API health endpoint", args, async () => {
@@ -434,7 +425,7 @@ async function runChecks(args) {
     checks.push(await probe("auth-validate", "identity-orgs", "Auth validation refresh", args, async () => {
       if (!args.token) return { status: CHECK_STATUS.SKIP, message: "No access token configured" };
       const session = await apiJson(args, "POST", "/api/auth/validate", {});
-      return { evidence: { userIdPresent: Boolean(session?.user_id), accessGranted: Boolean(session?.is_access_granted) } };
+      return { evidence: { userIdPresent: Boolean(session?.user_id) } };
     }));
   }
 
@@ -799,7 +790,7 @@ async function runChecks(args) {
         prompt: "A minimal black AURA status check glyph on a white background",
         model: process.env.AURA_STATUS_IMAGE_MODEL || "gpt-image-2",
         size: "1024x1024",
-      }, 180_000);
+      }, 360_000);
       const completed = frames.find((frame) => frame.event === "generation_completed");
       const error = frames.find((frame) => frame.event === "generation_error");
       if (error) {
@@ -886,13 +877,6 @@ async function runChecks(args) {
     checks.push(await probe("public-feedback-api", "public-experience", "Public feedback API", args, async () => {
       const feedback = await publicJson(args.baseUrl, "/api/public/feedback");
       return { evidence: { count: Array.isArray(feedback) ? feedback.length : null } };
-    }));
-  }
-
-  if (selected("public-models-api")) {
-    checks.push(await probe("public-models-api", "public-experience", "Public models API", args, async () => {
-      const models = await publicJson(args.baseUrl, "/api/public/models");
-      return { evidence: { count: collectionCount(models, ["models", "data"]) } };
     }));
   }
 

--- a/interface/public/observability/status.json
+++ b/interface/public/observability/status.json
@@ -122,9 +122,9 @@
       "status": "unknown",
       "lastCheckedAt": null,
       "checksPassed": 0,
-      "checksTotal": 7,
+      "checksTotal": 6,
       "checksFailed": 0,
-      "checksUnknown": 7,
+      "checksUnknown": 6,
       "latencyP95Ms": null,
       "message": "No recent result",
       "checks": [
@@ -150,16 +150,6 @@
         },
         {
           "id": "public-feedback-api",
-          "required": false,
-          "status": "unknown",
-          "featureStatus": "unknown",
-          "message": "No recent result",
-          "checkedAt": null,
-          "latencyMs": null,
-          "evidence": {}
-        },
-        {
-          "id": "public-models-api",
           "required": false,
           "status": "unknown",
           "featureStatus": "unknown",


### PR DESCRIPTION
## Summary
- remove the entitlement/access-granted assertion from auth health validation
- remove the empty legacy public models API check and keep x402 model discovery
- run media checks for image, 3D, and video in the production observability workflow
- expose production environment secrets to desktop release probes and avoid republishing stale desktop snapshots when probes do not run
- raise image generation latency/stream timeout to avoid marking slow successful image generation as an outage

## Validation
- node --test infra/evals/status/lib/*.test.mjs
- npm run evals:validate
- AURA_STATUS_CHECKS_DIR=/tmp/aura-status-x402 AURA_STATUS_API_BASE_URL=https://api.aura.ai node infra/evals/status/run-status-probes.mjs --checks public-x402-models