### PR TITLE
fix(observability): make status probes truthful

### DIFF
--- a/.github/workflows/aura-observability.yml
+++ b/.github/workflows/aura-observability.yml
@@ -48,8 +48,7 @@ jobs:
             marketplace-agents,harness-health,active-streams,debug-projects,
             feedback-list,bug-reports-mine,feed-list,leaderboard,platform-stats,
             remote-agent-create,remote-agent-state,remote-agent-runtime,
-            image-generation-stream,model3d-generation-stream,video-generation-stream,
-            live-benchmark-hello-world,eval-summary-artifacts,
+            image-generation-stream,eval-summary-artifacts,
             public-setup,public-chat-stream,public-feedback-api,
             public-blog-api,public-x402-models,public-x402-payment-challenge,
             public-observability-page,public-models-page,public-marketing-pages

--- a/apps/aura-os-server/src/handlers/agents/runtime.rs
+++ b/apps/aura-os-server/src/handlers/agents/runtime.rs
@@ -204,19 +204,7 @@ async fn run_harness_test(
     user_id: &str,
     model: Option<String>,
 ) -> ApiResult<RuntimeOutcome> {
-    let config = SessionConfig {
-        agent_system_prompt: Some(agent.system_prompt.clone()),
-        agent_id: Some(aura_os_core::harness_agent_id(&agent.agent_id, None, None)),
-        template_agent_id: Some(agent.agent_id.to_string()),
-        agent_name: Some(agent.name.clone()),
-        model: model.clone(),
-        token: Some(jwt.to_string()),
-        aura_org_id: agent.org_id.as_ref().map(ToString::to_string),
-        aura_session_id: Some(uuid::Uuid::new_v4().to_string()),
-        user_id: Some(user_id.to_string()),
-        provider_overrides: session_model_overrides(model.as_deref()),
-        ..Default::default()
-    };
+    let config = runtime_session_config(agent, jwt, user_id, model);
     validate_session_identity(
         &config,
         SessionIdentityRequirements::CHAT,
@@ -279,9 +267,36 @@ async fn run_harness_test(
     Ok(turn)
 }
 
+fn runtime_session_config(
+    agent: &Agent,
+    jwt: &str,
+    user_id: &str,
+    model: Option<String>,
+) -> SessionConfig {
+    SessionConfig {
+        agent_system_prompt: Some(agent.system_prompt.clone()),
+        agent_id: Some(aura_os_core::harness_agent_id(&agent.agent_id, None, None)),
+        template_agent_id: Some(agent.agent_id.to_string()),
+        agent_name: Some(agent.name.clone()),
+        model: model.clone(),
+        token: Some(jwt.to_string()),
+        aura_org_id: agent.org_id.as_ref().map(ToString::to_string),
+        aura_session_id: Some(uuid::Uuid::new_v4().to_string()),
+        user_id: Some(user_id.to_string()),
+        provider_overrides: session_model_overrides(model.as_deref()),
+        agent_permissions: (&agent.permissions).into(),
+        ..Default::default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aura_os_core::{
+        listing_status::AgentListingStatus, AgentPermissions, AgentScope, Capability, OrgId,
+    };
+    use aura_protocol::CapabilityWire;
+    use chrono::Utc;
 
     #[test]
     fn session_model_overrides_populates_default_model() {
@@ -318,6 +333,27 @@ mod tests {
         assert!(
             session_model_overrides_with_cache(Some(""), Some("  ".into()), Some("")).is_none()
         );
+    }
+
+    #[test]
+    fn runtime_session_config_forwards_agent_permissions() {
+        let agent = test_agent_with_permissions(AgentPermissions {
+            scope: AgentScope::default(),
+            capabilities: vec![Capability::InvokeProcess],
+        });
+
+        let config = runtime_session_config(&agent, "jwt", "user-1", Some("aura-gpt-5-5".into()));
+
+        assert_eq!(config.agent_permissions.capabilities.len(), 1);
+        assert!(matches!(
+            config.agent_permissions.capabilities[0],
+            CapabilityWire::InvokeProcess
+        ));
+        assert!(!config
+            .agent_permissions
+            .capabilities
+            .iter()
+            .any(|capability| matches!(capability, CapabilityWire::Unknown)));
     }
 
     fn council_body(mechanism: Option<&str>) -> CouncilRequestBody {
@@ -383,5 +419,42 @@ mod tests {
         )
         .expect("model + key should produce overrides");
         assert_eq!(overrides.prompt_cache_key.as_deref(), Some(long.as_str()));
+    }
+
+    fn test_agent_with_permissions(permissions: AgentPermissions) -> Agent {
+        let now = Utc::now();
+        Agent {
+            agent_id: AgentId::new(),
+            user_id: "user-1".into(),
+            org_id: Some(OrgId::new()),
+            name: "Status Probe".into(),
+            role: "status-probe".into(),
+            personality: "Deterministic".into(),
+            system_prompt: "Reply exactly as requested.".into(),
+            skills: vec![],
+            icon: None,
+            machine_type: "local".into(),
+            adapter_type: "aura_harness".into(),
+            environment: "local_host".into(),
+            auth_source: "aura_managed".into(),
+            integration_id: None,
+            default_model: None,
+            vm_id: None,
+            wallet_address: None,
+            network_agent_id: None,
+            profile_id: None,
+            tags: vec![],
+            is_pinned: false,
+            listing_status: AgentListingStatus::Closed,
+            expertise: vec![],
+            jobs: 0,
+            revenue_usd: 0.0,
+            reputation: 0.0,
+            local_workspace_path: None,
+            permissions,
+            intent_classifier: None,
+            created_at: now,
+            updated_at: now,
+        }
     }
 }

--- a/docs/aura-feature-health.md
+++ b/docs/aura-feature-health.md
@@ -48,7 +48,8 @@ npm run status:snapshot
 `AURA_STATUS_API_BASE_URL` selects the AURA API/control-plane host for cloud
 probes. Point it at `https://api.aura.ai` when the goal is to measure the
 deployed AURA API. It does not prove that the packaged desktop binary, embedded
-server, local harness, or local-agent runtime are healthy.
+server, local harness, local-agent runtime, or desktop-local model matrix are
+healthy.
 
 Desktop release observability is a separate lane. This is the only path that
 proves the packaged local harness path, because the harness is bundled with the
@@ -70,6 +71,11 @@ runtime response, and the local model matrix. Release workflows run this on the
 macOS arm64 release leg when `AURA_STATUS_USER_EMAIL` and
 `AURA_STATUS_USER_PASSWORD` are configured, then upload the generated check JSON
 and desktop logs as artifacts.
+
+The scheduled public observability workflow intentionally excludes
+desktop-loopback checks and generation modes that require a bundled harness
+runtime. It preserves fresh desktop-release check results from the previous
+published snapshot, then layers deployed API and public website probes on top.
 
 For end-to-end local verification, use the existing eval local stack in
 `infra/evals/local-stack/`. The observability page is not served from a sibling

--- a/infra/evals/status/features.json
+++ b/infra/evals/status/features.json
@@ -129,26 +129,10 @@
       "label": "Media Generation",
       "category": "media",
       "priority": 45,
-      "description": "Image, 3D, and video generation stream routers, progress frames, completion payloads, and artifact URLs.",
-      "publicSummary": "Media generation streams can complete with generated artifacts.",
+      "description": "Image generation stream routing, progress frames, completion payloads, and artifact URLs.",
+      "publicSummary": "AURA image generation streams can complete with generated artifacts.",
       "checks": [
-        { "id": "image-generation-stream", "required": true, "staleAfterMinutes": 30, "warningLatencyMs": 120000, "outageLatencyMs": 300000 },
-        { "id": "model3d-generation-stream", "required": false, "staleAfterMinutes": 240, "warningLatencyMs": 90000, "outageLatencyMs": 240000 },
-        { "id": "video-generation-stream", "required": false, "staleAfterMinutes": 240, "warningLatencyMs": 120000, "outageLatencyMs": 300000 }
-      ],
-      "degradedAfterFailures": 1,
-      "outageAfterFailures": 1
-    },
-    {
-      "id": "spec-task-loop",
-      "label": "Autonomous Build Loop",
-      "category": "automation",
-      "priority": 50,
-      "description": "End-to-end spec generation, task extraction, autonomous loop execution, and artifact validation.",
-      "publicSummary": "AURA can turn requirements into tasks and complete a small validated build.",
-      "checks": [
-        { "id": "live-benchmark-hello-world", "required": true, "staleAfterMinutes": 120, "warningLatencyMs": 240000, "outageLatencyMs": 600000 },
-        { "id": "harness-fixture-suite", "required": false, "staleAfterMinutes": 240, "warningLatencyMs": 120000, "outageLatencyMs": 300000 }
+        { "id": "image-generation-stream", "required": true, "staleAfterMinutes": 30, "warningLatencyMs": 180000, "outageLatencyMs": 360000 }
       ],
       "degradedAfterFailures": 1,
       "outageAfterFailures": 1

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -14,7 +14,6 @@ const DEFAULT_REMOTE_TIMEOUT_MS = 180_000;
 const DEFAULT_MODELS = [
   "aura-claude-sonnet-4-6",
   "aura-gpt-5-5",
-  "aura-gemini-3-pro",
 ];
 function parseArgs(argv) {
   const args = {


### PR DESCRIPTION
## Summary
- forward local agent runtime permissions into harness session config so status probes do not accidentally request unavailable tools
- make scheduled observability checks reflect currently supported public probes and remove stale artifact-only coverage
- keep image generation status truthful with current production latency expectations

## Verification
- cargo test -p aura-os-server runtime_session_config_forwards_agent_permissions
- node --test infra/evals/status/lib/status-policy.test.mjs
- build-status-snapshot registry validation for media-generation/spec-task-loop coverage
