### PR TITLE
feat(observability): persist status history

### DIFF
--- a/.github/workflows/aura-observability.yml
+++ b/.github/workflows/aura-observability.yml
@@ -69,6 +69,16 @@ jobs:
             > infra/evals/reports/status/previous/status.json || true
           npm run status:snapshot
 
+      - name: Persist observability history
+        if: always()
+        continue-on-error: true
+        env:
+          AURA_STORAGE_URL: ${{ vars.AURA_STORAGE_URL || 'https://aura-storage.onrender.com' }}
+          AURA_STORAGE_INTERNAL_TOKEN: ${{ secrets.AURA_STORAGE_INTERNAL_TOKEN || secrets.INTERNAL_SERVICE_TOKEN }}
+          AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_SOURCE: github-actions
+        run: npm run status:persist
+
       - uses: actions/checkout@v5
         if: always()
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -688,6 +688,17 @@ jobs:
             > infra/evals/reports/status/previous/status.json || true
           npm run status:snapshot
 
+      - name: Persist desktop observability history
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
+        continue-on-error: true
+        env:
+          AURA_STORAGE_URL: ${{ vars.AURA_STORAGE_URL || 'https://aura-storage.onrender.com' }}
+          AURA_STORAGE_INTERNAL_TOKEN: ${{ secrets.AURA_STORAGE_INTERNAL_TOKEN || secrets.INTERNAL_SERVICE_TOKEN }}
+          AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_SOURCE: desktop-nightly-release
+          AURA_STATUS_RELEASE_CHANNEL: nightly
+        run: npm run status:persist
+
       - uses: actions/checkout@v5
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         with:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -577,6 +577,17 @@ jobs:
             > infra/evals/reports/status/previous/status.json || true
           npm run status:snapshot
 
+      - name: Persist desktop observability history
+        if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
+        continue-on-error: true
+        env:
+          AURA_STORAGE_URL: ${{ vars.AURA_STORAGE_URL || 'https://aura-storage.onrender.com' }}
+          AURA_STORAGE_INTERNAL_TOKEN: ${{ secrets.AURA_STORAGE_INTERNAL_TOKEN || secrets.INTERNAL_SERVICE_TOKEN }}
+          AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_SOURCE: desktop-stable-release
+          AURA_STATUS_RELEASE_CHANNEL: stable
+        run: npm run status:persist
+
       - uses: actions/checkout@v5
         if: always() && matrix.target == 'macos' && matrix.arch == 'aarch64' && steps.desktop_observability.outputs.ran == 'true'
         with:

--- a/docs/aura-feature-health.md
+++ b/docs/aura-feature-health.md
@@ -139,6 +139,12 @@ snapshot URL first, then falls back to `/observability/status.json` from the
 current frontend build. If both JSON requests fail, the page falls back to an
 explicit unknown state.
 
+`status:persist` is the private history path. It reads the generated snapshot
+and posts it to aura-storage at `/internal/observability/runs` when
+`AURA_STORAGE_URL` and `AURA_STORAGE_INTERNAL_TOKEN` are configured. This does
+not change the public status page; it only gives internal tooling a queryable
+history of runs, features, checks, latency, and failure evidence.
+
 ## Publishing
 
 `.github/workflows/aura-observability.yml` runs every 30 minutes and can also
@@ -179,3 +185,6 @@ for the first version because the valuable part is the AURA-specific probe
 catalog and status policy. An external service only adds value if we later need
 subscriber notifications, incident timelines, or multi-region uptime checks
 independent of AURA's deploy pipeline.
+
+Private history persistence is best-effort in CI/release workflows. If
+aura-storage is unavailable, the latest public snapshot should still publish.

