### PR TITLE
fix(observability): refresh full suite after releases

### DIFF
--- a/.github/workflows/aura-observability.yml
+++ b/.github/workflows/aura-observability.yml
@@ -3,6 +3,12 @@ name: AURA Observability
 on:
   schedule:
     - cron: "*/30 * * * *"
+  workflow_run:
+    workflows:
+      - Desktop Nightly Release
+      - Desktop Stable Release
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -10,6 +16,7 @@ permissions:
 
 jobs:
   observability:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment: production
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -644,20 +644,14 @@ jobs:
             desktop-observability-logs
           if-no-files-found: ignore
 
-      - name: Build merged desktop observability snapshot
+      - name: Build desktop observability snapshot
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         env:
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
-          AURA_STATUS_PREVIOUS_SNAPSHOT: infra/evals/reports/status/previous/status.json
           AURA_STATUS_ENVIRONMENT: production
           AURA_STATUS_SOURCE: desktop-nightly-release
         shell: bash
-        run: |
-          mkdir -p infra/evals/reports/status/previous
-          git fetch origin +gh-pages:refs/remotes/origin/gh-pages || true
-          git show origin/gh-pages:observability/status.json \
-            > infra/evals/reports/status/previous/status.json || true
-          npm run status:snapshot
+        run: npm run status:snapshot
 
       - uses: actions/checkout@v5
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
@@ -666,7 +660,7 @@ jobs:
           fetch-depth: 0
           path: desktop-observability-pages
 
-      - name: Publish merged desktop observability snapshot
+      - name: Publish desktop observability snapshot
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         shell: bash
         run: |

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -533,20 +533,14 @@ jobs:
             desktop-observability-logs
           if-no-files-found: ignore
 
-      - name: Build merged desktop observability snapshot
+      - name: Build desktop observability snapshot
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         env:
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
-          AURA_STATUS_PREVIOUS_SNAPSHOT: infra/evals/reports/status/previous/status.json
           AURA_STATUS_ENVIRONMENT: production
           AURA_STATUS_SOURCE: desktop-stable-release
         shell: bash
-        run: |
-          mkdir -p infra/evals/reports/status/previous
-          git fetch origin +gh-pages:refs/remotes/origin/gh-pages || true
-          git show origin/gh-pages:observability/status.json \
-            > infra/evals/reports/status/previous/status.json || true
-          npm run status:snapshot
+        run: npm run status:snapshot
 
       - uses: actions/checkout@v5
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
@@ -555,7 +549,7 @@ jobs:
           fetch-depth: 0
           path: desktop-observability-pages
 
-      - name: Publish merged desktop observability snapshot
+      - name: Publish desktop observability snapshot
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         shell: bash
         run: |

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -762,17 +762,27 @@ async function runChecks(args) {
       const results = [];
       const { orgId } = await requireOrgId(args);
       for (const model of args.models) {
-        const result = await withCleanup(args, async (track) => {
-          const agent = await createAgent(args, track, "local", model, orgId);
-          const runtime = await runRuntimeTest(args, agent.agent_id, 60_000);
-          return {
+        try {
+          const result = await withCleanup(args, async (track) => {
+            const agent = await createAgent(args, track, "local", model, orgId);
+            const runtime = await runRuntimeTest(args, agent.agent_id, 60_000);
+            return {
+              model,
+              ok: String(runtime?.message ?? "").toLowerCase().includes("hello from aura"),
+              provider: runtime?.provider ?? null,
+              resolvedModel: runtime?.model ?? null,
+            };
+          });
+          results.push(result);
+        } catch (error) {
+          results.push({
             model,
-            ok: String(runtime?.message ?? "").toLowerCase().includes("hello from aura"),
-            provider: runtime?.provider ?? null,
-            resolvedModel: runtime?.model ?? null,
-          };
-        });
-        results.push(result);
+            ok: false,
+            provider: null,
+            resolvedModel: null,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
       const passed = results.filter((result) => result.ok).length;
       return {


### PR DESCRIPTION
## Summary
- run the full Aura Observability workflow after successful desktop nightly/stable releases
- stop desktop release snapshots from carrying forward stale broad-check failures
- record per-model model-matrix failures so one provider/tool error does not hide the rest of the matrix

## Verification
- node --check infra/evals/status/run-status-probes.mjs
- git diff --check
- actionlint .github/workflows/aura-observability.yml .github/workflows/release-nightly.yml .github/workflows/release-stable.yml
- node --test infra/evals/status/lib/*.test.mjs