### PR TITLE
feat(observability): add regression-focused status evals

### DIFF
--- a/.github/workflows/aura-observability.yml
+++ b/.github/workflows/aura-observability.yml
@@ -51,7 +51,8 @@ jobs:
             image-generation-stream,eval-summary-artifacts,
             public-setup,public-chat-stream,public-feedback-api,
             public-blog-api,public-x402-models,public-x402-payment-challenge,
-            public-observability-page,public-models-page,public-marketing-pages
+            published-observability-snapshot,public-observability-page,
+            public-models-page,public-marketing-pages
         run: npm run status:probes
 
       - name: Build public observability snapshot

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -623,7 +623,7 @@ jobs:
           AURA_STATUS_ENVIRONMENT: desktop-nightly-${{ matrix.target }}-${{ matrix.arch }}
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
           AURA_STATUS_DESKTOP_LOG_DIR: desktop-observability-logs
-          AURA_STATUS_DESKTOP_CHECKS: api-health,auth-session,orgs-list,user-profile,workspace-defaults,terminal-list,local-agent-create,local-agent-runtime,model-matrix
+          AURA_STATUS_DESKTOP_CHECKS: api-health,auth-session,orgs-list,user-profile,workspace-defaults,terminal-list,local-agent-create,local-agent-runtime,local-agent-permissions,model-matrix
         shell: bash
         run: |
           if [ -z "$AURA_STATUS_USER_EMAIL" ] || [ -z "$AURA_STATUS_USER_PASSWORD" ]; then

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -512,7 +512,7 @@ jobs:
           AURA_STATUS_ENVIRONMENT: desktop-stable-${{ matrix.target }}-${{ matrix.arch }}
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
           AURA_STATUS_DESKTOP_LOG_DIR: desktop-observability-logs
-          AURA_STATUS_DESKTOP_CHECKS: api-health,auth-session,orgs-list,user-profile,workspace-defaults,terminal-list,local-agent-create,local-agent-runtime,model-matrix
+          AURA_STATUS_DESKTOP_CHECKS: api-health,auth-session,orgs-list,user-profile,workspace-defaults,terminal-list,local-agent-create,local-agent-runtime,local-agent-permissions,model-matrix
         shell: bash
         run: |
           if [ -z "$AURA_STATUS_USER_EMAIL" ] || [ -z "$AURA_STATUS_USER_PASSWORD" ]; then

