### PR TITLE
fix(observability): preserve full status snapshot from releases

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -634,6 +634,35 @@ jobs:
           echo "ran=true" >> "$GITHUB_OUTPUT"
           npm run status:desktop-release
 
+      - name: Run production web observability probes
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
+        continue-on-error: true
+        env:
+          AURA_STATUS_API_BASE_URL: ${{ secrets.AURA_STATUS_API_BASE_URL || vars.AURA_STATUS_API_BASE_URL || 'https://api.aura.ai' }}
+          AURA_STATUS_PUBLIC_BASE_URL: ${{ secrets.AURA_STATUS_PUBLIC_BASE_URL || vars.AURA_STATUS_PUBLIC_BASE_URL || 'https://aura.ai' }}
+          AURA_STATUS_ACCESS_TOKEN: ${{ secrets.AURA_STATUS_ACCESS_TOKEN }}
+          AURA_STATUS_USER_EMAIL: ${{ secrets.AURA_STATUS_USER_EMAIL }}
+          AURA_STATUS_USER_PASSWORD: ${{ secrets.AURA_STATUS_USER_PASSWORD }}
+          AURA_STATUS_MODEL_IDS: ${{ secrets.AURA_STATUS_MODEL_IDS || vars.AURA_STATUS_MODEL_IDS }}
+          AURA_STATUS_IMAGE_MODEL: ${{ secrets.AURA_STATUS_IMAGE_MODEL || vars.AURA_STATUS_IMAGE_MODEL }}
+          AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_CHECKS_DIR: desktop-observability-checks
+          AURA_STATUS_CHECKS: >-
+            api-health,auth-session,auth-validate,system-info,
+            orgs-list,user-profile,org-integrations-list,org-tool-actions-list,
+            billing-status,credits-balance,project-crud,spec-task-crud,
+            project-stats,loop-status,process-list,process-crud,
+            marketplace-agents,harness-health,active-streams,debug-projects,
+            feedback-list,bug-reports-mine,feed-list,leaderboard,platform-stats,
+            remote-agent-create,remote-agent-state,remote-agent-runtime,
+            image-generation-stream,eval-summary-artifacts,
+            public-setup,public-chat-stream,public-feedback-api,
+            public-blog-api,public-x402-models,public-x402-payment-challenge,
+            published-observability-snapshot,public-observability-page,
+            public-models-page,public-marketing-pages
+        shell: bash
+        run: npm run status:probes
+
       - name: Upload desktop observability artifacts
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         uses: actions/upload-artifact@v5
@@ -648,10 +677,16 @@ jobs:
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         env:
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
+          AURA_STATUS_PREVIOUS_SNAPSHOT: infra/evals/reports/status/previous/status.json
           AURA_STATUS_ENVIRONMENT: production
           AURA_STATUS_SOURCE: desktop-nightly-release
         shell: bash
-        run: npm run status:snapshot
+        run: |
+          mkdir -p infra/evals/reports/status/previous
+          git fetch origin +gh-pages:refs/remotes/origin/gh-pages || true
+          git show origin/gh-pages:observability/status.json \
+            > infra/evals/reports/status/previous/status.json || true
+          npm run status:snapshot
 
       - uses: actions/checkout@v5
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -523,6 +523,35 @@ jobs:
           echo "ran=true" >> "$GITHUB_OUTPUT"
           npm run status:desktop-release
 
+      - name: Run production web observability probes
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
+        continue-on-error: true
+        env:
+          AURA_STATUS_API_BASE_URL: ${{ secrets.AURA_STATUS_API_BASE_URL || vars.AURA_STATUS_API_BASE_URL || 'https://api.aura.ai' }}
+          AURA_STATUS_PUBLIC_BASE_URL: ${{ secrets.AURA_STATUS_PUBLIC_BASE_URL || vars.AURA_STATUS_PUBLIC_BASE_URL || 'https://aura.ai' }}
+          AURA_STATUS_ACCESS_TOKEN: ${{ secrets.AURA_STATUS_ACCESS_TOKEN }}
+          AURA_STATUS_USER_EMAIL: ${{ secrets.AURA_STATUS_USER_EMAIL }}
+          AURA_STATUS_USER_PASSWORD: ${{ secrets.AURA_STATUS_USER_PASSWORD }}
+          AURA_STATUS_MODEL_IDS: ${{ secrets.AURA_STATUS_MODEL_IDS || vars.AURA_STATUS_MODEL_IDS }}
+          AURA_STATUS_IMAGE_MODEL: ${{ secrets.AURA_STATUS_IMAGE_MODEL || vars.AURA_STATUS_IMAGE_MODEL }}
+          AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_CHECKS_DIR: desktop-observability-checks
+          AURA_STATUS_CHECKS: >-
+            api-health,auth-session,auth-validate,system-info,
+            orgs-list,user-profile,org-integrations-list,org-tool-actions-list,
+            billing-status,credits-balance,project-crud,spec-task-crud,
+            project-stats,loop-status,process-list,process-crud,
+            marketplace-agents,harness-health,active-streams,debug-projects,
+            feedback-list,bug-reports-mine,feed-list,leaderboard,platform-stats,
+            remote-agent-create,remote-agent-state,remote-agent-runtime,
+            image-generation-stream,eval-summary-artifacts,
+            public-setup,public-chat-stream,public-feedback-api,
+            public-blog-api,public-x402-models,public-x402-payment-challenge,
+            published-observability-snapshot,public-observability-page,
+            public-models-page,public-marketing-pages
+        shell: bash
+        run: npm run status:probes
+
       - name: Upload desktop observability artifacts
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         uses: actions/upload-artifact@v5
@@ -537,10 +566,16 @@ jobs:
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         env:
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
+          AURA_STATUS_PREVIOUS_SNAPSHOT: infra/evals/reports/status/previous/status.json
           AURA_STATUS_ENVIRONMENT: production
           AURA_STATUS_SOURCE: desktop-stable-release
         shell: bash