--- a/infra/evals/status/lib/status-persistence.mjs
+++ b/infra/evals/status/lib/status-persistence.mjs
@@ -1,0 +1,77 @@
+import { promises as fs } from "node:fs";
+
+export function buildObservabilityIngestPayload(snapshot, metadata = {}) {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    throw new Error("snapshot must be a JSON object");
+  }
+  if (!Array.isArray(snapshot.features) || snapshot.features.length === 0) {
+    throw new Error("snapshot.features must be a non-empty array");
+  }
+  if (typeof snapshot.generatedAt !== "string" || snapshot.generatedAt.length === 0) {
+    throw new Error("snapshot.generatedAt is required");
+  }
+
+  const externalRunAttempt = Number(metadata.externalRunAttempt ?? 1);
+  return pruneNullish({
+    snapshot,
+    source: stringOr(metadata.source, snapshot.source, "aura-status"),
+    environment: stringOr(metadata.environment, snapshot.environment, "unknown"),
+    externalRunId: optionalString(metadata.externalRunId),
+    externalRunAttempt: Number.isFinite(externalRunAttempt) ? Math.max(1, Math.trunc(externalRunAttempt)) : 1,
+    gitSha: optionalString(metadata.gitSha),
+    gitBranch: optionalString(metadata.gitBranch),
+    workflowName: optionalString(metadata.workflowName),
+    releaseChannel: optionalString(metadata.releaseChannel),
+    generatedAt: snapshot.generatedAt,
+    completedAt: optionalString(metadata.completedAt),
+    overallStatus: optionalString(snapshot.overall),
+    totals: snapshot.totals && typeof snapshot.totals === "object" ? snapshot.totals : undefined,
+  });
+}
+
+export async function readSnapshot(filePath) {
+  return JSON.parse(await fs.readFile(filePath, "utf8"));
+}
+
+export async function persistObservabilityRun({ storageUrl, token, payload, timeoutMs = 30_000 }) {
+  if (!storageUrl) throw new Error("storageUrl is required");
+  if (!token) throw new Error("token is required");
+
+  const url = `${storageUrl.replace(/\/+$/, "")}/internal/observability/runs`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(`request timed out after ${timeoutMs}ms`)), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Internal-Token": token,
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`POST ${url} failed with ${response.status}: ${text}`);
+    }
+    return text ? JSON.parse(text) : null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function stringOr(...values) {
+  for (const value of values) {
+    const normalized = optionalString(value);
+    if (normalized) return normalized;
+  }
+  return "";
+}
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function pruneNullish(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== null));
+}

