### PR TITLE
fix(observability): scope status probe permissions

### DIFF
--- a/apps/aura-os-server/src/handlers/agents/crud/create.rs
+++ b/apps/aura-os-server/src/handlers/agents/crud/create.rs
@@ -200,7 +200,7 @@ fn trim_local_path(value: Option<&str>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aura_os_core::OrgId;
+    use aura_os_core::{AgentPermissions, AgentScope, OrgId};
 
     fn create_request(org_id: OrgId) -> CreateAgentRequest {
         CreateAgentRequest {
@@ -261,5 +261,26 @@ mod tests {
         apply_submitted_org_fallback(&mut agent, &prepared);
 
         assert_eq!(agent.org_id, Some(org_id));
+    }
+
+    #[test]
+    fn prepare_create_preserves_scoped_zero_capability_permissions() {
+        let org_id = OrgId::new();
+        let mut request = create_request(org_id);
+        request.permissions = AgentPermissions {
+            scope: AgentScope {
+                orgs: vec![org_id.to_string()],
+                ..AgentScope::default()
+            },
+            capabilities: Vec::new(),
+        };
+
+        let prepared = prepare_create(request).expect("valid create request");
+
+        assert!(prepared.net_req.permissions.capabilities.is_empty());
+        assert_eq!(
+            prepared.net_req.permissions.scope.orgs,
+            vec![org_id.to_string()]
+        );
     }
 }

--- a/infra/evals/status/check-expectations.json
+++ b/infra/evals/status/check-expectations.json
@@ -149,22 +149,6 @@
         { "path": "imageUrlPresent", "equals": true }
       ]
     },
-    "model3d-generation-stream": {
-      "description": "3D generation stream emits frame types and completion.",
-      "requiredEvidence": ["frameTypes"]
-    },
-    "video-generation-stream": {
-      "description": "Video generation stream emits frame types and completion.",
-      "requiredEvidence": ["frameTypes"]
-    },
-    "live-benchmark-hello-world": {
-      "description": "Existing live benchmark artifact reports benchmark output.",
-      "requiredEvidence": ["files"]
-    },
-    "harness-fixture-suite": {
-      "description": "Existing harness fixture artifact reports fixture output.",
-      "requiredEvidence": ["files"]
-    },
     "marketplace-agents": {
       "description": "Marketplace agent catalog returns a list count.",
       "requiredEvidence": ["count"]

--- a/infra/evals/status/lib/status-probe-permissions.mjs
+++ b/infra/evals/status/lib/status-probe-permissions.mjs
@@ -1,0 +1,9 @@
+export function statusProbeAgentPermissions(orgId) {
+  if (typeof orgId !== "string" || orgId.trim().length === 0) {
+    throw new Error("status probe agent creation requires an org id");
+  }
+  return {
+    scope: { orgs: [orgId.trim()], projects: [], agent_ids: [] },
+    capabilities: [],
+  };
+}

--- a/infra/evals/status/lib/status-probe-permissions.test.mjs
+++ b/infra/evals/status/lib/status-probe-permissions.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { statusProbeAgentPermissions } from "./status-probe-permissions.mjs";
+
+test("statusProbeAgentPermissions scopes probes to the org without tool capabilities", () => {
+  assert.deepEqual(statusProbeAgentPermissions(" org-1 "), {
+    scope: { orgs: ["org-1"], projects: [], agent_ids: [] },
+    capabilities: [],
+  });
+});
+
+test("statusProbeAgentPermissions rejects missing org ids", () => {
+  assert.throws(
+    () => statusProbeAgentPermissions("  "),
+    /requires an org id/,
+  );
+});

--- a/infra/evals/status/lib/status-registry.test.mjs
+++ b/infra/evals/status/lib/status-registry.test.mjs
@@ -42,8 +42,11 @@ test("every registered status check has a runner branch", async () => {
   const registry = await readJson("infra/evals/status/features.json");
   const runner = await readFile(path.join(repoRoot, "infra/evals/status/run-status-probes.mjs"), "utf8");
   const checkIds = registry.features.flatMap((feature) => feature.checks.map((check) => check.id));
+  const runnerIds = Array.from(runner.matchAll(/selected\("([^"]+)"\)/g), (match) => match[1]);
+  const unknown = runnerIds.filter((id) => !checkIds.includes(id));
   const missing = checkIds.filter((id) => !runner.includes(`selected("${id}")`));
 
+  assert.deepEqual(unknown, [], "runner must not expose unregistered checks");
   assert.deepEqual(missing, [], "every registered check must be selectable in the runner");
 });
 

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { CHECK_STATUS } from "./lib/status-policy.mjs";
 import { validateCheckEvidence } from "./lib/check-expectations.mjs";
+import { statusProbeAgentPermissions } from "./lib/status-probe-permissions.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..", "..", "..");
@@ -60,13 +61,6 @@ function parseArgs(argv) {
   if (args.models.length === 0) args.models = DEFAULT_MODELS;
   args.checks = args.checks.length > 0 ? new Set(args.checks) : null;
   return args;
-}
-
-function statusProbeAgentPermissions() {
-  return {
-    scope: { orgs: [], projects: [], agent_ids: [] },
-    capabilities: [],
-  };
 }
 
 function sseFramesFromText(text) {
@@ -366,7 +360,7 @@ async function createAgent(args, track, machineType, model = null, orgId = null)
     environment,
     auth_source: "aura_managed",
     default_model: model,
-    permissions: statusProbeAgentPermissions(),
+    permissions: statusProbeAgentPermissions(orgId),
     tags: ["aura-status-probe"],
   }, { timeoutMs: machineType === "remote" ? DEFAULT_REMOTE_TIMEOUT_MS : DEFAULT_TIMEOUT_MS });
   track("agent", agent.agent_id, `/api/agents/${agent.agent_id}`);