-        run: npm run status:snapshot
+        run: |
+          mkdir -p infra/evals/reports/status/previous
+          git fetch origin +gh-pages:refs/remotes/origin/gh-pages || true
+          git show origin/gh-pages:observability/status.json \
+            > infra/evals/reports/status/previous/status.json || true
+          npm run status:snapshot
 
       - uses: actions/checkout@v5
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'

--- a/docs/aura-feature-health.md
+++ b/docs/aura-feature-health.md
@@ -153,10 +153,12 @@ local `model-matrix`; those belong to `status:desktop-release`.
 The browser/API and desktop lanes publish to the same `gh-pages` path:
 `observability/status.json`. Each lane first reads the previously published
 snapshot from `gh-pages`, carries forward still-fresh checks from the other
-lane, overlays the checks it just ran, and republishes the merged snapshot. The
-website and desktop route read that published snapshot first, keeping
-`/observability` as one dashboard while preserving the correct execution
-environment for each eval.
+lane, overlays the checks it just ran, and republishes the merged snapshot.
+Desktop release publishing also runs the production browser/API probes into the
+same checks directory before publishing, so release-triggered snapshots contain
+fresh website/API evidence plus desktop-only evidence. The website and desktop
+route read that published snapshot first, keeping `/observability` as one
+dashboard while preserving the correct execution environment for each eval.
 
 The core production commands are:
 

--- a/infra/evals/status/build-status-snapshot.mjs
+++ b/infra/evals/status/build-status-snapshot.mjs
@@ -112,6 +112,7 @@ async function readChecks(args) {
 
 function checksFromSnapshot(snapshot) {
   if (!Array.isArray(snapshot?.features)) return [];
+  const snapshotGeneratedAt = normalizeSnapshotGeneratedAt(snapshot);
   const checks = [];
   for (const feature of snapshot.features) {
     for (const check of feature?.checks ?? []) {
@@ -124,7 +125,7 @@ function checksFromSnapshot(snapshot) {
         message: check.message ?? "",
         startedAt: check.checkedAt,
         endedAt: check.checkedAt,
-        runGeneratedAt: check.checkedAt,
+        runGeneratedAt: snapshotGeneratedAt ?? check.checkedAt,
         latencyMs: check.latencyMs ?? null,
         environment: snapshot.environment ?? null,
         evidence: check.evidence ?? {},
@@ -132,6 +133,13 @@ function checksFromSnapshot(snapshot) {
     }
   }
   return checks;
+}
+
+function normalizeSnapshotGeneratedAt(snapshot) {
+  if (typeof snapshot?.generatedAt !== "string" || snapshot.generatedAt.length === 0) return null;
+  const date = new Date(snapshot.generatedAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
 }
 
 async function writeJson(filePath, payload) {

--- a/infra/evals/status/check-expectations.json
+++ b/infra/evals/status/check-expectations.json
@@ -241,7 +241,7 @@
         { "path": "schemaVersion", "equals": 1 },
         { "path": "overall", "oneOf": ["operational", "degraded", "partial_outage", "major_outage", "maintenance"] },
         { "path": "generatedAtPresent", "equals": true },
-        { "path": "source", "equals": "github-actions" },
+        { "path": "source", "oneOf": ["github-actions", "desktop-nightly-release", "desktop-stable-release"] },
         { "path": "featureCount", "min": 1 },
         { "path": "totalsFeatures", "min": 1 },
         { "path": "snapshotAgeMinutes", "max": 180 },

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -19,6 +19,12 @@ const DEFAULT_MODELS = [
 const EXPECTED_RUNTIME_PHRASE = "hello from aura";
 const DEFAULT_PUBLISHED_STATUS_JSON_URL = "https://cypher-asi.github.io/aura-os/observability/status.json";
 const PUBLISHED_STATUS_MAX_AGE_MINUTES = 180;
+const LIVE_STATUS_SNAPSHOT_SOURCES = new Set([
+  "github-actions",
+  "desktop-nightly-release",
+  "desktop-stable-release",
+]);
+
 function parseArgs(argv) {
   const args = {
     baseUrl: process.env.AURA_STATUS_API_BASE_URL || "http://127.0.0.1:3190",
@@ -186,7 +192,7 @@ function statusSnapshotEvidence(payload) {
     totalsFeatures: payload?.totals?.features ?? null,
     unknownFeatureCount,
     snapshotAgeMinutes,
-    hasLiveSource: payload?.source === "github-actions",
+    hasLiveSource: LIVE_STATUS_SNAPSHOT_SOURCES.has(payload?.source),
     hasNonUnknownFeatureData: featureCount > 0 && unknownFeatureCount < featureCount,
   };
 }


### PR DESCRIPTION
## Summary
- prevent desktop release observability publishing from replacing the public snapshot with desktop-only evidence
- run production web probes in the desktop release publish lane so release snapshots include fresh web/API and desktop checks
- preserve carried snapshot freshness from the prior snapshot generation time and accept desktop release sources as live publishers

## Validation
- node --test infra/evals/status/lib/*.test.mjs
- npm run evals:validate
- node --check infra/evals/status/run-status-probes.mjs && node --check infra/evals/status/build-status-snapshot.mjs && git diff --check
- fixture: desktop-nightly-release snapshot merge keeps Local Agents / Model Responses / Public Website operational and Remote Agents major_outage
- local HTTP fixture: published-observability-snapshot accepts desktop-nightly-release when the snapshot is healthy
