### PR TITLE
feat(observability): separate feature health from runtime evidence

### DIFF
--- a/.github/workflows/aura-observability-repair.yml
+++ b/.github/workflows/aura-observability-repair.yml
@@ -66,6 +66,7 @@ jobs:
           AURA_STATUS_MODEL_IDS: ${{ secrets.AURA_STATUS_MODEL_IDS || vars.AURA_STATUS_MODEL_IDS }}
           AURA_STATUS_IMAGE_MODEL: ${{ secrets.AURA_STATUS_IMAGE_MODEL || vars.AURA_STATUS_IMAGE_MODEL }}
           AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_RUNTIME_ENVIRONMENT: production-api
           AURA_STATUS_CHECKS: ${{ inputs.checks }}
         run: npm run status:probes
 

--- a/.github/workflows/aura-observability.yml
+++ b/.github/workflows/aura-observability.yml
@@ -41,6 +41,7 @@ jobs:
           AURA_STATUS_MODEL_IDS: ${{ secrets.AURA_STATUS_MODEL_IDS || vars.AURA_STATUS_MODEL_IDS }}
           AURA_STATUS_IMAGE_MODEL: ${{ secrets.AURA_STATUS_IMAGE_MODEL || vars.AURA_STATUS_IMAGE_MODEL }}
           AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_RUNTIME_ENVIRONMENT: production-api
           AURA_STATUS_CHECKS: >-
             api-health,auth-session,auth-validate,system-info,
             orgs-list,user-profile,org-integrations-list,org-tool-actions-list,

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -621,9 +621,10 @@ jobs:
           AURA_STATUS_USER_EMAIL: ${{ secrets.AURA_STATUS_USER_EMAIL }}
           AURA_STATUS_USER_PASSWORD: ${{ secrets.AURA_STATUS_USER_PASSWORD }}
           AURA_STATUS_ENVIRONMENT: desktop-nightly-${{ matrix.target }}-${{ matrix.arch }}
+          AURA_STATUS_RUNTIME_ENVIRONMENT: desktop-release
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
           AURA_STATUS_DESKTOP_LOG_DIR: desktop-observability-logs
-          AURA_STATUS_DESKTOP_CHECKS: api-health,auth-session,orgs-list,user-profile,workspace-defaults,terminal-list,local-agent-create,local-agent-runtime,local-agent-permissions,model-matrix
+          AURA_STATUS_DESKTOP_CHECKS: api-health,auth-session,orgs-list,user-profile,workspace-defaults,terminal-list,local-agent-create,local-agent-runtime,local-agent-permissions,model-matrix,image-generation-stream
         shell: bash
         run: |
           if [ -z "$AURA_STATUS_USER_EMAIL" ] || [ -z "$AURA_STATUS_USER_PASSWORD" ]; then
@@ -646,6 +647,7 @@ jobs:
           AURA_STATUS_MODEL_IDS: ${{ secrets.AURA_STATUS_MODEL_IDS || vars.AURA_STATUS_MODEL_IDS }}
           AURA_STATUS_IMAGE_MODEL: ${{ secrets.AURA_STATUS_IMAGE_MODEL || vars.AURA_STATUS_IMAGE_MODEL }}
           AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_RUNTIME_ENVIRONMENT: production-api
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
           AURA_STATUS_CHECKS: >-
             api-health,auth-session,auth-validate,system-info,

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -510,9 +510,10 @@ jobs:
           AURA_STATUS_USER_EMAIL: ${{ secrets.AURA_STATUS_USER_EMAIL }}
           AURA_STATUS_USER_PASSWORD: ${{ secrets.AURA_STATUS_USER_PASSWORD }}
           AURA_STATUS_ENVIRONMENT: desktop-stable-${{ matrix.target }}-${{ matrix.arch }}
+          AURA_STATUS_RUNTIME_ENVIRONMENT: desktop-release
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
           AURA_STATUS_DESKTOP_LOG_DIR: desktop-observability-logs
-          AURA_STATUS_DESKTOP_CHECKS: api-health,auth-session,orgs-list,user-profile,workspace-defaults,terminal-list,local-agent-create,local-agent-runtime,local-agent-permissions,model-matrix
+          AURA_STATUS_DESKTOP_CHECKS: api-health,auth-session,orgs-list,user-profile,workspace-defaults,terminal-list,local-agent-create,local-agent-runtime,local-agent-permissions,model-matrix,image-generation-stream
         shell: bash
         run: |
           if [ -z "$AURA_STATUS_USER_EMAIL" ] || [ -z "$AURA_STATUS_USER_PASSWORD" ]; then
@@ -535,6 +536,7 @@ jobs:
           AURA_STATUS_MODEL_IDS: ${{ secrets.AURA_STATUS_MODEL_IDS || vars.AURA_STATUS_MODEL_IDS }}
           AURA_STATUS_IMAGE_MODEL: ${{ secrets.AURA_STATUS_IMAGE_MODEL || vars.AURA_STATUS_IMAGE_MODEL }}
           AURA_STATUS_ENVIRONMENT: production
+          AURA_STATUS_RUNTIME_ENVIRONMENT: production-api
           AURA_STATUS_CHECKS_DIR: desktop-observability-checks
           AURA_STATUS_CHECKS: >-
             api-health,auth-session,auth-validate,system-info,

--- a/docs/aura-feature-health.md
+++ b/docs/aura-feature-health.md
@@ -16,6 +16,13 @@ contract before allowing a check to pass, and
 `infra/evals/status/lib/status-registry.test.mjs` fails locally if a check is
 registered without both an expected-output contract and a runner branch.
 
+Feature health and runtime environment are separate axes. A feature represents
+the user-facing capability, while each check declares the runtime it actually
+exercised, such as `production-api`, `desktop-release`, or `local-dev`. The
+dashboard groups checks by feature, labels the runtime for each row, and lets a
+runtime-specific check be informational when it exposes useful deployment
+evidence without proving or disproving the whole feature.
+
 Current feature groups:
 
 - Core API: `/health`, authenticated session reads, and system metadata.
@@ -26,7 +33,8 @@ Current feature groups:
 - Projects, Specs, and Tasks: project CRUD, spec CRUD, task CRUD, project stats, and loop status.
 - Processes: workflow lists, process creation, default node creation, and cleanup.
 - Model Responses: curated model matrix through the AURA runtime path.
-- Media Generation: image generation by default, with optional 3D and video stream probes.
+- Media Generation: desktop-backed image generation, plus informational
+  production-auth stream health.
 - Autonomous Build Loop: benchmark and harness fixture outputs.
 - Marketplace and Bootstrap: marketplace catalog and harness bootstrap health.
 - Integrations and Billing: integrations, tool actions, subscription status, and credits.
@@ -100,15 +108,19 @@ npm run status:desktop-release
 
 By default this covers the binary-local API, authenticated session, org/profile
 reads, workspace defaults, terminal list, local agent creation, local agent
-runtime response, and the local model matrix. Release workflows run this on the
-macOS arm64 release leg when `AURA_STATUS_USER_EMAIL` and
+runtime response, the local model matrix, and desktop-backed image generation.
+Release workflows run this on the macOS arm64 release leg when
+`AURA_STATUS_USER_EMAIL` and
 `AURA_STATUS_USER_PASSWORD` are configured, then upload the generated check JSON
 and desktop logs as artifacts.
 
 The scheduled public observability workflow intentionally excludes
-desktop-loopback checks and generation modes that require a bundled harness
-runtime. It preserves fresh desktop-release check results from the previous
-published snapshot, then layers deployed API and public website probes on top.
+desktop-loopback checks. It can still run informational deployed API checks for
+the production-auth media endpoint, but the required product proof for Media
+Generation comes from the desktop-release lane because that is where the
+bundled harness actually exists. The workflow preserves fresh desktop-release
+check results from the previous published snapshot, then layers deployed API
+and public website probes on top.
 
 For end-to-end local verification, use the existing eval local stack in
 `infra/evals/local-stack/`. The observability page is not served from a sibling
@@ -136,9 +148,12 @@ the goal is to validate local `aura-network`, `aura-storage`, `orbit`, or local
 database behavior. Remote-agent checks should run through the hybrid or
 production path so local harness execution cannot mask deployed swarm failures.
 
-Default probe runs include every implemented check unless `--checks` is used to
-select a smaller set. The production browser/API lane runs media generation
-checks directly, including image, 3D, and video streams:
+Each probe lane should run only checks it can truthfully exercise. Production
+browser/API runs should use production-runtime checks, and desktop-release runs
+should use desktop-runtime checks. For example,
+`image-generation-stream` is the same feature eval in both lanes; the
+`runtimeEnvironment` field tells the dashboard whether that result came from
+the deployed authenticated API path or the packaged desktop harness path:
 
 ```sh
 npm run status:probes -- --base-url http://127.0.0.1:3190 --token "$AURA_STATUS_ACCESS_TOKEN"
@@ -184,9 +199,12 @@ be triggered manually. It runs probes with production secrets, builds the
 snapshot even when probes fail, and uploads the generated JSON/check artifacts.
 This scheduled workflow uses `AURA_STATUS_CHECKS` to restrict itself to checks
 that can be truthfully exercised against deployed website/API surfaces. It runs
-the public media generation checks, but it does not run desktop-loopback checks
-such as `local-agent-runtime`, `workspace-defaults`, `terminal-list`, or the
-local `model-matrix`; those belong to `status:desktop-release`.
+the informational production-auth media generation check, but it does not run
+desktop-loopback checks such as `local-agent-runtime`, `workspace-defaults`,
+`terminal-list`, or the local `model-matrix`; those belong to
+`status:desktop-release`. The shared `image-generation-stream` eval can run in
+both lanes because its runtime environment distinguishes production-auth API
+evidence from desktop-harness evidence.
 
 The browser/API and desktop lanes publish to the same `gh-pages` path:
 `observability/status.json`. Each lane first reads the previously published
@@ -207,7 +225,7 @@ while preserving the correct execution environment for each eval.
 The core production commands are:
 
 ```sh
