### PR TITLE
fix(observability): use minimal status probe permissions

### DIFF
--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -62,19 +62,10 @@ function parseArgs(argv) {
   return args;
 }
 
-function fullAccessAgentPermissions() {
+function statusProbeAgentPermissions() {
   return {
     scope: { orgs: [], projects: [], agent_ids: [] },
-    capabilities: [
-      "spawnAgent",
-      "controlAgent",
-      "readAgent",
-      "listAgents",
-      "invokeProcess",
-      "generateMedia",
-      "readAllProjects",
-      "writeAllProjects",
-    ].map((type) => ({ type })),
+    capabilities: [],
   };
 }
 
@@ -375,7 +366,7 @@ async function createAgent(args, track, machineType, model = null, orgId = null)
     environment,
     auth_source: "aura_managed",
     default_model: model,
-    permissions: fullAccessAgentPermissions(),
+    permissions: statusProbeAgentPermissions(),
     tags: ["aura-status-probe"],
   }, { timeoutMs: machineType === "remote" ? DEFAULT_REMOTE_TIMEOUT_MS : DEFAULT_TIMEOUT_MS });
   track("agent", agent.agent_id, `/api/agents/${agent.agent_id}`);


### PR DESCRIPTION
## Summary
- create status probe agents with an explicit no-tool permission bundle
- keep local-agent and model-matrix checks focused on plain runtime responses
- avoid exposing computer-use to Claude for checks that do not need it

## Verification
- mock API run of local-agent-create, local-agent-runtime, and model-matrix asserted all created agents had empty capabilities
- node --test infra/evals/status/lib/status-policy.test.mjs infra/evals/status/lib/check-expectations.test.mjs
- build-status-snapshot registry validation