@@ -805,44 +799,6 @@ async function runChecks(args) {
     }));
   }
 
-  if (selected("model3d-generation-stream")) {
-    checks.push(await probe("model3d-generation-stream", "media-generation", "3D generation stream", args, async () => {
-      if (!args.token) return { status: CHECK_STATUS.SKIP, message: "No access token configured" };
-      const frames = await apiSse(args, "/api/generate/3d/stream", {
-        prompt: "A simple cube for an AURA status probe",
-        image_data: process.env.AURA_STATUS_3D_SOURCE_IMAGE || "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
-      }, 240_000);
-      const completed = frames.find((frame) => frame.event === "generation_completed" || frame.event === "completed");
-      const error = frames.find((frame) => frame.event === "generation_error" || frame.event === "error");
-      if (error) return { status: CHECK_STATUS.FAIL, message: error.data?.message ?? "3D generation error", evidence: { frames } };
-      return {
-        status: completed ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
-        message: completed ? "" : "3D generation stream did not emit completion",
-        evidence: { frameTypes: frames.map((frame) => frame.event) },
-      };
-    }));
-  }
-
-  if (selected("video-generation-stream")) {
-    checks.push(await probe("video-generation-stream", "media-generation", "Video generation stream", args, async () => {
-      if (!args.token) return { status: CHECK_STATUS.SKIP, message: "No access token configured" };
-      const frames = await apiSse(args, "/api/generate/video/stream", {
-        prompt: "A one second AURA status pulse animation",
-        model: process.env.AURA_STATUS_VIDEO_MODEL || "veo-3.1-fast",
-        durationSeconds: 1,
-        aspectRatio: "16:9",
-      }, 300_000);
-      const completed = frames.find((frame) => frame.event === "generation_completed" || frame.event === "completed");
-      const error = frames.find((frame) => frame.event === "generation_error" || frame.event === "error");
-      if (error) return { status: CHECK_STATUS.FAIL, message: error.data?.message ?? "Video generation error", evidence: { frames } };
-      return {
-        status: completed ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
-        message: completed ? "" : "Video generation stream did not emit completion",
-        evidence: { frameTypes: frames.map((frame) => frame.event) },
-      };
-    }));
-  }
-
   if (selected("public-setup")) {
     checks.push(await probe("public-setup", "public-experience", "Public guest session setup", args, async () => {
       const setup = await apiJson(args, "POST", "/api/public/setup", {});
@@ -974,39 +930,6 @@ async function runChecks(args) {
       }
       const ok = results.every((result) => result.status >= 200 && result.status < 400);
       return { status: ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL, evidence: { results } };
-    }));
-  }
-
-  if (selected("live-benchmark-hello-world")) {
-    checks.push(await probe("live-benchmark-hello-world", "spec-task-loop", "Live benchmark hello world artifact", args, async () => {
-      const files = await artifactScan([
-        "interface/test-results/aura-evals-summary.json",
-        "interface/test-results/live-benchmark-summary.json",
-        "infra/evals/reports/baselines/live-benchmark-summary.json",
-      ]);
-      const existing = files.filter((file) => file.exists).length;
-      return {
-        status: existing > 0 ? CHECK_STATUS.PASS : CHECK_STATUS.WARN,
-        message: `${existing}/${files.length} live benchmark artifacts found`,
-        evidence: { files },
-      };
-    }));
-  }
-
-  if (selected("harness-fixture-suite")) {
-    checks.push(await probe("harness-fixture-suite", "spec-task-loop", "Harness fixture eval artifacts", args, async () => {
-      const files = await artifactScan([
-        "interface/test-results/aura-evals-summary.json",
-        "infra/evals/reports/baselines/smoke-summary.json",
-        "infra/evals/reports/baselines/chat-core-summary.json",
-        "infra/evals/reports/baselines/workflow-summary.json",
-      ]);
-      const existing = files.filter((file) => file.exists).length;
-      return {
-        status: existing > 0 ? CHECK_STATUS.PASS : CHECK_STATUS.WARN,
-        message: `${existing}/${files.length} harness fixture artifacts found`,
-        evidence: { files },
-      };
     }));
   }
 


### PR DESCRIPTION
## Summary
- scope status probe-created agents to the current org with zero capabilities so the harness does not promote empty permissions to full access/computer-use
- remove stale unregistered status checks from the runner and expectations file
- add regression coverage for probe permissions and registry drift

## Verification
- node --test infra/evals/status/lib/status-probe-permissions.test.mjs infra/evals/status/lib/status-policy.test.mjs infra/evals/status/lib/check-expectations.test.mjs infra/evals/status/lib/status-registry.test.mjs
- cargo test -p aura-os-server prepare_create_preserves_scoped_zero_capability_permissions
- cargo test -p aura-os-server runtime_session_config_forwards_agent_permissions
- npm run evals:validate
- mock local status probe run confirmed all created agents use org-scoped zero-capability permissions