--- a/infra/evals/status/lib/status-persistence.test.mjs
+++ b/infra/evals/status/lib/status-persistence.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { test } from "node:test";
+
+import {
+  buildObservabilityIngestPayload,
+  persistObservabilityRun,
+} from "./status-persistence.mjs";
+
+function sampleSnapshot(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-06-12T22:41:55.355Z",
+    source: "github-actions",
+    environment: "production",
+    overall: "major_outage",
+    totals: { features: 1, operational: 0, majorOutage: 1 },
+    features: [{
+      id: "remote-agents",
+      label: "Remote Agents",
+      category: "agents",
+      priority: 30,
+      status: "major_outage",
+      checks: [{
+        id: "remote-agent-create",
+        required: true,
+        status: "fail",
+        featureStatus: "major_outage",
+        checkedAt: "2026-06-12T22:40:12.000Z",
+        latencyMs: 135766,
+        evidence: { remoteState: "unschedulable" },
+      }],
+    }],
+    ...overrides,
+  };
+}
+
+test("buildObservabilityIngestPayload derives storage ingest metadata from snapshot and CI context", () => {
+  const snapshot = sampleSnapshot();
+  const payload = buildObservabilityIngestPayload(snapshot, {
+    source: "desktop-nightly-release",
+    environment: "production",
+    externalRunId: "27446843504",
+    externalRunAttempt: "2",
+    gitSha: "abc123",
+    gitBranch: "main",
+    workflowName: "AURA Observability",
+    releaseChannel: "nightly",
+    completedAt: "2026-06-12T22:42:12.000Z",
+  });
+
+  assert.equal(payload.source, "desktop-nightly-release");
+  assert.equal(payload.environment, "production");
+  assert.equal(payload.externalRunId, "27446843504");
+  assert.equal(payload.externalRunAttempt, 2);
+  assert.equal(payload.gitSha, "abc123");
+  assert.equal(payload.gitBranch, "main");
+  assert.equal(payload.workflowName, "AURA Observability");
+  assert.equal(payload.releaseChannel, "nightly");
+  assert.equal(payload.generatedAt, snapshot.generatedAt);
+  assert.equal(payload.completedAt, "2026-06-12T22:42:12.000Z");
+  assert.equal(payload.overallStatus, "major_outage");
+  assert.deepEqual(payload.totals, snapshot.totals);
+  assert.equal(payload.snapshot, snapshot);
+});
+
+test("buildObservabilityIngestPayload rejects snapshots without feature data", () => {
+  assert.throws(
+    () => buildObservabilityIngestPayload(sampleSnapshot({ features: [] })),
+    /snapshot\.features must be a non-empty array/,
+  );
+});
+
+test("persistObservabilityRun posts to Aura storage internal endpoint", async () => {
+  let observed = null;
+  const server = http.createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    observed = {
+      method: request.method,
+      url: request.url,
+      token: request.headers["x-internal-token"],
+      body: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+    };
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ id: "stored-run-id" }));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const { port } = server.address();
+    const payload = buildObservabilityIngestPayload(sampleSnapshot(), {
+      externalRunId: "27446843504",
+    });
+    const result = await persistObservabilityRun({
+      storageUrl: `http://127.0.0.1:${port}`,
+      token: "internal-token",
+      payload,
+      timeoutMs: 5_000,
+    });
+
+    assert.equal(result.id, "stored-run-id");
+    assert.equal(observed.method, "POST");
+    assert.equal(observed.url, "/internal/observability/runs");
+    assert.equal(observed.token, "internal-token");
+    assert.equal(observed.body.externalRunId, "27446843504");
+    assert.equal(observed.body.snapshot.features[0].id, "remote-agents");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/infra/evals/status/persist-status-history.mjs
+++ b/infra/evals/status/persist-status-history.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildObservabilityIngestPayload,
+  persistObservabilityRun,
+  readSnapshot,
+} from "./lib/status-persistence.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+
+function parseArgs(argv) {
+  const args = {
+    snapshot: process.env.AURA_STATUS_SNAPSHOT_FILE
+      || process.env.AURA_STATUS_OUTPUT
+      || path.join(repoRoot, "interface/public/observability/status.json"),
+    storageUrl: process.env.AURA_STATUS_STORAGE_URL || process.env.AURA_STORAGE_URL || "",
+    token: process.env.AURA_STATUS_STORAGE_INTERNAL_TOKEN
+      || process.env.AURA_STORAGE_INTERNAL_TOKEN
+      || process.env.INTERNAL_SERVICE_TOKEN
+      || "",
+    enabled: !["0", "false", "no"].includes(String(process.env.AURA_STATUS_PERSIST_HISTORY || "1").toLowerCase()),
+    timeoutMs: Number(process.env.AURA_STATUS_STORAGE_TIMEOUT_MS || "30000"),
+    releaseChannel: process.env.AURA_STATUS_RELEASE_CHANNEL || process.env.AURA_RELEASE_CHANNEL || "",
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      i += 1;
+      if (i >= argv.length) throw new Error(`Missing value for ${arg}`);
+      return argv[i];
+    };
+    if (arg === "--snapshot") args.snapshot = path.resolve(next());
+    else if (arg === "--storage-url") args.storageUrl = next();
+    else if (arg === "--token") args.token = next();
+    else if (arg === "--release-channel") args.releaseChannel = next();
+    else if (arg === "--timeout-ms") args.timeoutMs = Number(next());
+    else if (arg === "--disabled") args.enabled = false;
+    else if (arg === "--help") {
+      process.stdout.write("Usage: node infra/evals/status/persist-status-history.mjs [--snapshot FILE] [--storage-url URL] [--token TOKEN]\n");
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  args.snapshot = path.resolve(args.snapshot);
+  if (!Number.isFinite(args.timeoutMs) || args.timeoutMs <= 0) args.timeoutMs = 30_000;
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+if (!args.enabled) {
+  process.stdout.write("Observability history persistence disabled.\n");
+  process.exit(0);
+}
+
+if (!args.storageUrl || !args.token) {
+  process.stdout.write("Skipping observability history persistence because storage URL or internal token is not configured.\n");
+  process.exit(0);
+}
+
+const snapshot = await readSnapshot(args.snapshot);
+const payload = buildObservabilityIngestPayload(snapshot, {
+  source: process.env.AURA_STATUS_SOURCE,
+  environment: process.env.AURA_STATUS_ENVIRONMENT,
+  externalRunId: process.env.AURA_STATUS_EXTERNAL_RUN_ID || process.env.GITHUB_RUN_ID,
+  externalRunAttempt: process.env.AURA_STATUS_EXTERNAL_RUN_ATTEMPT || process.env.GITHUB_RUN_ATTEMPT,
+  gitSha: process.env.AURA_STATUS_GIT_SHA || process.env.GITHUB_SHA,
+  gitBranch: process.env.AURA_STATUS_GIT_BRANCH || process.env.GITHUB_REF_NAME,
+  workflowName: process.env.AURA_STATUS_WORKFLOW_NAME || process.env.GITHUB_WORKFLOW,
+  releaseChannel: args.releaseChannel,
+  completedAt: new Date().toISOString(),
+});
+
+const run = await persistObservabilityRun({
+  storageUrl: args.storageUrl,
+  token: args.token,
+  payload,
+  timeoutMs: args.timeoutMs,
+});
+
+process.stdout.write(`Persisted observability run ${run?.id ?? "(unknown id)"} to Aura storage.\n`);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "status:probes": "node infra/evals/status/run-status-probes.mjs",
     "status:desktop-release": "node infra/evals/status/run-desktop-release-probes.mjs",
     "status:snapshot": "node infra/evals/status/build-status-snapshot.mjs",
+    "status:persist": "node infra/evals/status/persist-status-history.mjs",
     "status:all": "npm run status:probes && npm run status:snapshot"
   }
 }


### PR DESCRIPTION
## Summary
- add status:persist CLI that posts generated status snapshots to Aura storage
- wire best-effort history persistence into observability and desktop release workflows
- add persistence payload and HTTP tests

## Verification
- node --test infra/evals/status/lib/*.test.mjs
- npm run evals:validate
- node --check infra/evals/status/persist-status-history.mjs
- npm run status:persist -- --disabled
- git diff --check
- local write/readback against local aura-storage