### PR TITLE
fix(observability): tighten eval cadence and contracts

### DIFF
--- a/.github/workflows/aura-observability.yml
+++ b/.github/workflows/aura-observability.yml
@@ -2,7 +2,7 @@ name: AURA Observability
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 */2 * * *"
   workflow_run:
     workflows:
       - Desktop Nightly Release

--- a/infra/evals/status/check-expectations.json
+++ b/infra/evals/status/check-expectations.json
@@ -170,7 +170,12 @@
     },
     "harness-health": {
       "description": "Harness bootstrap health returns a JSON health payload.",
-      "requiredEvidence": []
+      "requiredEvidence": ["reachable", "status", "url"],
+      "assertions": [
+        { "path": "reachable", "equals": true },
+        { "path": "status", "equals": 200 },
+        { "path": "url", "nonEmpty": true }
+      ]
     },
     "org-integrations-list": {
       "description": "Org integrations endpoint returns a list count for the current org.",
@@ -232,7 +237,12 @@
     },
     "eval-summary-artifacts": {
       "description": "Eval artifact scan reports files and found counts.",
-      "requiredEvidence": ["files"]
+      "requiredEvidence": ["files", "existingCount", "expectedCount"],
+      "assertions": [
+        { "path": "existingCount", "min": 1 },
+        { "path": "expectedCount", "min": 1 },
+        { "path": "files", "nonEmpty": true }
+      ]
     },
     "published-observability-snapshot": {
       "description": "The published snapshot consumed by /observability is workflow-generated, fresh, and contains real feature data.",
@@ -261,9 +271,13 @@
       ]
     },
     "public-models-page": {
-      "description": "Public models page returns an HTTP status.",
-      "requiredEvidence": ["status"],
-      "assertions": [{ "path": "status", "min": 200, "max": 399 }]
+      "description": "Public models route serves the Aura app shell.",
+      "requiredEvidence": ["status", "hasAppShell", "bodyLength"],
+      "assertions": [
+        { "path": "status", "equals": 200 },
+        { "path": "hasAppShell", "equals": true },
+        { "path": "bodyLength", "min": 1 }
+      ]
     },
     "public-marketing-pages": {
       "description": "Public marketing route sweep returns per-route results.",

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -1046,11 +1046,16 @@ async function runChecks(args) {
   if (selected("public-models-page")) {
     checks.push(await probe("public-models-page", "public-website", "Public models page", args, async () => {
       const base = args.publicBaseUrl || args.baseUrl;
-      const response = await fetchWithTimeout(`${base}/models`, {}, DEFAULT_TIMEOUT_MS);
+      const result = await publicText(base, "/models");
+      const hasAppShell = result.text.includes("root") || result.text.includes("AURA");
       return {
-        status: response.ok ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
-        message: response.ok ? "" : `HTTP ${response.status}`,
-        evidence: { status: response.status },
+        status: hasAppShell ? CHECK_STATUS.PASS : CHECK_STATUS.FAIL,
+        message: hasAppShell ? "" : "Public models page did not return the Aura app shell",
+        evidence: {
+          status: result.status,
+          hasAppShell,
+          bodyLength: result.text.length,
+        },
       };
     }));
   }
@@ -1091,7 +1096,7 @@ async function runChecks(args) {
       return {
         status: existing > 0 ? CHECK_STATUS.PASS : CHECK_STATUS.WARN,
         message: `${existing}/${files.length} eval summary artifacts found`,
-        evidence: { files },
+        evidence: { files, existingCount: existing, expectedCount: files.length },
       };
     }));
   }

--- a/interface/tests/e2e/evals/chatCoreMockApp.ts
+++ b/interface/tests/e2e/evals/chatCoreMockApp.ts
@@ -373,6 +373,13 @@ export async function installChatCoreMockApp(
     if (pathname === "/api/streams/active") return json(route, []);
 
     if (
+      pathname === `/api/projects/${scenario.project.projectId}/agents/${scenario.agent.agentInstanceId}/sessions/${chatSession.session_id}/events/paginated`
+    ) {
+      historyRequests.push(`${method} ${pathname}`);
+      return json(route, { events: history, has_more: false, next_cursor: null });
+    }
+
+    if (
       pathname === `/api/projects/${scenario.project.projectId}/agents/${scenario.agent.agentInstanceId}/events` ||
       pathname === `/api/projects/${scenario.project.projectId}/agents/${scenario.agent.agentInstanceId}/sessions/${chatSession.session_id}/events`
     ) {


### PR DESCRIPTION
## Summary
- run Aura Observability every 2 hours instead of every 30 minutes
- keep successful desktop release triggers intact
- tighten weak eval contracts for harness health, the models route, and eval artifacts

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/aura-observability.yml"); puts "yaml ok"'`
- `node --test infra/evals/status/lib/status-registry.test.mjs infra/evals/status/lib/check-expectations.test.mjs infra/evals/status/build-status-snapshot.test.mjs infra/evals/status/persist-status-history.test.mjs infra/evals/status/lib/status-persistence.test.mjs`
- `npm run evals:validate`
- `AURA_STATUS_API_BASE_URL=https://api.aura.ai AURA_STATUS_PUBLIC_BASE_URL=https://aura.ai AURA_STATUS_CHECKS=published-observability-snapshot,public-observability-page,public-models-page,public-marketing-pages,eval-summary-artifacts npm run status:probes`
- negative evidence contract check for harness-health, public-models-page, eval-summary-artifacts