-npm run status:probes -- --base-url "$AURA_STATUS_API_BASE_URL" --token "$AURA_STATUS_ACCESS_TOKEN" --environment production
+npm run status:probes -- --base-url "$AURA_STATUS_API_BASE_URL" --token "$AURA_STATUS_ACCESS_TOKEN" --environment production --runtime-environment production-api
 npm run status:investigate -- --environment production --source github-actions
 npm run status:snapshot -- --environment production --source github-actions
 ```

--- a/infra/evals/status/build-status-snapshot.mjs
+++ b/infra/evals/status/build-status-snapshot.mjs
@@ -167,6 +167,7 @@ function checksFromSnapshot(snapshot) {
         runGeneratedAt: snapshotGeneratedAt ?? check.checkedAt,
         latencyMs: check.latencyMs ?? null,
         environment: snapshot.environment ?? null,
+        runtimeEnvironment: check.runtimeEnvironment ?? check.runtime ?? null,
         evidence: check.evidence ?? {},
       });
     }

--- a/infra/evals/status/check-expectations.json
+++ b/infra/evals/status/check-expectations.json
@@ -157,7 +157,7 @@
       ]
     },
     "image-generation-stream": {
-      "description": "Image generation stream emits frame types and a completion artifact signal.",
+      "description": "Image generation stream emits frame types and a completion artifact signal in the runtime environment under test.",
       "requiredEvidence": ["frameTypes", "imageUrlPresent"],
       "assertions": [
         { "path": "frameTypes", "contains": "generation_completed" },

--- a/infra/evals/status/features.json
+++ b/infra/evals/status/features.json
@@ -2,6 +2,23 @@
   "schemaVersion": 1,
   "title": "AURA Observability",
   "description": "Feature health backed by AURA-owned live eval probes.",
+  "runtimeEnvironments": [
+    {
+      "id": "production-api",
+      "label": "Production API",
+      "description": "Hosted AURA API and its configured upstream services."
+    },
+    {
+      "id": "desktop-release",
+      "label": "Desktop Release",
+      "description": "Packaged desktop binary with the bundled local harness runtime."
+    },
+    {
+      "id": "local-dev",
+      "label": "Local Dev",
+      "description": "Developer-run local API and harness stack."
+    }
+  ],
   "features": [
     {
       "id": "core-api",
@@ -133,7 +150,25 @@
       "description": "Image generation stream routing, progress frames, completion payloads, and artifact URLs.",
       "publicSummary": "AURA image generation streams can complete with generated artifacts.",
       "checks": [
-        { "id": "image-generation-stream", "required": true, "staleAfterMinutes": 30, "warningLatencyMs": 180000, "outageLatencyMs": 360000 }
+        {
+          "id": "image-generation-stream",
+          "label": "Image generation stream",
+          "runtimeEnvironment": "desktop-release",
+          "required": true,
+          "staleAfterMinutes": 1800,
+          "warningLatencyMs": 180000,
+          "outageLatencyMs": 360000
+        },
+        {
+          "id": "image-generation-stream",
+          "label": "Image generation stream",
+          "runtimeEnvironment": "production-api",
+          "required": false,
+          "statusImpact": "informational",
+          "staleAfterMinutes": 30,
+          "warningLatencyMs": 180000,
+          "outageLatencyMs": 360000
+        }
       ],
       "degradedAfterFailures": 1,
       "outageAfterFailures": 1

--- a/infra/evals/status/lib/status-investigation-packets.mjs
+++ b/infra/evals/status/lib/status-investigation-packets.mjs
@@ -41,6 +41,7 @@ export function buildInvestigationEvidencePacket({
     checkContract: {
       id: checkConfig?.id ?? check?.checkId ?? null,
       label: check?.label ?? checkConfig?.label ?? check?.checkId ?? null,
+      runtimeEnvironment: checkConfig?.runtimeEnvironment ?? check?.runtimeEnvironment ?? null,
       required: checkConfig?.required !== false,
       warningLatencyMs: checkConfig?.warningLatencyMs ?? null,
       outageLatencyMs: checkConfig?.outageLatencyMs ?? null,
@@ -64,6 +65,7 @@ export function buildInvestigationEvidencePacket({
       runGeneratedAt: check?.runGeneratedAt ?? null,
       latencyMs: check?.latencyMs ?? null,
       environment: check?.environment ?? null,
+      runtimeEnvironment: check?.runtimeEnvironment ?? null,
       evidence: failedEvidence,
     },
     siblingPattern: siblingSummaries.pattern,
@@ -81,7 +83,7 @@ export function buildInvestigationEvidencePacket({
     }),
     reproductionHint: {
       label: `Run only ${check?.checkId ?? "this check"}`,
-      command: check?.checkId ? `AURA_STATUS_CHECKS=${check.checkId} npm run status:probes` : "npm run status:probes",
+      command: reproductionCommand(check),
       details: "Use the same environment variables as the scheduled observability workflow.",
     },
     sourceHints,
@@ -90,11 +92,20 @@ export function buildInvestigationEvidencePacket({
   });
 }
 
+function reproductionCommand(check) {
+  if (!check?.checkId) return "npm run status:probes";
+  const runtimePrefix = check.runtimeEnvironment
+    ? `AURA_STATUS_RUNTIME_ENVIRONMENT=${check.runtimeEnvironment} `
+    : "";
+  return `${runtimePrefix}AURA_STATUS_CHECKS=${check.checkId} npm run status:probes`;
+}
+
 function summarizeSiblings(check, siblingChecks) {
   const normalizedMessage = normalizeMessage(check?.message);
   const checks = siblingChecks.map((sibling) => ({
     checkId: sibling.checkId,
     featureId: sibling.featureId,
+    runtimeEnvironment: sibling.runtimeEnvironment ?? null,
     status: sibling.status,
     message: sibling.message,
     endedAt: sibling.endedAt,

--- a/infra/evals/status/lib/status-investigation-verifiers.mjs
+++ b/infra/evals/status/lib/status-investigation-verifiers.mjs
@@ -23,13 +23,13 @@ export function buildInvestigationVerifierContext({
 
   const sameMessageSiblingIds = siblingChecks
     .filter((sibling) => normalizeMessage(sibling.message) === normalizeMessage(check?.message))
-    .map((sibling) => sibling.checkId);
+    .map(checkRef);
   const failedSiblingIds = siblingChecks
     .filter((sibling) => sibling.status === "fail")
-    .map((sibling) => sibling.checkId);
+    .map(checkRef);
   const passingSiblingIds = siblingChecks
     .filter((sibling) => sibling.status === "pass")
-    .map((sibling) => sibling.checkId);
+    .map(checkRef);
   const sourcePaths = [...new Set([
     ...sourceHints.map((hint) => hint.path).filter(Boolean),
     ...sourceContext.map((context) => context.path).filter(Boolean),
@@ -110,7 +110,7 @@ function recommendedVerifierProbes({
   if (missingRequiredEvidence.length > 0 || contractValidationError) {
     probes.push({
       label: "Re-run the failed expected-output contract",
-      command: check?.checkId ? `AURA_STATUS_CHECKS=${check.checkId} npm run status:probes` : "npm run status:probes",
+      command: reproductionCommand(check),
       reason: contractValidationError ?? `Missing required evidence: ${missingRequiredEvidence.join(", ")}`,
     });
   }
@@ -151,6 +151,18 @@ function recommendedVerifierProbes({
     });
   }
   return probes;
+}
+
+function reproductionCommand(check) {
+  if (!check?.checkId) return "npm run status:probes";
+  const runtimePrefix = check.runtimeEnvironment
+    ? `AURA_STATUS_RUNTIME_ENVIRONMENT=${check.runtimeEnvironment} `
+    : "";
+  return `${runtimePrefix}AURA_STATUS_CHECKS=${check.checkId} npm run status:probes`;
+}
+
+function checkRef(check) {
+  return check?.runtimeEnvironment ? `${check.runtimeEnvironment}/${check.checkId}` : check?.checkId;
 }
 
 function normalizeMessage(value) {

--- a/infra/evals/status/lib/status-investigations.mjs
+++ b/infra/evals/status/lib/status-investigations.mjs
@@ -13,8 +13,27 @@ export const INVESTIGATION_CONFIDENCE = Object.freeze({
 const VALID_INVESTIGATION_STATUSES = new Set(Object.values(INVESTIGATION_STATUS));
 const VALID_CONFIDENCE = new Set(Object.values(INVESTIGATION_CONFIDENCE));
 
-export function investigationKey(featureId, checkId) {
-  return `${featureId ?? ""}:${checkId ?? ""}`;
+export function normalizeRuntimeEnvironment(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function inferRuntimeEnvironment(environment) {
+  const normalized = typeof environment === "string" ? environment.trim().toLowerCase() : "";
+  if (normalized.startsWith("desktop-")) return "desktop-release";
+  if (normalized === "production") return "production-api";
+  if (normalized === "local") return "local-dev";
+  return null;
+}
+
+export function recordRuntimeEnvironment(record) {
+  return normalizeRuntimeEnvironment(
+    record?.runtimeEnvironment ?? record?.runtime ?? inferRuntimeEnvironment(record?.environment),
+  );
+}
+
+export function investigationKey(featureId, checkId, runtimeEnvironment = null) {
+  const runtime = normalizeRuntimeEnvironment(runtimeEnvironment);
+  return runtime ? `${featureId ?? ""}:${runtime}:${checkId ?? ""}` : `${featureId ?? ""}:${checkId ?? ""}`;
 }
 
 export function normalizeInvestigation(raw, generatedAt) {
@@ -24,15 +43,17 @@ export function normalizeInvestigation(raw, generatedAt) {
   const featureId = typeof raw.featureId === "string" && raw.featureId.trim()
     ? raw.featureId.trim()
     : null;
+  const runtimeEnvironment = recordRuntimeEnvironment(raw);
   const normalizedGeneratedAt = normalizeIsoDate(raw.generatedAt, generatedAt);
 
   return {
     schemaVersion: 1,
     kind: "llm-investigation",
-    id: stringOrDefault(raw.id, investigationKey(featureId, checkId)),
+    id: stringOrDefault(raw.id, investigationKey(featureId, checkId, runtimeEnvironment)),
     featureId,
     featureLabel: stringOrDefault(raw.featureLabel, featureId ?? "Unknown feature"),
     checkId,
+    runtimeEnvironment,
     title: stringOrDefault(raw.title, "Investigator report"),
     status: VALID_INVESTIGATION_STATUSES.has(raw.status) ? raw.status : INVESTIGATION_STATUS.READY,
     checkStatus: typeof raw.checkStatus === "string" ? raw.checkStatus : null,
@@ -63,9 +84,16 @@ export function latestInvestigationsByCheck(investigations, generatedAt) {
   for (const raw of investigations ?? []) {
     const investigation = normalizeInvestigation(raw, generatedAt);
     if (!investigation) continue;
-    const keys = investigation.featureId
-      ? [investigationKey(investigation.featureId, investigation.checkId)]
-      : [investigationKey(null, investigation.checkId)];
+    const keys = investigation.runtimeEnvironment
+      ? investigation.featureId
+        ? [
+          investigationKey(investigation.featureId, investigation.checkId, investigation.runtimeEnvironment),
+          investigationKey(null, investigation.checkId, investigation.runtimeEnvironment),
+        ]
+        : [investigationKey(null, investigation.checkId, investigation.runtimeEnvironment)]
+      : investigation.featureId
+        ? [investigationKey(investigation.featureId, investigation.checkId)]
+        : [investigationKey(null, investigation.checkId)];
     for (const key of keys) {
       const existing = map.get(key);
       if (!existing || new Date(investigation.generatedAt).getTime() > new Date(existing.generatedAt).getTime()) {
@@ -83,6 +111,7 @@ export function annotateInvestigation(investigation, { feature, checkConfig, ver
     featureId: feature?.id ?? investigation.featureId,
     featureLabel: feature?.label ?? investigation.featureLabel,
     checkId: checkConfig?.id ?? investigation.checkId,
+    runtimeEnvironment: verdict?.check?.runtimeEnvironment ?? investigation.runtimeEnvironment,
     checkStatus: verdict?.check?.status ?? investigation.checkStatus ?? "unknown",
     featureStatus: verdict?.status ?? investigation.featureStatus ?? "unknown",
     environment: environment ?? investigation.environment,

--- a/infra/evals/status/lib/status-investigator.mjs
+++ b/infra/evals/status/lib/status-investigator.mjs
@@ -73,12 +73,14 @@ export function buildInvestigationInput({
       runGeneratedAt: check?.runGeneratedAt ?? null,
       latencyMs: check?.latencyMs ?? null,
       environment: check?.environment ?? null,
+      runtimeEnvironment: check?.runtimeEnvironment ?? null,
       evidence: check?.evidence ?? {},
     },
     expectedOutputContract: expectation ?? null,
     siblingChecks: siblingChecks.map((sibling) => ({
       checkId: sibling.checkId,
       featureId: sibling.featureId,
+      runtimeEnvironment: sibling.runtimeEnvironment ?? null,
       status: sibling.status,
       message: sibling.message,
       endedAt: sibling.endedAt,
@@ -201,10 +203,11 @@ export async function investigateCheck({
     return normalizeInvestigation({
       schemaVersion: 1,
       kind: "llm-investigation",
-      id: investigationId(feature?.id ?? check?.featureId, check?.checkId, generatedAt),
+      id: investigationId(feature?.id ?? check?.featureId, check?.checkId, generatedAt, check?.runtimeEnvironment),
       featureId: feature?.id ?? check?.featureId ?? null,
       featureLabel: feature?.label ?? feature?.id ?? "Unknown feature",
       checkId: check?.checkId,
+      runtimeEnvironment: check?.runtimeEnvironment ?? null,
       title: "Investigator failed",
       status: INVESTIGATION_STATUS.FAILED,
       checkStatus: check?.status ?? null,
@@ -262,10 +265,11 @@ export function normalizeInvestigationResponse(content, {
     ...parsed,
     schemaVersion: 1,
     kind: "llm-investigation",
-    id: investigationId(feature?.id ?? check?.featureId, check?.checkId, generatedAt),
+    id: investigationId(feature?.id ?? check?.featureId, check?.checkId, generatedAt, check?.runtimeEnvironment),
     featureId: feature?.id ?? check?.featureId ?? null,
     featureLabel: feature?.label ?? feature?.id ?? "Unknown feature",
     checkId: check?.checkId,
+    runtimeEnvironment: check?.runtimeEnvironment ?? null,
     status: INVESTIGATION_STATUS.READY,
     checkStatus: check?.status ?? null,
     generatedAt,
@@ -294,12 +298,14 @@ function parseJsonObject(content) {
   throw new Error("Investigator response did not contain a JSON object");
 }
 
-function investigationId(featureId, checkId, generatedAt) {
+function investigationId(featureId, checkId, generatedAt, runtimeEnvironment = null) {
   const digest = createHash("sha256")
-    .update(`${featureId ?? "unknown"}:${checkId ?? "unknown"}:${generatedAt}`)
+    .update(`${featureId ?? "unknown"}:${runtimeEnvironment ?? ""}:${checkId ?? "unknown"}:${generatedAt}`)
     .digest("hex")
     .slice(0, 12);
-  return `${featureId ?? "unknown"}:${checkId ?? "unknown"}:${digest}`;
+  return runtimeEnvironment
+    ? `${featureId ?? "unknown"}:${runtimeEnvironment}:${checkId ?? "unknown"}:${digest}`
+    : `${featureId ?? "unknown"}:${checkId ?? "unknown"}:${digest}`;
 }
 
 function evidenceDigest(check) {

--- a/infra/evals/status/lib/status-lessons.mjs
+++ b/infra/evals/status/lib/status-lessons.mjs
@@ -65,8 +65,8 @@ export function buildLearningInput({
     source,
     runSummary: {
       checkCount: checks.length,
-      failingCheckIds: checks.filter((check) => check.status === "fail").map((check) => check.checkId),
-      warningCheckIds: checks.filter((check) => check.status === "warn").map((check) => check.checkId),
+      failingCheckIds: checks.filter((check) => check.status === "fail").map(checkRef),
+      warningCheckIds: checks.filter((check) => check.status === "warn").map(checkRef),
       investigationCount: investigations.length,
       repairCount: repairs.length,
       repairDispatchPlan,
@@ -211,7 +211,7 @@ function buildLearningCase(entry) {
     return value === undefined || value === null;
   });
   return {
-    id: `${check.featureId ?? "unknown"}:${check.checkId ?? "unknown"}`,
+    id: `${check.featureId ?? "unknown"}:${check.runtimeEnvironment ?? ""}:${check.checkId ?? "unknown"}`,
     feature: entry.feature ?? null,
     checkConfig: entry.checkConfig ?? null,
     check: {
@@ -221,6 +221,8 @@ function buildLearningCase(entry) {
       message: check.message ?? "",
       endedAt: check.endedAt ?? null,
       latencyMs: check.latencyMs ?? null,
+      environment: check.environment ?? null,
+      runtimeEnvironment: check.runtimeEnvironment ?? null,
       evidence,
     },
     expectedOutputContract: expectation ? {
@@ -234,6 +236,10 @@ function buildLearningCase(entry) {
     verifierContext: entry.verifierContext ?? null,
     sourceDiscovery: entry.sourceDiscovery ?? null,
   };
+}
+
+function checkRef(check) {
+  return check?.runtimeEnvironment ? `${check.runtimeEnvironment}/${check.checkId}` : check?.checkId;
 }
 
 function summarizeInvestigation(investigation) {

--- a/infra/evals/status/lib/status-policy.mjs
+++ b/infra/evals/status/lib/status-policy.mjs
@@ -1,7 +1,9 @@
 import {
   annotateInvestigation,
+  inferRuntimeEnvironment,
   investigationKey,
   latestInvestigationsByCheck,
+  normalizeRuntimeEnvironment,
 } from "./status-investigations.mjs";
 
 export const FEATURE_STATUS = Object.freeze({
@@ -50,6 +52,9 @@ export function normalizeCheckResult(raw, generatedAt) {
   const startedAt = normalizeIsoDate(raw?.startedAt, endedAt);
   const runGeneratedAt = normalizeIsoDate(raw?.runGeneratedAt, null);
   const latencyMs = Number.isFinite(Number(raw?.latencyMs)) ? Math.max(0, Number(raw.latencyMs)) : null;
+  const runtimeEnvironment = normalizeRuntimeEnvironment(
+    raw?.runtimeEnvironment ?? raw?.runtime ?? inferRuntimeEnvironment(raw?.environment),
+  );
 
   return {
     checkId,
@@ -62,8 +67,21 @@ export function normalizeCheckResult(raw, generatedAt) {
     runGeneratedAt,
     latencyMs,
     environment: typeof raw?.environment === "string" ? raw.environment : null,
+    runtimeEnvironment,
     evidence: raw?.evidence && typeof raw.evidence === "object" ? raw.evidence : {},
   };
+}
+
+function checkMapKey(checkId, runtimeEnvironment = null) {
+  return runtimeEnvironment ? `${runtimeEnvironment}::${checkId}` : checkId;
+}
+
+function upsertLatest(map, key, check) {
+  if (!key) return;
+  const existing = map.get(key);
+  if (!existing || new Date(check.endedAt).getTime() > new Date(existing.endedAt).getTime()) {
+    map.set(key, check);
+  }
 }
 
 function latestByCheckId(checks, generatedAt) {
@@ -71,12 +89,35 @@ function latestByCheckId(checks, generatedAt) {
   for (const raw of checks) {
     const check = normalizeCheckResult(raw, generatedAt);
     if (!check.checkId) continue;
-    const existing = map.get(check.checkId);
-    if (!existing || new Date(check.endedAt).getTime() > new Date(existing.endedAt).getTime()) {
-      map.set(check.checkId, check);
-    }
+    upsertLatest(map, checkMapKey(check.checkId, check.runtimeEnvironment), check);
+    upsertLatest(map, check.checkId, check);
   }
   return map;
+}
+
+function checkConfigRuntimeEnvironment(config) {
+  return normalizeRuntimeEnvironment(config?.runtimeEnvironment ?? config?.runtime);
+}
+
+function checkConfigStatusImpact(config) {
+  return typeof config?.statusImpact === "string" ? config.statusImpact : "feature";
+}
+
+function lookupCheck(checkMap, config) {
+  const runtimeEnvironment = checkConfigRuntimeEnvironment(config);
+  if (!runtimeEnvironment) return checkMap.get(config.id);
+  const exact = checkMap.get(checkMapKey(config.id, runtimeEnvironment));
+  if (exact) return exact;
+  const legacy = checkMap.get(config.id);
+  return legacy?.runtimeEnvironment ? null : legacy;
+}
+
+function runtimeDefinitionMap(registry) {
+  return new Map((registry.runtimeEnvironments ?? []).map((runtime) => [runtime.id, runtime]));
+}
+
+function runtimeLabel(runtimeEnvironment, runtimeMap) {
+  return runtimeMap.get(runtimeEnvironment)?.label ?? runtimeEnvironment;
 }
 
 function checkVerdict(check, config, generatedAt) {
@@ -103,6 +144,16 @@ function checkVerdict(check, config, generatedAt) {
 
   const warningLatencyMs = Number(config.warningLatencyMs ?? Infinity);
   const outageLatencyMs = Number(config.outageLatencyMs ?? Infinity);
+  const informational = checkConfigStatusImpact(config) === "informational";
+
+  if (informational) {
+    return {
+      status: FEATURE_STATUS.OPERATIONAL,
+      reason: check.message || "Informational runtime check",
+      stale: false,
+      check,
+    };
+  }
 
   if (check.status === CHECK_STATUS.FAIL) {
     return {
@@ -164,7 +215,7 @@ function statusMax(left, right) {
 export function aggregateFeature(feature, checkMap, generatedAt, context = {}) {
   const checkConfigs = Array.isArray(feature.checks) ? feature.checks : [];
   const verdicts = checkConfigs.map((config) =>
-    checkVerdict(checkMap.get(config.id), config, generatedAt),
+    checkVerdict(lookupCheck(checkMap, config), config, generatedAt),
   );
   const requiredVerdicts = verdicts.filter((verdict, index) => checkConfigs[index]?.required !== false);
   const presentRequired = requiredVerdicts.filter((verdict) => verdict.check != null);
@@ -229,8 +280,11 @@ export function aggregateFeature(feature, checkMap, generatedAt, context = {}) {
     message: featureMessage(status, verdicts),
     checks: verdicts.map((verdict, index) => {
       const checkConfig = checkConfigs[index];
+      const runtimeEnvironment = checkConfigRuntimeEnvironment(checkConfig) ?? verdict.check?.runtimeEnvironment ?? null;
       const investigation = annotateInvestigation(
-        context.investigationMap?.get(investigationKey(feature.id, checkConfig.id))
+        context.investigationMap?.get(investigationKey(feature.id, checkConfig.id, runtimeEnvironment))
+          ?? context.investigationMap?.get(investigationKey(null, checkConfig.id, runtimeEnvironment))
+          ?? context.investigationMap?.get(investigationKey(feature.id, checkConfig.id))
           ?? context.investigationMap?.get(investigationKey(null, checkConfig.id)),
         {
           feature,
@@ -242,6 +296,10 @@ export function aggregateFeature(feature, checkMap, generatedAt, context = {}) {
       );
       return {
         id: checkConfig.id,
+        label: checkConfig.label ?? checkConfig.id,
+        runtimeEnvironment,
+        runtimeLabel: runtimeLabel(runtimeEnvironment, context.runtimeMap ?? new Map()),
+        statusImpact: checkConfigStatusImpact(checkConfig),
         required: checkConfig.required !== false,
         status: verdict.check?.status ?? "unknown",
         featureStatus: verdict.status,
@@ -273,9 +331,10 @@ export function buildStatusSnapshot({
   const normalizedGeneratedAt = normalizeIsoDate(generatedAt, new Date().toISOString());
   const checkMap = latestByCheckId(checks, normalizedGeneratedAt);
   const investigationMap = latestInvestigationsByCheck(investigations, normalizedGeneratedAt);
+  const runtimeMap = runtimeDefinitionMap(registry);
   const features = [...(registry.features ?? [])]
     .map((feature) =>
-      aggregateFeature(feature, checkMap, normalizedGeneratedAt, { environment, source, investigationMap }),
+      aggregateFeature(feature, checkMap, normalizedGeneratedAt, { environment, source, investigationMap, runtimeMap }),
     )
     .sort((left, right) => left.priority - right.priority || left.label.localeCompare(right.label));
   const attachedInvestigations = features
@@ -290,6 +349,9 @@ export function buildStatusSnapshot({
     (current, feature) => statusMax(current, feature.status),
     FEATURE_STATUS.OPERATIONAL,
   );
+  const runtimeIds = [...new Set(features.flatMap((feature) =>
+    feature.checks.map((check) => check.runtimeEnvironment).filter(Boolean),
+  ))].sort();
 
   return {
     schemaVersion: 1,
@@ -307,8 +369,17 @@ export function buildStatusSnapshot({
       majorOutage: features.filter((feature) => feature.status === FEATURE_STATUS.MAJOR_OUTAGE).length,
       unknown: features.filter((feature) => feature.status === FEATURE_STATUS.UNKNOWN).length,
       maintenance: features.filter((feature) => feature.status === FEATURE_STATUS.MAINTENANCE).length,
+      runtimeEnvironments: runtimeIds.length,
       investigations: attachedInvestigations.length,
     },
+    runtimeEnvironments: runtimeIds.map((id) => {
+      const definition = runtimeMap.get(id) ?? {};
+      return {
+        id,
+        label: definition.label ?? id,
+        description: definition.description ?? "",
+      };
+    }),
     features,
     investigations: attachedInvestigations,
   };

--- a/infra/evals/status/lib/status-policy.test.mjs
+++ b/infra/evals/status/lib/status-policy.test.mjs
@@ -148,6 +148,96 @@ test("buildStatusSnapshot picks the latest check result and computes overall sev
   assert.equal(snapshot.totals.degraded, 1);
 });
 
+test("buildStatusSnapshot separates feature health from runtime-specific media checks", () => {
+  const registry = {
+    title: "AURA Observability",
+    runtimeEnvironments: [
+      { id: "desktop-release", label: "Desktop Release" },
+      { id: "production-api", label: "Production API" },
+    ],
+    features: [
+      {
+        id: "media-generation",
+        label: "Media Generation",
+        category: "media",
+        priority: 10,
+        checks: [
+          {
+            id: "image-generation-stream",
+            label: "Image generation stream",
+            runtimeEnvironment: "desktop-release",
+            required: true,
+            staleAfterMinutes: 10,
+          },
+          {
+            id: "image-generation-stream",
+            label: "Image generation stream",
+            runtimeEnvironment: "production-api",
+            required: false,
+            statusImpact: "informational",
+            staleAfterMinutes: 10,
+          },
+        ],
+        outageAfterFailures: 1,
+      },
+    ],
+  };
+
+  const waitingForDesktop = buildStatusSnapshot({
+    registry,
+    generatedAt: GENERATED_AT,
+    environment: "production",
+    checks: [
+      {
+        checkId: "image-generation-stream",
+        featureId: "media-generation",
+        status: CHECK_STATUS.FAIL,
+        message: "production API has no harness route",
+        endedAt: GENERATED_AT,
+        runtimeEnvironment: "production-api",
+      },
+    ],
+  });
+
+  assert.equal(waitingForDesktop.features[0].status, FEATURE_STATUS.UNKNOWN);
+  assert.equal(waitingForDesktop.features[0].message, "No recent result");
+  assert.equal(waitingForDesktop.features[0].checks[1].statusImpact, "informational");
+  assert.equal(waitingForDesktop.features[0].checks[1].runtimeLabel, "Production API");
+
+  const desktopPassing = buildStatusSnapshot({
+    registry,
+    generatedAt: GENERATED_AT,
+    environment: "desktop-nightly-macos-aarch64",
+    checks: [
+      {
+        checkId: "image-generation-stream",
+        featureId: "media-generation",
+        status: CHECK_STATUS.PASS,
+        endedAt: GENERATED_AT,
+        runtimeEnvironment: "desktop-release",
+        evidence: { frameTypes: ["generation_start", "generation_completed"], imageUrlPresent: true },
+      },
+      {
+        checkId: "image-generation-stream",
+        featureId: "media-generation",
+        status: CHECK_STATUS.FAIL,
+        message: "production API has no harness route",
+        endedAt: GENERATED_AT,
+        runtimeEnvironment: "production-api",
+      },
+    ],
+  });
+
+  assert.equal(desktopPassing.features[0].status, FEATURE_STATUS.OPERATIONAL);
+  assert.equal(desktopPassing.features[0].checksPassed, 1);
+  assert.equal(desktopPassing.features[0].checksFailed, 1);
+  assert.equal(desktopPassing.totals.runtimeEnvironments, 2);
+  assert.deepEqual(
+    desktopPassing.runtimeEnvironments.map((runtime) => runtime.label),
+    ["Desktop Release", "Production API"],
+  );
+});
+
 test("buildStatusSnapshot attaches LLM-generated investigations to failed checks", () => {
   const registry = {
     title: "AURA Observability",

--- a/infra/evals/status/lib/status-registry.test.mjs
+++ b/infra/evals/status/lib/status-registry.test.mjs
@@ -15,10 +15,12 @@ async function readJson(relativePath) {
 test("every registered status check has an expected-output contract", async () => {
   const registry = await readJson("infra/evals/status/features.json");
   const expectations = await readJson("infra/evals/status/check-expectations.json");
-  const checkIds = registry.features.flatMap((feature) => feature.checks.map((check) => check.id));
+  const checks = registry.features.flatMap((feature) => feature.checks);
+  const checkKeys = checks.map(checkRegistryKey);
+  const checkIds = [...new Set(checks.map((check) => check.id))];
   const expectationIds = Object.keys(expectations.checks);
 
-  assert.equal(new Set(checkIds).size, checkIds.length, "registry check ids must be unique");
+  assert.equal(new Set(checkKeys).size, checkKeys.length, "registry check id/runtime pairs must be unique");
   assert.deepEqual(
     expectationIds.filter((id) => !checkIds.includes(id)),
     [],
@@ -41,7 +43,7 @@ test("every registered status check has an expected-output contract", async () =
 test("every registered status check has a runner branch", async () => {
   const registry = await readJson("infra/evals/status/features.json");
   const runner = await readFile(path.join(repoRoot, "infra/evals/status/run-status-probes.mjs"), "utf8");
-  const checkIds = registry.features.flatMap((feature) => feature.checks.map((check) => check.id));
+  const checkIds = [...new Set(registry.features.flatMap((feature) => feature.checks.map((check) => check.id)))];
   const runnerIds = Array.from(runner.matchAll(/selected\("([^"]+)"\)/g), (match) => match[1]);
   const unknown = runnerIds.filter((id) => !checkIds.includes(id));
   const missing = checkIds.filter((id) => !runner.includes(`selected("${id}")`));
@@ -58,11 +60,11 @@ test("every registered status check has response-time thresholds", async () => {
   for (const feature of registry.features) {
     for (const check of feature.checks) {
       if (!Object.hasOwn(check, "warningLatencyMs") || !Object.hasOwn(check, "outageLatencyMs")) {
-        missing.push(check.id);
+        missing.push(checkRegistryKey(check));
         continue;
       }
       if (!(check.warningLatencyMs > 0) || !(check.outageLatencyMs > check.warningLatencyMs)) {
-        invalid.push(check.id);
+        invalid.push(checkRegistryKey(check));
       }
     }
   }
@@ -70,3 +72,7 @@ test("every registered status check has response-time thresholds", async () => {
   assert.deepEqual(missing, [], "every check must define warningLatencyMs and outageLatencyMs");
   assert.deepEqual(invalid, [], "every check must define positive thresholds with outage > warning");
 });
+
+function checkRegistryKey(check) {
+  return check.runtimeEnvironment ? `${check.runtimeEnvironment}::${check.id}` : check.id;
+}

--- a/infra/evals/status/lib/status-repairer.mjs
+++ b/infra/evals/status/lib/status-repairer.mjs
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
 
+import { recordRuntimeEnvironment } from "./status-investigations.mjs";
 import { redactSensitive } from "./status-redaction.mjs";
 
 export const REPAIR_STATUS = Object.freeze({
@@ -83,6 +84,8 @@ export function buildRepairInput({
       startedAt: check?.startedAt ?? null,
       endedAt: check?.endedAt ?? null,
       latencyMs: check?.latencyMs ?? null,
+      environment: check?.environment ?? null,
+      runtimeEnvironment: check?.runtimeEnvironment ?? null,
       evidence: check?.evidence ?? {},
     },
     expectedOutputContract: expectation ?? null,
@@ -105,9 +108,9 @@ export function buildRepairInput({
     sourceHints,
     sourceContext,
     verifierContext,
-    defaultReproductionCommand: check?.checkId ? `AURA_STATUS_CHECKS=${check.checkId} npm run status:probes` : "npm run status:probes",
+    defaultReproductionCommand: reproductionCommand(check),
     defaultVerificationCommands: [
-      check?.checkId ? `AURA_STATUS_CHECKS=${check.checkId} npm run status:probes` : "npm run status:probes",
+      reproductionCommand(check),
       "node --test $(rg --files infra/evals/status | rg 'test\\.mjs$')",
     ],
     responseSchema: {
@@ -247,10 +250,11 @@ export function normalizeRepairResponse(content, metadata) {
     ...parsed,
     schemaVersion: 1,
     kind: "llm-repair",
-    id: repairId(metadata.feature?.id ?? metadata.check?.featureId, metadata.check?.checkId, metadata.generatedAt),
+    id: repairId(metadata.feature?.id ?? metadata.check?.featureId, metadata.check?.checkId, metadata.generatedAt, metadata.check?.runtimeEnvironment),
     featureId: metadata.feature?.id ?? metadata.check?.featureId ?? null,
     featureLabel: metadata.feature?.label ?? metadata.feature?.id ?? "Unknown feature",
     checkId: metadata.check?.checkId,
+    runtimeEnvironment: metadata.check?.runtimeEnvironment ?? null,
     investigationId: metadata.investigation?.id ?? null,
     status: REPAIR_STATUS.READY,
     generatedAt: metadata.generatedAt,
@@ -265,14 +269,16 @@ export function normalizeRepair(raw, generatedAt = new Date().toISOString()) {
   const checkId = typeof raw?.checkId === "string" ? raw.checkId.trim() : "";
   if (!checkId) return null;
   const featureId = typeof raw.featureId === "string" && raw.featureId.trim() ? raw.featureId.trim() : null;
+  const runtimeEnvironment = recordRuntimeEnvironment(raw);
   const repairable = raw.repairable === true;
   return {
     schemaVersion: 1,
     kind: "llm-repair",
-    id: stringOrDefault(raw.id, repairId(featureId, checkId, generatedAt)),
+    id: stringOrDefault(raw.id, repairId(featureId, checkId, generatedAt, runtimeEnvironment)),
     featureId,
     featureLabel: stringOrDefault(raw.featureLabel, featureId ?? "Unknown feature"),
     checkId,
+    runtimeEnvironment,
     investigationId: typeof raw.investigationId === "string" ? raw.investigationId : null,
     status: VALID_REPAIR_STATUS.has(raw.status) ? raw.status : REPAIR_STATUS.READY,
     generatedAt: normalizeIsoDate(raw.generatedAt, generatedAt),
@@ -368,12 +374,22 @@ function parseJsonObject(content) {
   throw new Error("Repair response did not contain a JSON object");
 }
 
-function repairId(featureId, checkId, generatedAt) {
+function reproductionCommand(check) {
+  if (!check?.checkId) return "npm run status:probes";
+  const runtimePrefix = check.runtimeEnvironment
+    ? `AURA_STATUS_RUNTIME_ENVIRONMENT=${check.runtimeEnvironment} `
+    : "";
+  return `${runtimePrefix}AURA_STATUS_CHECKS=${check.checkId} npm run status:probes`;
+}
+
+function repairId(featureId, checkId, generatedAt, runtimeEnvironment = null) {
   const digest = createHash("sha256")
-    .update(`${featureId ?? "unknown"}:${checkId ?? "unknown"}:${generatedAt}`)
+    .update(`${featureId ?? "unknown"}:${runtimeEnvironment ?? ""}:${checkId ?? "unknown"}:${generatedAt}`)
     .digest("hex")
     .slice(0, 12);
-  return `${featureId ?? "unknown"}:${checkId ?? "unknown"}:${digest}`;
+  return runtimeEnvironment
+    ? `${featureId ?? "unknown"}:${runtimeEnvironment}:${checkId ?? "unknown"}:${digest}`
+    : `${featureId ?? "unknown"}:${checkId ?? "unknown"}:${digest}`;
 }
 
 function normalizeIsoDate(value, fallback) {

--- a/infra/evals/status/plan-status-repair-dispatch.mjs
+++ b/infra/evals/status/plan-status-repair-dispatch.mjs
@@ -8,6 +8,7 @@ import {
   INVESTIGATION_STATUS,
   investigationKey,
   latestInvestigationsByCheck,
+  recordRuntimeEnvironment,
 } from "./lib/status-investigations.mjs";
 import { normalizeCheckResult } from "./lib/status-policy.mjs";
 
@@ -104,12 +105,18 @@ function latestByCheckId(checks, generatedAt) {
   const map = new Map();
   for (const check of checks) {
     if (!check.checkId) continue;
-    const existing = map.get(check.checkId);
+    const key = checkRuntimeKey(check);
+    const existing = map.get(key);
     const endedAt = new Date(check.endedAt ?? generatedAt).getTime();
     const existingEndedAt = new Date(existing?.endedAt ?? 0).getTime();
-    if (!existing || endedAt > existingEndedAt) map.set(check.checkId, check);
+    if (!existing || endedAt > existingEndedAt) map.set(key, check);
   }
   return [...map.values()];
+}
+
+function checkRuntimeKey(check) {
+  const runtimeEnvironment = recordRuntimeEnvironment(check);
+  return runtimeEnvironment ? `${runtimeEnvironment}::${check.checkId}` : check.checkId;
 }
 
 async function readInvestigations(args, generatedAt) {
@@ -138,12 +145,16 @@ function shouldRepairCheck(check, investigation, minConfidence) {
 function buildPlan({ checks, investigationMap, minConfidence, maxChecks, generatedAt }) {
   const eligible = [];
   for (const check of checks) {
-    const investigation = investigationMap.get(investigationKey(check.featureId, check.checkId))
+    const runtimeEnvironment = recordRuntimeEnvironment(check);
+    const investigation = investigationMap.get(investigationKey(check.featureId, check.checkId, runtimeEnvironment))
+      ?? investigationMap.get(investigationKey(null, check.checkId, runtimeEnvironment))
+      ?? investigationMap.get(investigationKey(check.featureId, check.checkId))
       ?? investigationMap.get(investigationKey(null, check.checkId));
     if (!shouldRepairCheck(check, investigation, minConfidence)) continue;
     eligible.push({
       checkId: check.checkId,
       featureId: check.featureId,
+      runtimeEnvironment,
       status: check.status,
       investigationId: investigation.id,
       investigationConfidence: investigation.confidence,

--- a/infra/evals/status/run-desktop-release-probes.mjs
+++ b/infra/evals/status/run-desktop-release-probes.mjs
@@ -27,6 +27,7 @@ function parseArgs(argv) {
     port: process.env.AURA_STATUS_DESKTOP_PORT || process.env.AURA_SERVER_PORT || "19847",
     baseUrl: process.env.AURA_STATUS_DESKTOP_BASE_URL || "",
     checks: process.env.AURA_STATUS_DESKTOP_CHECKS || DEFAULT_CHECKS.join(","),
+    runtimeEnvironment: process.env.AURA_STATUS_RUNTIME_ENVIRONMENT || "desktop-release",
     outDir:
       process.env.AURA_STATUS_CHECKS_DIR ||
       path.join(repoRoot, "infra/evals/reports/status/checks"),
@@ -46,6 +47,7 @@ function parseArgs(argv) {
     else if (arg === "--port") args.port = next();
     else if (arg === "--base-url") args.baseUrl = next();
     else if (arg === "--checks") args.checks = next();
+    else if (arg === "--runtime-environment") args.runtimeEnvironment = next();
     else if (arg === "--out-dir") args.outDir = path.resolve(next());
     else if (arg === "--environment") args.environment = next();
     else if (arg === "--timeout-ms") args.timeoutMs = Number(next());
@@ -127,6 +129,8 @@ function runProbes(args) {
         args.outDir,
         "--environment",
         args.environment,
+        "--runtime-environment",
+        args.runtimeEnvironment,
       ],
       {
         cwd: repoRoot,
@@ -134,6 +138,7 @@ function runProbes(args) {
           ...process.env,
           AURA_STATUS_API_BASE_URL: args.baseUrl,
           AURA_STATUS_ENVIRONMENT: args.environment,
+          AURA_STATUS_RUNTIME_ENVIRONMENT: args.runtimeEnvironment,
           AURA_STATUS_CHECKS_DIR: args.outDir,
         },
         stdio: ["ignore", "pipe", "pipe"],

--- a/infra/evals/status/run-status-investigations.mjs
+++ b/infra/evals/status/run-status-investigations.mjs
@@ -14,6 +14,7 @@ import {
   callOpenAiCompatibleJson,
 } from "./lib/status-llm-client.mjs";
 import { discoverInvestigationSources } from "./lib/status-source-discovery.mjs";
+import { recordRuntimeEnvironment } from "./lib/status-investigations.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..", "..", "..");
@@ -208,22 +209,39 @@ function latestByCheckId(checks, generatedAt) {
   const map = new Map();
   for (const check of checks) {
     if (!check.checkId) continue;
-    const existing = map.get(check.checkId);
+    const key = checkRuntimeKey(check);
+    const existing = map.get(key);
     const endedAt = new Date(check.endedAt ?? generatedAt).getTime();
     const existingEndedAt = new Date(existing?.endedAt ?? 0).getTime();
-    if (!existing || endedAt > existingEndedAt) map.set(check.checkId, check);
+    if (!existing || endedAt > existingEndedAt) map.set(key, check);
   }
   return [...map.values()];
 }
 
+function checkRuntimeKey(check) {
+  const runtimeEnvironment = recordRuntimeEnvironment(check);
+  return runtimeEnvironment ? `${runtimeEnvironment}::${check.checkId}` : check.checkId;
+}
+
+function sameCheckRuntime(left, right) {
+  return left?.checkId === right?.checkId && recordRuntimeEnvironment(left) === recordRuntimeEnvironment(right);
+}
+
 function findFeature(registry, check) {
   return (registry.features ?? []).find((feature) => feature.id === check.featureId)
-    ?? (registry.features ?? []).find((feature) => (feature.checks ?? []).some((config) => config.id === check.checkId))
+    ?? (registry.features ?? []).find((feature) => (feature.checks ?? []).some((config) => checkConfigMatches(config, check)))
     ?? null;
 }
 
-function findCheckConfig(feature, checkId) {
-  return (feature?.checks ?? []).find((config) => config.id === checkId) ?? null;
+function findCheckConfig(feature, check) {
+  return (feature?.checks ?? []).find((config) => checkConfigMatches(config, check))
+    ?? (feature?.checks ?? []).find((config) => config.id === check?.checkId)
+    ?? null;
+}
+
+function checkConfigMatches(config, check) {
+  if (!config || config.id !== check?.checkId) return false;
+  return !config.runtimeEnvironment || config.runtimeEnvironment === recordRuntimeEnvironment(check);
 }
 
 function hasConfiguredModel(args) {
@@ -292,12 +310,12 @@ async function main() {
 
   for (const check of failingChecks) {
     const feature = findFeature(registry, check);
-    const checkConfig = findCheckConfig(feature, check.checkId);
+    const checkConfig = findCheckConfig(feature, check);
     const expectation = expectations.checks?.[check.checkId] ?? null;
-    const siblingChecks = checks.filter((candidate) => candidate.featureId === check.featureId && candidate.checkId !== check.checkId);
+    const siblingChecks = checks.filter((candidate) => candidate.featureId === check.featureId && checkRuntimeKey(candidate) !== checkRuntimeKey(check));
     const previousChecks = checkRecords
       .filter((candidate) =>
-        candidate.checkId === check.checkId
+        sameCheckRuntime(candidate, check)
           && candidate.endedAt
           && check.endedAt
           && new Date(candidate.endedAt).getTime() < new Date(check.endedAt).getTime(),

--- a/infra/evals/status/run-status-learning.mjs
+++ b/infra/evals/status/run-status-learning.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   latestInvestigationsByCheck,
   investigationKey,
+  recordRuntimeEnvironment,
 } from "./lib/status-investigations.mjs";
 import { buildInvestigationVerifierContext } from "./lib/status-investigation-verifiers.mjs";
 import {
@@ -212,12 +213,22 @@ function latestByCheckId(checks, generatedAt) {
   const map = new Map();
   for (const check of checks) {
     if (!check.checkId) continue;
-    const existing = map.get(check.checkId);
+    const key = checkRuntimeKey(check);
+    const existing = map.get(key);
     const endedAt = new Date(check.endedAt ?? generatedAt).getTime();
     const existingEndedAt = new Date(existing?.endedAt ?? 0).getTime();
-    if (!existing || endedAt > existingEndedAt) map.set(check.checkId, check);
+    if (!existing || endedAt > existingEndedAt) map.set(key, check);
   }
   return [...map.values()];
+}
+
+function checkRuntimeKey(check) {
+  const runtimeEnvironment = recordRuntimeEnvironment(check);
+  return runtimeEnvironment ? `${runtimeEnvironment}::${check.checkId}` : check.checkId;
+}
+
+function sameCheckRuntime(left, right) {
+  return left?.checkId === right?.checkId && recordRuntimeEnvironment(left) === recordRuntimeEnvironment(right);
 }
 
 async function readInvestigations(args, generatedAt) {
@@ -267,11 +278,15 @@ async function readOptionalJson(filePath) {
 function latestRepairsByCheck(repairs) {
   const map = new Map();
   for (const repair of repairs) {
-    const key = investigationKey(repair.featureId, repair.checkId);
-    const existing = map.get(key) ?? map.get(investigationKey(null, repair.checkId));
+    const runtimeEnvironment = recordRuntimeEnvironment(repair);
+    const key = investigationKey(repair.featureId, repair.checkId, runtimeEnvironment);
+    const existing = map.get(key)
+      ?? map.get(investigationKey(null, repair.checkId, runtimeEnvironment))
+      ?? map.get(investigationKey(null, repair.checkId));
     if (!existing || new Date(repair.generatedAt ?? 0).getTime() > new Date(existing.generatedAt ?? 0).getTime()) {
       map.set(key, repair);
-      map.set(investigationKey(null, repair.checkId), repair);
+      if (runtimeEnvironment) map.set(investigationKey(null, repair.checkId, runtimeEnvironment), repair);
+      else map.set(investigationKey(null, repair.checkId), repair);
     }
   }
   return map;
@@ -279,12 +294,19 @@ function latestRepairsByCheck(repairs) {
 
 function findFeature(registry, check) {
   return (registry.features ?? []).find((feature) => feature.id === check.featureId)
-    ?? (registry.features ?? []).find((feature) => (feature.checks ?? []).some((config) => config.id === check.checkId))
+    ?? (registry.features ?? []).find((feature) => (feature.checks ?? []).some((config) => checkConfigMatches(config, check)))
     ?? null;
 }
 
-function findCheckConfig(feature, checkId) {
-  return (feature?.checks ?? []).find((config) => config.id === checkId) ?? null;
+function findCheckConfig(feature, check) {
+  return (feature?.checks ?? []).find((config) => checkConfigMatches(config, check))
+    ?? (feature?.checks ?? []).find((config) => config.id === check?.checkId)
+    ?? null;
+}
+
+function checkConfigMatches(config, check) {
+  if (!config || config.id !== check?.checkId) return false;
+  return !config.runtimeEnvironment || config.runtimeEnvironment === recordRuntimeEnvironment(check);
 }
 
 function shouldLearnFromCheck(check) {
@@ -331,12 +353,12 @@ async function buildLearningCases({
   const cases = [];
   for (const check of checks.filter(shouldLearnFromCheck).slice(0, args.maxCases)) {
     const feature = findFeature(registry, check);
-    const checkConfig = findCheckConfig(feature, check.checkId);
+    const checkConfig = findCheckConfig(feature, check);
     const expectation = expectations.checks?.[check.checkId] ?? null;
-    const siblingChecks = checks.filter((candidate) => candidate.featureId === check.featureId && candidate.checkId !== check.checkId);
+    const siblingChecks = checks.filter((candidate) => candidate.featureId === check.featureId && checkRuntimeKey(candidate) !== checkRuntimeKey(check));
     const previousChecks = checkRecords
       .filter((candidate) =>
-        candidate.checkId === check.checkId
+        sameCheckRuntime(candidate, check)
           && candidate.endedAt
           && check.endedAt
           && new Date(candidate.endedAt).getTime() < new Date(check.endedAt).getTime(),
@@ -361,10 +383,15 @@ async function buildLearningCases({
       sourceContext,
       sourceDiscovery,
     });
-    const investigation = investigationMap.get(investigationKey(check.featureId, check.checkId))
+    const runtimeEnvironment = recordRuntimeEnvironment(check);
+    const investigation = investigationMap.get(investigationKey(check.featureId, check.checkId, runtimeEnvironment))
+      ?? investigationMap.get(investigationKey(null, check.checkId, runtimeEnvironment))
+      ?? investigationMap.get(investigationKey(check.featureId, check.checkId))
       ?? investigationMap.get(investigationKey(null, check.checkId))
       ?? null;
-    const repair = repairMap.get(investigationKey(check.featureId, check.checkId))
+    const repair = repairMap.get(investigationKey(check.featureId, check.checkId, runtimeEnvironment))
+      ?? repairMap.get(investigationKey(null, check.checkId, runtimeEnvironment))
+      ?? repairMap.get(investigationKey(check.featureId, check.checkId))
       ?? repairMap.get(investigationKey(null, check.checkId))
       ?? null;
     cases.push({

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -37,6 +37,7 @@ function parseArgs(argv) {
     expectationsFile: process.env.AURA_STATUS_EXPECTATIONS_FILE || path.join(__dirname, "check-expectations.json"),
     expectations: null,
     environment: process.env.AURA_STATUS_ENVIRONMENT || "local",
+    runtimeEnvironment: process.env.AURA_STATUS_RUNTIME_ENVIRONMENT || "",
     checks: (process.env.AURA_STATUS_CHECKS || "").split(",").map((v) => v.trim()).filter(Boolean),
     models: (process.env.AURA_STATUS_MODEL_IDS || "").split(",").map((v) => v.trim()).filter(Boolean),
     keepEntities: process.env.AURA_STATUS_KEEP_ENTITIES === "1",
@@ -57,6 +58,7 @@ function parseArgs(argv) {
     else if (arg === "--out-dir") args.outDir = path.resolve(next());
     else if (arg === "--expectations") args.expectationsFile = path.resolve(next());
     else if (arg === "--environment") args.environment = next();
+    else if (arg === "--runtime-environment") args.runtimeEnvironment = next();
     else if (arg === "--checks") args.checks = next().split(",").map((v) => v.trim()).filter(Boolean);
     else if (arg === "--models") args.models = next().split(",").map((v) => v.trim()).filter(Boolean);
     else if (arg === "--keep-entities") args.keepEntities = true;
@@ -68,10 +70,23 @@ function parseArgs(argv) {
     }
   }
   args.baseUrl = args.baseUrl.replace(/\/+$/, "");
+  args.runtimeEnvironment = normalizeRuntimeEnvironment(args.runtimeEnvironment || inferRuntimeEnvironment(args.environment));
   args.publicBaseUrl = args.publicBaseUrl.replace(/\/+$/, "");
   if (args.models.length === 0) args.models = DEFAULT_MODELS;
   args.checks = args.checks.length > 0 ? new Set(args.checks) : null;
   return args;
+}
+
+function normalizeRuntimeEnvironment(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function inferRuntimeEnvironment(environment) {
+  const normalized = typeof environment === "string" ? environment.trim().toLowerCase() : "";
+  if (normalized.startsWith("desktop-")) return "desktop-release";
+  if (normalized === "production") return "production-api";
+  if (normalized === "local") return "local-dev";
+  return normalized || "";
 }
 
 function sseFramesFromText(text) {
@@ -259,6 +274,7 @@ async function probe(checkId, featureId, label, args, fn) {
       endedAt: new Date().toISOString(),
       latencyMs: Date.now() - started,
       environment: args.environment,
+      runtimeEnvironment: args.runtimeEnvironment,
       evidence: evidence?.evidence ?? evidence ?? {},
     };
     const expectationError = validateCheckEvidence(checkId, result, args.expectations);
@@ -281,6 +297,7 @@ async function probe(checkId, featureId, label, args, fn) {
       endedAt: new Date().toISOString(),
       latencyMs: Date.now() - started,
       environment: args.environment,
+      runtimeEnvironment: args.runtimeEnvironment,
       evidence: {},
     };
   }
@@ -1112,6 +1129,7 @@ async function writeRun(args, checks) {
     runId,
     generatedAt: new Date().toISOString(),
     environment: args.environment,
+    runtimeEnvironment: args.runtimeEnvironment,
     baseUrl: args.baseUrl,
     checks,
   };

--- a/infra/evals/status/run-status-repairs.mjs
+++ b/infra/evals/status/run-status-repairs.mjs
@@ -10,6 +10,7 @@ import {
   latestInvestigationsByCheck,
   investigationKey,
   INVESTIGATION_STATUS,
+  recordRuntimeEnvironment,
 } from "./lib/status-investigations.mjs";
 import { buildInvestigationVerifierContext } from "./lib/status-investigation-verifiers.mjs";
 import {
@@ -220,12 +221,22 @@ function latestByCheckId(checks, generatedAt) {
   const map = new Map();
   for (const check of checks) {
     if (!check.checkId) continue;
-    const existing = map.get(check.checkId);
+    const key = checkRuntimeKey(check);
+    const existing = map.get(key);
     const endedAt = new Date(check.endedAt ?? generatedAt).getTime();
     const existingEndedAt = new Date(existing?.endedAt ?? 0).getTime();
-    if (!existing || endedAt > existingEndedAt) map.set(check.checkId, check);
+    if (!existing || endedAt > existingEndedAt) map.set(key, check);
   }
   return [...map.values()];
+}
+
+function checkRuntimeKey(check) {
+  const runtimeEnvironment = recordRuntimeEnvironment(check);
+  return runtimeEnvironment ? `${runtimeEnvironment}::${check.checkId}` : check.checkId;
+}
+
+function sameCheckRuntime(left, right) {
+  return left?.checkId === right?.checkId && recordRuntimeEnvironment(left) === recordRuntimeEnvironment(right);
 }
 
 async function readInvestigations(args, generatedAt) {
@@ -250,12 +261,19 @@ function investigationsFromPayload(payload) {
 
 function findFeature(registry, check) {
   return (registry.features ?? []).find((feature) => feature.id === check.featureId)
-    ?? (registry.features ?? []).find((feature) => (feature.checks ?? []).some((config) => config.id === check.checkId))
+    ?? (registry.features ?? []).find((feature) => (feature.checks ?? []).some((config) => checkConfigMatches(config, check)))
     ?? null;
 }
 
-function findCheckConfig(feature, checkId) {
-  return (feature?.checks ?? []).find((config) => config.id === checkId) ?? null;
+function findCheckConfig(feature, check) {
+  return (feature?.checks ?? []).find((config) => checkConfigMatches(config, check))
+    ?? (feature?.checks ?? []).find((config) => config.id === check?.checkId)
+    ?? null;
+}
+
+function checkConfigMatches(config, check) {
+  if (!config || config.id !== check?.checkId) return false;
+  return !config.runtimeEnvironment || config.runtimeEnvironment === recordRuntimeEnvironment(check);
 }
 
 function needsRepair(check) {
@@ -568,8 +586,11 @@ async function main() {
   const investigations = await readInvestigations(args, generatedAt);
   const investigationMap = latestInvestigationsByCheck(investigations, generatedAt);
   const failingChecks = checks.filter(needsRepair).filter((check) => {
-    const key = investigationKey(check.featureId, check.checkId);
-    const investigation = investigationMap.get(key) ?? investigationMap.get(investigationKey(null, check.checkId));
+    const runtimeEnvironment = recordRuntimeEnvironment(check);
+    const investigation = investigationMap.get(investigationKey(check.featureId, check.checkId, runtimeEnvironment))
+      ?? investigationMap.get(investigationKey(null, check.checkId, runtimeEnvironment))
+      ?? investigationMap.get(investigationKey(check.featureId, check.checkId))
+      ?? investigationMap.get(investigationKey(null, check.checkId));
     return investigation?.status === INVESTIGATION_STATUS.READY;
   }).slice(0, args.maxRepairs);
 
@@ -598,14 +619,17 @@ async function main() {
 
   for (const check of failingChecks) {
     const feature = findFeature(registry, check);
-    const checkConfig = findCheckConfig(feature, check.checkId);
+    const checkConfig = findCheckConfig(feature, check);
     const expectation = expectations.checks?.[check.checkId] ?? null;
-    const investigation = investigationMap.get(investigationKey(check.featureId, check.checkId))
+    const runtimeEnvironment = recordRuntimeEnvironment(check);
+    const investigation = investigationMap.get(investigationKey(check.featureId, check.checkId, runtimeEnvironment))
+      ?? investigationMap.get(investigationKey(null, check.checkId, runtimeEnvironment))
+      ?? investigationMap.get(investigationKey(check.featureId, check.checkId))
       ?? investigationMap.get(investigationKey(null, check.checkId));
-    const siblingChecks = checks.filter((candidate) => candidate.featureId === check.featureId && candidate.checkId !== check.checkId);
+    const siblingChecks = checks.filter((candidate) => candidate.featureId === check.featureId && checkRuntimeKey(candidate) !== checkRuntimeKey(check));
     const previousChecks = checkRecords
       .filter((candidate) =>
-        candidate.checkId === check.checkId
+        sameCheckRuntime(candidate, check)
           && candidate.endedAt
           && check.endedAt
           && new Date(candidate.endedAt).getTime() < new Date(check.endedAt).getTime(),

--- a/interface/src/api/marketing/status.ts
+++ b/interface/src/api/marketing/status.ts
@@ -24,6 +24,7 @@ export interface StatusInvestigation {
   readonly featureId: string | null;
   readonly featureLabel: string;
   readonly checkId: string;
+  readonly runtimeEnvironment?: string | null;
   readonly title: string;
   readonly status: "ready" | "failed" | "skipped";
   readonly checkStatus: StatusCheckState | null;
@@ -50,6 +51,10 @@ export interface StatusInvestigation {
 
 export interface StatusCheck {
   readonly id: string;
+  readonly label?: string;
+  readonly runtimeEnvironment?: string | null;
+  readonly runtimeLabel?: string | null;
+  readonly statusImpact?: "feature" | "informational" | string;
   readonly required: boolean;
   readonly status: StatusCheckState;
   readonly featureStatus: FeatureHealthStatus;
@@ -94,8 +99,14 @@ export interface StatusSnapshot {
     readonly majorOutage: number;
     readonly unknown: number;
     readonly maintenance: number;
+    readonly runtimeEnvironments?: number;
     readonly investigations?: number;
   };
+  readonly runtimeEnvironments?: readonly {
+    readonly id: string;
+    readonly label: string;
+    readonly description?: string;
+  }[];
   readonly features: readonly StatusFeature[];
   readonly investigations?: readonly StatusInvestigation[];
 }

--- a/interface/src/views/marketing/StatusView/StatusView.css
+++ b/interface/src/views/marketing/StatusView/StatusView.css
@@ -94,7 +94,7 @@
 
 .statusSummary {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 1px;
   margin-bottom: 10px;
   border: 1px solid rgba(238, 242, 244, 0.09);
@@ -310,12 +310,12 @@
 .statusCheckHeader,
 .statusCheckRow {
   display: grid;
-  grid-template-columns: minmax(190px, 1.45fr) minmax(92px, 0.6fr) minmax(82px, 0.5fr) minmax(96px, 0.65fr);
-  min-width: 580px;
+  grid-template-columns: minmax(210px, 1.45fr) minmax(116px, 0.75fr) minmax(92px, 0.6fr) minmax(82px, 0.5fr) minmax(96px, 0.65fr);
+  min-width: 720px;
 }
 
-.statusCheckHeader span,
-.statusCheckRow span {
+.statusCheckHeader > span,
+.statusCheckRow > span {
   min-width: 0;
   padding: 10px 12px;
   overflow: hidden;
@@ -327,7 +327,7 @@
   color: rgba(238, 242, 244, 0.68);
 }
 
-.statusCheckHeader span {
+.statusCheckHeader > span {
   font-size: 11px;
   font-weight: 700;
   color: rgba(238, 242, 244, 0.48);
@@ -337,6 +337,31 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+}
+
+.statusCheckName code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border: 0;
+  color: rgba(238, 242, 244, 0.42);
+  font-family: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", monospace;
+  font-size: 10px;
+}
+
+.statusRuntimeTag {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  min-height: 20px;
+  padding: 0 7px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border: 1px solid rgba(154, 199, 255, 0.16);
+  background: rgba(52, 112, 191, 0.12);
+  color: rgba(205, 226, 255, 0.82);
+  font-size: 11px;
+  line-height: 1;
 }
 
 .statusOptional {

--- a/interface/src/views/marketing/StatusView/StatusView.test.tsx
+++ b/interface/src/views/marketing/StatusView/StatusView.test.tsx
@@ -86,7 +86,12 @@ const FIXTURE_SNAPSHOT: StatusSnapshot = {
     unknown: 0,
     maintenance: 0,
     investigations: 1,
+    runtimeEnvironments: 2,
   },
+  runtimeEnvironments: [
+    { id: "production-api", label: "Production API" },
+    { id: "desktop-release", label: "Desktop Release" },
+  ],
   features: [
     {
       id: "core-api",
@@ -106,6 +111,9 @@ const FIXTURE_SNAPSHOT: StatusSnapshot = {
       checks: [
         {
           id: "api-health",
+          label: "API health endpoint",
+          runtimeEnvironment: "production-api",
+          runtimeLabel: "Production API",
           required: true,
           status: "pass",
           featureStatus: "operational",
@@ -116,6 +124,8 @@ const FIXTURE_SNAPSHOT: StatusSnapshot = {
         },
         {
           id: "auth-session",
+          runtimeEnvironment: "production-api",
+          runtimeLabel: "Production API",
           required: true,
           status: "pass",
           featureStatus: "operational",
@@ -144,6 +154,9 @@ const FIXTURE_SNAPSHOT: StatusSnapshot = {
       checks: [
         {
           id: "model-matrix",
+          runtimeEnvironment: "desktop-release",
+          runtimeLabel: "Desktop Release",
+          statusImpact: "informational",
           required: true,
           status: "warn",
           featureStatus: "degraded",
@@ -267,6 +280,7 @@ describe("StatusView", () => {
       }),
     );
     expect(screen.getAllByText("Degraded").length).toBeGreaterThan(0);
+    expect(screen.getByText("Runtimes")).toBeInTheDocument();
     expect(screen.getByText("2/3 models returned the expected response")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: "Platform" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: "Models" })).toBeInTheDocument();
@@ -285,6 +299,8 @@ describe("StatusView", () => {
     expect(table).toBeDefined();
     if (!table) return;
     expect(within(table).getByText("model-matrix")).toBeInTheDocument();
+    expect(within(table).getByText("Desktop Release")).toBeInTheDocument();
+    expect(within(table).getByText("Info")).toBeInTheDocument();
     expect(within(table).getByText("warn")).toBeInTheDocument();
     expect(within(table).getByText("42 s")).toBeInTheDocument();
     expect(within(table).getByText("2/3")).toBeInTheDocument();

--- a/interface/src/views/marketing/StatusView/StatusView.tsx
+++ b/interface/src/views/marketing/StatusView/StatusView.tsx
@@ -58,7 +58,9 @@ const FALLBACK_SNAPSHOT: StatusSnapshot = {
     majorOutage: 0,
     unknown: 0,
     maintenance: 0,
+    runtimeEnvironments: 0,
   },
+  runtimeEnvironments: [],
   features: [],
 };
 
@@ -128,6 +130,10 @@ function extractEvidence(check: StatusCheck): string {
   return Object.keys(evidence).length > 0 ? "Captured" : "-";
 }
 
+function runtimeDisplay(check: StatusCheck): string {
+  return check.runtimeLabel || check.runtimeEnvironment || "-";
+}
+
 function investigationsFor(feature: StatusFeature): StatusInvestigation[] {
   return feature.checks
     .map((check) => check.investigation)
@@ -136,30 +142,38 @@ function investigationsFor(feature: StatusFeature): StatusInvestigation[] {
 
 interface InvestigationReportGroup {
   readonly investigation: StatusInvestigation;
-  readonly checkIds: readonly string[];
+  readonly checkRefs: readonly string[];
 }
 
 function investigationGroupKey(investigation: StatusInvestigation): string {
+  const runtime = investigation.runtimeEnvironment || "";
   const evidenceMessage = investigation.evidenceDigest?.message;
   if (typeof evidenceMessage === "string" && evidenceMessage.trim()) {
-    return `${investigation.featureId ?? ""}:${evidenceMessage.trim()}`;
+    return `${investigation.featureId ?? ""}:${runtime}:${evidenceMessage.trim()}`;
   }
-  return `${investigation.featureId ?? ""}:${investigation.checkId}:${investigation.rootCause}`;
+  return `${investigation.featureId ?? ""}:${runtime}:${investigation.checkId}:${investigation.rootCause}`;
+}
+
+function investigationCheckRef(investigation: StatusInvestigation): string {
+  return investigation.runtimeEnvironment
+    ? `${investigation.runtimeEnvironment}/${investigation.checkId}`
+    : investigation.checkId;
 }
 
 function groupInvestigations(investigations: readonly StatusInvestigation[]): InvestigationReportGroup[] {
   const groups = new Map<string, InvestigationReportGroup>();
   for (const investigation of investigations) {
     const key = investigationGroupKey(investigation);
+    const checkRef = investigationCheckRef(investigation);
     const existing = groups.get(key);
     if (!existing) {
-      groups.set(key, { investigation, checkIds: [investigation.checkId] });
+      groups.set(key, { investigation, checkRefs: [checkRef] });
       continue;
     }
-    if (!existing.checkIds.includes(investigation.checkId)) {
+    if (!existing.checkRefs.includes(checkRef)) {
       groups.set(key, {
         investigation: existing.investigation,
-        checkIds: [...existing.checkIds, investigation.checkId],
+        checkRefs: [...existing.checkRefs, checkRef],
       });
     }
   }
@@ -250,7 +264,7 @@ function InvestigationReportView({
 }: {
   readonly group: InvestigationReportGroup;
 }): ReactNode {
-  const { investigation, checkIds } = group;
+  const { investigation, checkRefs } = group;
   const whatWouldDisproveThis = investigation.whatWouldDisproveThis ?? [];
   const recommendedVerifierProbes = investigation.recommendedVerifierProbes ?? [];
   return (
@@ -267,16 +281,16 @@ function InvestigationReportView({
 
       <div className="statusInvestigationMeta">
         <span>{investigation.confidence} confidence</span>
-        <span>{checkIds.length === 1 ? investigation.checkId : `${checkIds.length} checks`}</span>
+        <span>{checkRefs.length === 1 ? checkRefs[0] : `${checkRefs.length} checks`}</span>
         {investigation.featureStatus && <span>{STATUS_LABELS[investigation.featureStatus]}</span>}
         {(investigation.provider || investigation.model) && (
           <span>{[investigation.provider, investigation.model].filter(Boolean).join(" / ")}</span>
         )}
       </div>
 
-      {checkIds.length > 1 && (
+      {checkRefs.length > 1 && (
         <p className="statusInvestigationCoveredChecks">
-          Covers checks: <strong>{checkIds.join(", ")}</strong>
+          Covers checks: <strong>{checkRefs.join(", ")}</strong>
         </p>
       )}
 
@@ -389,15 +403,21 @@ function CheckRows({ checks }: { readonly checks: readonly StatusCheck[] }): Rea
     <div className="statusChecks" role="table" aria-label="Feature checks">
       <div className="statusCheckHeader" role="row">
         <span role="columnheader">Check</span>
+        <span role="columnheader">Runtime</span>
         <span role="columnheader">State</span>
         <span role="columnheader">Latency</span>
         <span role="columnheader">Evidence</span>
       </div>
       {checks.map((check) => (
-        <div className="statusCheckRow" role="row" key={check.id}>
+        <div className="statusCheckRow" role="row" key={`${check.runtimeEnvironment || "default"}:${check.id}`}>
           <span className="statusCheckName" role="cell">
-            {check.id}
+            <span>{check.label || check.id}</span>
+            {check.label && check.label !== check.id && <code>{check.id}</code>}
             {!check.required && <span className="statusOptional">Optional</span>}
+            {check.statusImpact === "informational" && <span className="statusOptional">Info</span>}
+          </span>
+          <span role="cell">
+            <span className="statusRuntimeTag">{runtimeDisplay(check)}</span>
           </span>
           <span className={`statusCheckState ${checkStatusClass(check.status)}`} role="cell">
             {check.status}
@@ -490,6 +510,11 @@ export function StatusView(): ReactNode {
   const investigationCount = activeSnapshot.investigations?.length
     ?? activeSnapshot.totals.investigations
     ?? activeSnapshot.features.reduce((sum, feature) => sum + investigationsFor(feature).length, 0);
+  const runtimeCount = activeSnapshot.totals.runtimeEnvironments
+    ?? activeSnapshot.runtimeEnvironments?.length
+    ?? new Set(activeSnapshot.features.flatMap((feature) =>
+      feature.checks.map((check) => check.runtimeEnvironment).filter(Boolean),
+    )).size;
 
   return (
     <main className="statusPage">
@@ -526,6 +551,11 @@ export function StatusView(): ReactNode {
           label="Average p95"
           value={formatLatency(avgLatency)}
           icon={<Gauge size={18} strokeWidth={1.8} />}
+        />
+        <SummaryMetric
+          label="Runtimes"
+          value={runtimeCount}
+          icon={<Terminal size={18} strokeWidth={1.8} />}
         />
         <SummaryMetric
           label="Investigations"


### PR DESCRIPTION
## Summary
- Separate feature status from runtime evidence so one feature can show desktop-release and production-api results without drift.
- Keep image-generation-stream as one eval contract with runtime-specific rows and optional production API evidence.
- Carry runtime context through status policy, investigations, repairs, learning packets, and the observability UI.

## Verification
- node --test $(rg --files infra/evals/status | rg 'test\.mjs$')
- cd interface && npm run test -- StatusView
- cd interface && npm run build
- Ruby YAML parse for observability/release workflows
- Local rendered QA for duplicate image-generation-stream runtime rows