--- a/docs/aura-feature-health.md
+++ b/docs/aura-feature-health.md
@@ -121,6 +121,11 @@ node infra/evals/status/run-status-probes.mjs \
   --environment local-dev
 ```
 
+The `published-observability-snapshot` check validates the workflow-published
+snapshot that the React page prefers by default. Override that URL with
+`AURA_STATUS_PUBLISHED_SNAPSHOT_URL` or `--published-snapshot-url` when testing
+a fork or preview branch.
+
 `status:probes` writes check runs under
 `infra/evals/reports/status/checks/`. `status:snapshot` reads those runs,
 applies `infra/evals/status/lib/status-policy.mjs`, and writes:
@@ -129,9 +134,10 @@ applies `infra/evals/status/lib/status-policy.mjs`, and writes:
 - `infra/evals/reports/status/status.json`
 
 The AURA OS React route at `/observability`
-(`interface/src/views/marketing/StatusView`) fetches `/observability/status.json` and
-renders the snapshot. If the JSON is missing, the page falls back to an explicit
-unknown state.
+(`interface/src/views/marketing/StatusView`) fetches the workflow-published
+snapshot URL first, then falls back to `/observability/status.json` from the
+current frontend build. If both JSON requests fail, the page falls back to an
+explicit unknown state.
 
 ## Publishing
 
@@ -144,11 +150,12 @@ the public media generation checks, but it does not run desktop-loopback checks
 such as `local-agent-runtime`, `workspace-defaults`, `terminal-list`, or the
 local `model-matrix`; those belong to `status:desktop-release`.
 
-The browser/API and desktop lanes publish to the same public path:
-`/observability/status.json`. Each lane first reads the previously published
+The browser/API and desktop lanes publish to the same `gh-pages` path:
+`observability/status.json`. Each lane first reads the previously published
 snapshot from `gh-pages`, carries forward still-fresh checks from the other
-lane, overlays the checks it just ran, and republishes the merged snapshot. This
-keeps `/observability` as one dashboard while preserving the correct execution
+lane, overlays the checks it just ran, and republishes the merged snapshot. The
+website and desktop route read that published snapshot first, keeping
+`/observability` as one dashboard while preserving the correct execution
 environment for each eval.
 
 The core production commands are:
@@ -165,8 +172,8 @@ case the probe runner logs into `AURA_STATUS_API_BASE_URL` with
 run.
 
 The generated `interface/public/observability/status.json` ships with the AURA OS
-interface build, and the `/observability` route reads it directly. No
-external status-page service is required for the first version because the
-valuable part is the AURA-specific probe catalog and status policy. An external
-service only adds value if we later need subscriber notifications, incident
-timelines, or multi-region uptime checks independent of AURA's deploy pipeline.
+interface build as a local fallback. No external status-page service is required
+for the first version because the valuable part is the AURA-specific probe
+catalog and status policy. An external service only adds value if we later need
+subscriber notifications, incident timelines, or multi-region uptime checks
+independent of AURA's deploy pipeline.

--- a/infra/evals/status/check-expectations.json
+++ b/infra/evals/status/check-expectations.json
@@ -72,14 +72,15 @@
     },
     "public-x402-payment-challenge": {
       "description": "Public x402 chat returns a payment challenge with wallet, network, asset, and amount fields before settlement.",
-      "requiredEvidence": ["status", "payToPresent", "network", "asset", "amount", "acceptsCount"],
+      "requiredEvidence": ["status", "payToPresent", "network", "asset", "amount", "acceptsCount", "paymentRequiredHeaderPresent"],
       "assertions": [
         { "path": "status", "equals": 402 },
         { "path": "payToPresent", "equals": true },
         { "path": "network", "nonEmpty": true },
         { "path": "asset", "nonEmpty": true },
         { "path": "amount", "nonEmpty": true },
-        { "path": "acceptsCount", "min": 1 }
+        { "path": "acceptsCount", "min": 1 },
+        { "path": "paymentRequiredHeaderPresent", "equals": true }
       ]
     },
     "local-agent-create": {
@@ -90,6 +91,17 @@
       "description": "Local runtime test returns the expected response metadata.",
       "requiredEvidence": ["orgId", "agentId", "model", "provider", "message"],
       "assertions": [{ "path": "message", "containsIgnoreCase": "hello from aura" }]
+    },
+    "local-agent-permissions": {
+      "description": "A local status probe agent persists the org-scoped, capability-free permissions bundle used by live evals.",
+      "requiredEvidence": ["orgId", "agentId", "permissionsPresent", "orgScoped", "projectScopeEmpty", "agentScopeEmpty", "capabilityCount", "capabilityTypes"],
+      "assertions": [
+        { "path": "permissionsPresent", "equals": true },
+        { "path": "orgScoped", "equals": true },
+        { "path": "projectScopeEmpty", "equals": true },
+        { "path": "agentScopeEmpty", "equals": true },
+        { "path": "capabilityCount", "equals": 0 }
+      ]
     },
     "remote-agent-create": {
       "description": "Remote agent creation reaches a ready state.",
@@ -134,10 +146,13 @@
     },
     "model-matrix": {
       "description": "Every configured model is exercised and pass/total counts are recorded.",
-      "requiredEvidence": ["orgId", "passed", "total", "results"],
+      "requiredEvidence": ["orgId", "passed", "total", "allPassed", "failedModelCount", "failedModels", "expectedPhrase", "results"],
       "assertions": [
         { "path": "total", "min": 1 },
         { "path": "passed", "min": 1 },
+        { "path": "allPassed", "equals": true },
+        { "path": "failedModelCount", "equals": 0 },
+        { "path": "expectedPhrase", "equals": "hello from aura" },
         { "path": "results", "nonEmpty": true }
       ]
     },
@@ -219,12 +234,33 @@
       "description": "Eval artifact scan reports files and found counts.",
       "requiredEvidence": ["files"]
     },
+    "published-observability-snapshot": {
+      "description": "The published snapshot consumed by /observability is workflow-generated, fresh, and contains real feature data.",
+      "requiredEvidence": ["schemaVersion", "overall", "generatedAtPresent", "source", "featureCount", "totalsFeatures", "unknownFeatureCount", "snapshotAgeMinutes", "hasLiveSource", "hasNonUnknownFeatureData", "snapshotUrl", "maxAgeMinutes"],
+      "assertions": [
+        { "path": "schemaVersion", "equals": 1 },
+        { "path": "overall", "oneOf": ["operational", "degraded", "partial_outage", "major_outage", "maintenance"] },
+        { "path": "generatedAtPresent", "equals": true },
+        { "path": "source", "equals": "github-actions" },
+        { "path": "featureCount", "min": 1 },
+        { "path": "totalsFeatures", "min": 1 },
+        { "path": "snapshotAgeMinutes", "max": 180 },
+        { "path": "hasLiveSource", "equals": true },
+        { "path": "hasNonUnknownFeatureData", "equals": true },
+        { "path": "snapshotUrl", "nonEmpty": true },
+        { "path": "maxAgeMinutes", "equals": 180 }
+      ]
+    },
     "public-observability-page": {
       "description": "Public observability snapshot JSON returns overall state and feature count.",
-      "requiredEvidence": ["overall", "featureCount"],
+      "requiredEvidence": ["schemaVersion", "overall", "generatedAtPresent", "source", "featureCount", "totalsFeatures"],
       "assertions": [
+        { "path": "schemaVersion", "equals": 1 },
         { "path": "overall", "oneOf": ["operational", "degraded", "partial_outage", "major_outage", "unknown", "maintenance"] },
-        { "path": "featureCount", "min": 1 }
+        { "path": "generatedAtPresent", "equals": true },
+        { "path": "source", "nonEmpty": true },
+        { "path": "featureCount", "min": 1 },
+        { "path": "totalsFeatures", "min": 1 }
       ]
     },
     "public-models-page": {
@@ -234,7 +270,13 @@
     },
     "public-marketing-pages": {
       "description": "Public marketing route sweep returns per-route results.",
-      "requiredEvidence": ["results"]
+      "requiredEvidence": ["allRoutesOk", "routeCount", "failedRoutes", "failedRouteCount", "results"],
+      "assertions": [
+        { "path": "allRoutesOk", "equals": true },
+        { "path": "routeCount", "min": 8 },
+        { "path": "failedRouteCount", "equals": 0 },
+        { "path": "results", "nonEmpty": true }
+      ]
     }
   }
 }

--- a/infra/evals/status/features.json
+++ b/infra/evals/status/features.json
@@ -56,11 +56,12 @@
       "label": "Local Agents",
       "category": "agents",
       "priority": 20,
-      "description": "Local agent template creation, project binding, and workspace-backed chat readiness.",
-      "publicSummary": "Local agents can be created and exercised through the harness.",
+      "description": "Local agent template creation, persisted permissions, project binding, and workspace-backed chat readiness.",
+      "publicSummary": "Local agents can be created, scoped, and exercised through the harness.",
       "checks": [
         { "id": "local-agent-create", "required": true, "staleAfterMinutes": 1800, "warningLatencyMs": 5000, "outageLatencyMs": 15000 },
-        { "id": "local-agent-runtime", "required": true, "staleAfterMinutes": 1800, "warningLatencyMs": 15000, "outageLatencyMs": 45000 }
+        { "id": "local-agent-runtime", "required": true, "staleAfterMinutes": 1800, "warningLatencyMs": 15000, "outageLatencyMs": 45000 },
+        { "id": "local-agent-permissions", "required": false, "staleAfterMinutes": 1800, "warningLatencyMs": 5000, "outageLatencyMs": 15000 }
       ],
       "degradedAfterFailures": 1,
       "outageAfterFailures": 2
@@ -233,6 +234,7 @@
       "description": "Public AURA pages, observability snapshot JSON, and marketing routes.",
       "publicSummary": "AURA's public web surfaces are reachable.",
       "checks": [
+        { "id": "published-observability-snapshot", "required": true, "staleAfterMinutes": 15, "warningLatencyMs": 2000, "outageLatencyMs": 8000 },
         { "id": "public-observability-page", "required": true, "staleAfterMinutes": 15, "warningLatencyMs": 2000, "outageLatencyMs": 8000 },
         { "id": "public-models-page", "required": false, "staleAfterMinutes": 30, "warningLatencyMs": 3000, "outageLatencyMs": 10000 },
         { "id": "public-marketing-pages", "required": false, "staleAfterMinutes": 30, "warningLatencyMs": 5000, "outageLatencyMs": 15000 }

--- a/infra/evals/status/run-desktop-release-probes.mjs
+++ b/infra/evals/status/run-desktop-release-probes.mjs
@@ -17,6 +17,7 @@ const DEFAULT_CHECKS = [
   "terminal-list",
   "local-agent-create",
   "local-agent-runtime",
+  "local-agent-permissions",
   "model-matrix",
 ];
 

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -16,10 +16,14 @@ const DEFAULT_MODELS = [
   "aura-claude-sonnet-4-6",
   "aura-gpt-5-5",
 ];
+const EXPECTED_RUNTIME_PHRASE = "hello from aura";
+const DEFAULT_PUBLISHED_STATUS_JSON_URL = "https://cypher-asi.github.io/aura-os/observability/status.json";
+const PUBLISHED_STATUS_MAX_AGE_MINUTES = 180;
 function parseArgs(argv) {
   const args = {
     baseUrl: process.env.AURA_STATUS_API_BASE_URL || "http://127.0.0.1:3190",
     publicBaseUrl: process.env.AURA_STATUS_PUBLIC_BASE_URL || "",
+    publishedSnapshotUrl: process.env.AURA_STATUS_PUBLISHED_SNAPSHOT_URL || process.env.VITE_AURA_STATUS_SNAPSHOT_URL || DEFAULT_PUBLISHED_STATUS_JSON_URL,
     token: process.env.AURA_STATUS_ACCESS_TOKEN || process.env.AURA_EVAL_ACCESS_TOKEN || "",
     userEmail: process.env.AURA_STATUS_USER_EMAIL || "",
     userPassword: process.env.AURA_STATUS_USER_PASSWORD || "",
@@ -40,6 +44,7 @@ function parseArgs(argv) {
     };
     if (arg === "--base-url") args.baseUrl = next();
     else if (arg === "--public-base-url") args.publicBaseUrl = next();
+    else if (arg === "--published-snapshot-url") args.publishedSnapshotUrl = next();
     else if (arg === "--token") args.token = next();
     else if (arg === "--user-email") args.userEmail = next();
     else if (arg === "--user-password") args.userPassword = next();
@@ -50,7 +55,7 @@ function parseArgs(argv) {
     else if (arg === "--models") args.models = next().split(",").map((v) => v.trim()).filter(Boolean);
     else if (arg === "--keep-entities") args.keepEntities = true;
     else if (arg === "--help") {
-      process.stdout.write("Usage: node infra/evals/status/run-status-probes.mjs [--base-url URL] [--token TOKEN] [--checks a,b]\n");
+      process.stdout.write("Usage: node infra/evals/status/run-status-probes.mjs [--base-url URL] [--public-base-url URL] [--published-snapshot-url URL] [--token TOKEN] [--checks a,b]\n");
       process.exit(0);
     } else {
       throw new Error(`Unknown argument: ${arg}`);
@@ -153,6 +158,37 @@ async function publicText(baseUrl, endpoint) {
   const text = await response.text();
   if (!response.ok) throw new Error(`GET ${endpoint} failed with ${response.status}: ${text}`);
   return { status: response.status, text };
+}
+
+async function publicJsonUrl(url) {
+  const response = await fetchWithTimeout(url, {}, DEFAULT_TIMEOUT_MS);
+  const text = await response.text();
+  if (!response.ok) throw new Error(`GET ${url} failed with ${response.status}: ${text}`);
+  return text ? JSON.parse(text) : null;
+}
+
+function statusSnapshotEvidence(payload) {
+  const features = Array.isArray(payload?.features)
+    ? payload.features
+    : Object.values(payload?.features ?? {});
+  const generatedAtMs = Date.parse(payload?.generatedAt ?? "");
+  const snapshotAgeMinutes = Number.isFinite(generatedAtMs)
+    ? Math.round(Math.max(0, (Date.now() - generatedAtMs) / 60000))
+    : null;
+  const unknownFeatureCount = features.filter((feature) => feature?.status === "unknown").length;
+  const featureCount = features.length;
+  return {
+    schemaVersion: payload?.schemaVersion ?? null,
+    overall: payload?.overall,
+    generatedAtPresent: typeof payload?.generatedAt === "string" && payload.generatedAt.length > 0,
+    source: payload?.source ?? null,
+    featureCount,
+    totalsFeatures: payload?.totals?.features ?? null,
+    unknownFeatureCount,
+    snapshotAgeMinutes,
+    hasLiveSource: payload?.source === "github-actions",
+    hasNonUnknownFeatureData: featureCount > 0 && unknownFeatureCount < featureCount,
+  };
 }
 
 function collectionCount(payload, keys = []) {
@@ -365,6 +401,31 @@ async function createAgent(args, track, machineType, model = null, orgId = null)
   }, { timeoutMs: machineType === "remote" ? DEFAULT_REMOTE_TIMEOUT_MS : DEFAULT_TIMEOUT_MS });
   track("agent", agent.agent_id, `/api/agents/${agent.agent_id}`);
   return agent;
+}
+
+function permissionEvidence(permissions, orgId) {
+  const scope = permissions?.scope ?? {};
+  const capabilities = Array.isArray(permissions?.capabilities) ? permissions.capabilities : [];
+  const orgScope = Array.isArray(scope.orgs) ? scope.orgs : [];
+  const projectScope = Array.isArray(scope.projects) ? scope.projects : [];
+  const agentScope = Array.isArray(scope.agent_ids) ? scope.agent_ids : [];
+  const capabilityTypes = capabilities
+    .map((capability) => {
+      if (typeof capability === "string") return capability;
+      if (typeof capability?.type === "string") return capability.type;
+      return null;
+    })
+    .filter(Boolean);
+
+  return {
+    permissionsPresent: permissions != null && typeof permissions === "object",
+    orgScope,
+    orgScoped: orgScope.length === 1 && orgScope[0] === orgId,
+    projectScopeEmpty: projectScope.length === 0,
+    agentScopeEmpty: agentScope.length === 0,
+    capabilityCount: capabilities.length,
+    capabilityTypes,
+  };
 }
 
 async function runRuntimeTest(args, agentId, timeoutMs = DEFAULT_TIMEOUT_MS) {
@@ -679,11 +740,38 @@ async function runChecks(args) {
         const { orgId } = await requireOrgId(args);
         const agent = await createAgent(args, track, "local", null, orgId);
         const runtime = await runRuntimeTest(args, agent.agent_id, 60_000);
-        const ok = String(runtime?.message ?? "").toLowerCase().includes("hello from aura");
+        const ok = String(runtime?.message ?? "").toLowerCase().includes(EXPECTED_RUNTIME_PHRASE);
         return {
           status: ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
           message: ok ? "" : "Runtime response did not contain expected phrase",
           evidence: { orgId, agentId: agent.agent_id, model: runtime?.model, provider: runtime?.provider, message: runtime?.message },
+        };
+      });
+    }));
+  }
+
+  if (selected("local-agent-permissions")) {
+    checks.push(await probe("local-agent-permissions", "local-agents", "Local agent persisted permissions", args, async () => {
+      if (!args.token) return { status: CHECK_STATUS.SKIP, message: "No access token configured" };
+      return withCleanup(args, async (track) => {
+        const { orgId } = await requireOrgId(args);
+        const agent = await createAgent(args, track, "local", null, orgId);
+        const fetched = await apiJson(args, "GET", `/api/agents/${agent.agent_id}`);
+        const evidence = {
+          orgId,
+          agentId: agent.agent_id,
+          ...permissionEvidence(fetched?.permissions ?? agent?.permissions, orgId),
+        };
+        const ok =
+          evidence.permissionsPresent &&
+          evidence.orgScoped &&
+          evidence.projectScopeEmpty &&
+          evidence.agentScopeEmpty &&
+          evidence.capabilityCount === 0;
+        return {
+          status: ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
+          message: ok ? "" : "Local status probe agent permissions did not persist as org-scoped and capability-free",
+          evidence,
         };
       });
     }));
@@ -730,7 +818,7 @@ async function runChecks(args) {
         const agent = await createAgent(args, track, "remote", null, orgId);
         await waitForRemoteReady(args, agent.agent_id);
         const runtime = await runRuntimeTest(args, agent.agent_id, 90_000);
-        const ok = String(runtime?.message ?? "").toLowerCase().includes("hello from aura");
+        const ok = String(runtime?.message ?? "").toLowerCase().includes(EXPECTED_RUNTIME_PHRASE);
         return {
           status: ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
           message: ok ? "" : "Runtime response did not contain expected phrase",
@@ -750,11 +838,13 @@ async function runChecks(args) {
           const result = await withCleanup(args, async (track) => {
             const agent = await createAgent(args, track, "local", model, orgId);
             const runtime = await runRuntimeTest(args, agent.agent_id, 60_000);
+            const message = String(runtime?.message ?? "");
             return {
               model,
-              ok: String(runtime?.message ?? "").toLowerCase().includes("hello from aura"),
+              ok: message.toLowerCase().includes(EXPECTED_RUNTIME_PHRASE),
               provider: runtime?.provider ?? null,
               resolvedModel: runtime?.model ?? null,
+              messageSample: message.slice(0, 120),
             };
           });
           results.push(result);
@@ -769,10 +859,21 @@ async function runChecks(args) {
         }
       }
       const passed = results.filter((result) => result.ok).length;
+      const failedModels = results.filter((result) => !result.ok).map((result) => result.model);
+      const allPassed = passed === results.length;
       return {
-        status: passed === results.length ? CHECK_STATUS.PASS : passed > 0 ? CHECK_STATUS.WARN : CHECK_STATUS.FAIL,
+        status: allPassed ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
         message: `${passed}/${results.length} models returned the expected response`,
-        evidence: { orgId, passed, total: results.length, results },
+        evidence: {
+          orgId,
+          passed,
+          total: results.length,
+          allPassed,
+          failedModelCount: failedModels.length,
+          failedModels,
+          expectedPhrase: EXPECTED_RUNTIME_PHRASE,
+          results,
+        },
       };
     }));
   }
@@ -879,7 +980,8 @@ async function runChecks(args) {
       const requirement = Array.isArray(payload?.accepts) ? payload.accepts[0] : null;
       const payToPresent = typeof requirement?.payTo === "string" && requirement.payTo.length > 0;
       const amountPresent = typeof requirement?.amount === "string" && requirement.amount.length > 0;
-      const ok = response.status === 402 && payToPresent && amountPresent && requirement?.network && requirement?.asset;
+      const paymentRequiredHeaderPresent = response.headers.has("payment-required");
+      const ok = response.status === 402 && payToPresent && amountPresent && requirement?.network && requirement?.asset && paymentRequiredHeaderPresent;
       return {
         status: ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
         message: ok ? "" : `Public x402 challenge returned HTTP ${response.status}`,
@@ -890,7 +992,7 @@ async function runChecks(args) {
           asset: requirement?.asset ?? null,
           amount: requirement?.amount ?? null,
           acceptsCount: Array.isArray(payload?.accepts) ? payload.accepts.length : 0,
-          paymentRequiredHeaderPresent: response.headers.has("payment-required"),
+          paymentRequiredHeaderPresent,
         },
       };
     }));
@@ -900,10 +1002,29 @@ async function runChecks(args) {
     checks.push(await probe("public-observability-page", "public-website", "Public observability snapshot", args, async () => {
       const base = args.publicBaseUrl || args.baseUrl;
       const payload = await publicJson(base, "/observability/status.json");
-      const featureCount = Array.isArray(payload?.features)
-        ? payload.features.length
-        : Object.keys(payload?.features ?? {}).length;
-      return { evidence: { overall: payload?.overall, featureCount } };
+      return { evidence: statusSnapshotEvidence(payload) };
+    }));
+  }
+
+  if (selected("published-observability-snapshot")) {
+    checks.push(await probe("published-observability-snapshot", "public-website", "Published observability snapshot", args, async () => {
+      const payload = await publicJsonUrl(args.publishedSnapshotUrl);
+      const evidence = {
+        ...statusSnapshotEvidence(payload),
+        snapshotUrl: args.publishedSnapshotUrl,
+        maxAgeMinutes: PUBLISHED_STATUS_MAX_AGE_MINUTES,
+      };
+      const ok =
+        evidence.schemaVersion === 1 &&
+        evidence.hasLiveSource &&
+        evidence.hasNonUnknownFeatureData &&
+        evidence.snapshotAgeMinutes != null &&
+        evidence.snapshotAgeMinutes <= PUBLISHED_STATUS_MAX_AGE_MINUTES;
+      return {
+        status: ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
+        message: ok ? "" : "Published observability snapshot is missing live workflow data or is stale",
+        evidence,
+      };
     }));
   }
 
@@ -929,7 +1050,17 @@ async function runChecks(args) {
         results.push({ route, status: result.status, hasRoot: result.text.includes("root") || result.text.includes("AURA") });
       }
       const ok = results.every((result) => result.status >= 200 && result.status < 400);
-      return { status: ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL, evidence: { results } };
+      const failedRoutes = results.filter((result) => result.status < 200 || result.status >= 400).map((result) => result.route);
+      return {
+        status: ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
+        evidence: {
+          allRoutesOk: ok,
+          routeCount: results.length,
+          failedRoutes,
+          failedRouteCount: failedRoutes.length,
+          results,
+        },
+      };
     }));
   }
 


### PR DESCRIPTION
## Summary
- add a published observability snapshot eval for the GitHub Pages JSON that /observability consumes
- add a local-agent permissions eval to desktop release probes
- tighten model matrix, x402, public route, and snapshot expected-output contracts
- update observability docs for published snapshot vs local fallback behavior

## Validation
- node --test infra/evals/status/lib/*.test.mjs
- npm run evals:validate
- node --check infra/evals/status/run-status-probes.mjs && node --check infra/evals/status/run-desktop-release-probes.mjs && node --check infra/evals/status/build-status-snapshot.mjs
- live public probe sweep against aura.ai for published-observability-snapshot, public-observability-page, public-models-page, public-marketing-pages, public-x402-models, public-x402-payment-challenge
- local negative contract fixtures rejected model partial failure, permission capability creep, missing x402 header, fallback/stale snapshot, and broken public route

Note: local desktop at 127.0.0.1:19847 was running but unauthenticated, so local-agent-permissions is wired into the desktop release CI lane where the test-account secrets are available.