### PR TITLE
Rebuild analytics: server-only True DAU, typed registry + contract tests, build guards

### DIFF
--- a/.github/workflows/analytics-contract.yml
+++ b/.github/workflows/analytics-contract.yml
@@ -1,0 +1,68 @@
+name: Analytics Contract
+
+# Fails loudly the moment analytics tracking would silently break:
+#  - an event is renamed/dropped/added without updating the registry,
+#  - a non-literal event name is passed to track(),
+#  - the client stops forwarding events to the Mixpanel SDK,
+#  - the server session_active single-emitter / event-name / manifest
+#    invariants are violated.
+#
+# Runs on push to main (the primary workflow here) AND on pull requests, so
+# direct-to-main pushes are covered too — not just PRs. On a direct push it
+# runs right after the push and fails the commit if tracking broke.
+on:
+  push:
+    branches: [main]
+    paths:
+      - interface/src/**
+      - interface/package.json
+      - interface/package-lock.json
+      - apps/aura-os-server/src/**
+      - .github/workflows/analytics-contract.yml
+  pull_request:
+    paths:
+      - interface/src/**
+      - interface/package.json
+      - interface/package-lock.json
+      - apps/aura-os-server/src/**
+      - .github/workflows/analytics-contract.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: analytics-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  client-analytics:
+    name: Client analytics (registry + contract + pipeline)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Node.js
+        uses: ./.github/actions/setup-node
+        with:
+          cache: npm
+          cache-dependency-path: interface/package-lock.json
+      - name: Install interface dependencies
+        working-directory: interface
+        run: npm ci
+      - name: Run analytics contract + pipeline tests
+        working-directory: interface
+        run: npx vitest run src/lib/analytics-contract.test.ts src/lib/analytics.test.ts
+
+  server-analytics:
+    name: Server analytics (event constants + manifest + single emitter)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust toolchain
+        uses: ./.github/actions/setup-rust-toolchain
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: analytics-contract
+      - name: Run server analytics tests
+        run: cargo test -p aura-os-server mixpanel

--- a/.github/workflows/android-mobile.yml
+++ b/.github/workflows/android-mobile.yml
@@ -110,6 +110,9 @@ jobs:
       # store-shipped client SDK actually reports analytics (without it the
       # browser SDK no-ops). The release lane fails the build if it is missing.
       VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
+      # Make analytics a hard requirement for store builds: the fastlane
+      # web-asset sync runs the --require-analytics validator when this is set.
+      REQUIRE_ANALYTICS: "1"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/android-mobile.yml
+++ b/.github/workflows/android-mobile.yml
@@ -106,6 +106,10 @@ jobs:
       ANDROID_VERSION_CODE: ${{ github.run_number }}
       VITE_ANDROID_DEFAULT_HOST: ${{ vars.VITE_ANDROID_DEFAULT_HOST }}
       VITE_NATIVE_DEFAULT_HOST: ${{ vars.VITE_NATIVE_DEFAULT_HOST }}
+      # Baked into the web bundle by the Vite build that fastlane runs, so the
+      # store-shipped client SDK actually reports analytics (without it the
+      # browser SDK no-ops). The release lane fails the build if it is missing.
+      VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ios-mobile.yml
+++ b/.github/workflows/ios-mobile.yml
@@ -108,6 +108,9 @@ jobs:
       # TestFlight/App Store client SDK actually reports analytics (without it
       # the browser SDK no-ops). The release lane fails the build if missing.
       VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
+      # Make analytics a hard requirement for store builds: the fastlane
+      # web-asset sync runs the --require-analytics validator when this is set.
+      REQUIRE_ANALYTICS: "1"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ios-mobile.yml
+++ b/.github/workflows/ios-mobile.yml
@@ -104,6 +104,10 @@ jobs:
       MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
       VITE_IOS_DEFAULT_HOST: ${{ vars.VITE_IOS_DEFAULT_HOST }}
       VITE_NATIVE_DEFAULT_HOST: ${{ vars.VITE_NATIVE_DEFAULT_HOST }}
+      # Baked into the web bundle by the Vite build that fastlane runs, so the
+      # TestFlight/App Store client SDK actually reports analytics (without it
+      # the browser SDK no-ops). The release lane fails the build if missing.
+      VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-mobile-nightly.yml
+++ b/.github/workflows/release-mobile-nightly.yml
@@ -40,6 +40,8 @@ jobs:
       VITE_ANDROID_DEFAULT_HOST: ${{ vars.VITE_ANDROID_DEFAULT_HOST }}
       VITE_NATIVE_DEFAULT_HOST: ${{ vars.VITE_NATIVE_DEFAULT_HOST }}
       VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
+      # Fail the nightly build if analytics didn't make it into the bundle.
+      REQUIRE_ANALYTICS: "1"
 
     steps:
       - uses: actions/checkout@v5
@@ -162,6 +164,8 @@ jobs:
       VITE_IOS_DEFAULT_HOST: ${{ vars.VITE_IOS_DEFAULT_HOST }}
       VITE_NATIVE_DEFAULT_HOST: ${{ vars.VITE_NATIVE_DEFAULT_HOST }}
       VITE_MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
+      # Fail the nightly build if analytics didn't make it into the bundle.
+      REQUIRE_ANALYTICS: "1"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -244,10 +244,15 @@ jobs:
       SWARM_BASE_URL: ${{ vars.SWARM_BASE_URL || 'http://ab6d2375031e74ce1976fdf62ea951a4-e757483aaffba396.elb.us-east-2.amazonaws.com' }}
       REQUIRE_ZERO_PRO: ${{ vars.REQUIRE_ZERO_PRO }}
       AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN: ${{ vars.AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN }}
-      # NOTE: This job no longer builds the frontend (it consumes the
-      # prebuilt dist from `build-interface`), so VITE_MIXPANEL_TOKEN is not
-      # needed here. The token is baked in the `build-interface` job instead.
-      # `CACHE_VITE_MIXPANEL_TOKEN` below is kept only for cache fingerprinting.
+      # NOTE: This job no longer builds the frontend (it consumes the prebuilt
+      # dist from `build-interface`), so the *client* token VITE_MIXPANEL_TOKEN
+      # is baked in `build-interface`, not here. MIXPANEL_TOKEN below is the
+      # *server-side* token for the bundled local aura-os-server, the sole
+      # emitter of session_active (True DAU) on desktop. Same public
+      # project-token value; without it desktop True DAU is silently dropped.
+      # Cache-busting is already covered by `CACHE_VITE_MIXPANEL_TOKEN`
+      # (identical value) in the fingerprint below.
+      MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
       Z_BILLING_API_KEY: ${{ secrets.Z_BILLING_API_KEY }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -231,9 +231,13 @@ jobs:
       SWARM_BASE_URL: ${{ vars.SWARM_BASE_URL || 'http://ab6d2375031e74ce1976fdf62ea951a4-e757483aaffba396.elb.us-east-2.amazonaws.com' }}
       REQUIRE_ZERO_PRO: ${{ vars.REQUIRE_ZERO_PRO }}
       AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN: ${{ vars.AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN }}
-      # NOTE: This job no longer builds the frontend (it consumes the
-      # prebuilt dist from `build-interface`), so VITE_MIXPANEL_TOKEN is not
-      # needed here. The token is baked in the `build-interface` job instead.
+      # NOTE: This job no longer builds the frontend (it consumes the prebuilt
+      # dist from `build-interface`), so the *client* token VITE_MIXPANEL_TOKEN
+      # is baked in `build-interface`, not here. MIXPANEL_TOKEN below is the
+      # *server-side* token for the bundled local aura-os-server, the sole
+      # emitter of session_active (True DAU) on desktop. Same public
+      # project-token value; without it desktop True DAU is silently dropped.
+      MIXPANEL_TOKEN: ${{ vars.VITE_MIXPANEL_TOKEN }}
       Z_BILLING_API_KEY: ${{ secrets.Z_BILLING_API_KEY }}
     strategy:
       fail-fast: false

--- a/apps/aura-os-desktop/build.rs
+++ b/apps/aura-os-desktop/build.rs
@@ -15,6 +15,10 @@ const DEFAULT_SWARM_BASE_URL: &str =
     "http://ab6d2375031e74ce1976fdf62ea951a4-e757483aaffba396.elb.us-east-2.amazonaws.com";
 const DEFAULT_REQUIRE_ZERO_PRO: &str = "false";
 const DEFAULT_Z_BILLING_API_KEY: &str = "";
+// Mixpanel project token for the bundled local server's session_active emit.
+// Same public, client-side ingest token already shipped in the frontend bundle
+// (VITE_MIXPANEL_TOKEN) — not a secret. Empty in dev builds (analytics off).
+const DEFAULT_MIXPANEL_TOKEN: &str = "";
 const DEFAULT_DISABLE_LOCAL_HARNESS_AUTOSPAWN: &str = "true";
 const DEFAULT_SYS_ADMIN_EMAILS: &str = "";
 
@@ -316,6 +320,11 @@ fn main() {
         "Z_BILLING_API_KEY",
         "AURA_DESKTOP_DEFAULT_Z_BILLING_API_KEY",
         DEFAULT_Z_BILLING_API_KEY,
+    );
+    emit_runtime_default(
+        "MIXPANEL_TOKEN",
+        "AURA_DESKTOP_DEFAULT_MIXPANEL_TOKEN",
+        DEFAULT_MIXPANEL_TOKEN,
     );
     emit_runtime_default(
         "AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN",

--- a/apps/aura-os-desktop/src/init/env.rs
+++ b/apps/aura-os-desktop/src/init/env.rs
@@ -67,6 +67,13 @@ pub(crate) fn apply_desktop_runtime_defaults() {
         "Z_BILLING_API_KEY",
         env!("AURA_DESKTOP_DEFAULT_Z_BILLING_API_KEY"),
     );
+    // Server-side Mixpanel token for the bundled local aura-os-server, which is
+    // the sole emitter of session_active (True DAU) on desktop. Without it the
+    // local server's MixpanelTracker is None and desktop True DAU is dropped.
+    set_env_default(
+        "MIXPANEL_TOKEN",
+        env!("AURA_DESKTOP_DEFAULT_MIXPANEL_TOKEN"),
+    );
     set_env_default(
         "AURA_DISABLE_LOCAL_HARNESS_AUTOSPAWN",
         env!("AURA_DESKTOP_DEFAULT_DISABLE_LOCAL_HARNESS_AUTOSPAWN"),

--- a/apps/aura-os-server/src/handlers/agents/crud/create.rs
+++ b/apps/aura-os-server/src/handlers/agents/crud/create.rs
@@ -293,6 +293,7 @@ mod tests {
                 ..AgentScope::default()
             },
             capabilities: Vec::new(),
+            ..Default::default()
         };
 
         let prepared = prepare_create(request).expect("valid create request");
@@ -314,6 +315,7 @@ mod tests {
                 ..AgentScope::default()
             },
             capabilities: Vec::new(),
+            ..Default::default()
         };
         let prepared = prepare_create(request).expect("valid create request");
         let net_agent = network_agent_with_permissions(AgentPermissions::default());

--- a/apps/aura-os-server/src/handlers/agents/runtime.rs
+++ b/apps/aura-os-server/src/handlers/agents/runtime.rs
@@ -340,6 +340,7 @@ mod tests {
         let agent = test_agent_with_permissions(AgentPermissions {
             scope: AgentScope::default(),
             capabilities: vec![Capability::InvokeProcess],
+            ..Default::default()
         });
 
         let config = runtime_session_config(&agent, "jwt", "user-1", Some("aura-gpt-5-5".into()));

--- a/apps/aura-os-server/src/handlers/shares/mod.rs
+++ b/apps/aura-os-server/src/handlers/shares/mod.rs
@@ -147,7 +147,11 @@ fn track_share_link_generated(
                 map.insert("$os".to_string(), json!(os));
             }
         }
-        mixpanel.track_event("share_link_generated", owner_user_id, properties);
+        mixpanel.track_event(
+            crate::mixpanel::EVENT_SHARE_LINK_GENERATED,
+            owner_user_id,
+            properties,
+        );
     }
 }
 

--- a/apps/aura-os-server/src/mixpanel.rs
+++ b/apps/aura-os-server/src/mixpanel.rs
@@ -11,6 +11,15 @@ use std::sync::Arc;
 use tracing::warn;
 use uuid::Uuid;
 
+/// Canonical server-emitted analytics event names. These are the only
+/// three events the server fires. They mirror the `server_events` list in
+/// the shared analytics manifest (`interface/src/lib/analytics-events.json`)
+/// and the TS registry's `SERVER_EVENTS`; the tests below verify they stay
+/// in sync and that `session_active` is emitted from exactly one site.
+pub(crate) const EVENT_SESSION_ACTIVE: &str = "session_active";
+pub(crate) const EVENT_SHARE_LINK_GENERATED: &str = "share_link_generated";
+pub(crate) const EVENT_SHARE_LINK_OPENED: &str = "share_link_opened";
+
 /// Tracks which users have already fired `session_active` today.
 /// Key: `"user_id:YYYY-MM-DD"`, Value: `()`.
 #[derive(Clone)]
@@ -117,7 +126,7 @@ impl MixpanelTracker {
 
         let properties = build_session_active_properties(version, platform, client_ip, user_agent);
 
-        self.enqueue_event("session_active", user_id.to_string(), properties);
+        self.enqueue_event(EVENT_SESSION_ACTIVE, user_id.to_string(), properties);
     }
 
     /// Record the latest non-empty client metadata for a user. Empty
@@ -198,7 +207,7 @@ impl MixpanelTracker {
         }
 
         self.enqueue_event(
-            "share_link_opened",
+            EVENT_SHARE_LINK_OPENED,
             format!("share:{fingerprint}"),
             properties,
         );
@@ -589,5 +598,100 @@ mod tests {
         let empty = tracker.client_meta("user-2");
         assert!(empty.app_version.is_none());
         assert!(empty.platform.is_none());
+    }
+
+    /// The three server event-name constants must exactly match the
+    /// `server_events` list in the shared cross-language manifest
+    /// (`interface/src/lib/analytics-events.json`). The TS contract test
+    /// checks that same manifest against the TS registry, so this is the
+    /// TS<->Rust agreement guard: rename a server event on either side
+    /// without updating the manifest and one of the two tests fails.
+    #[test]
+    fn server_event_constants_match_shared_manifest() {
+        let manifest_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../interface/src/lib/analytics-events.json"
+        );
+        let raw = std::fs::read_to_string(manifest_path).expect(
+            "shared analytics manifest must exist at interface/src/lib/analytics-events.json",
+        );
+        let manifest: Value = serde_json::from_str(&raw).expect("manifest must be valid JSON");
+
+        let mut manifest_events: Vec<String> = manifest["server_events"]
+            .as_array()
+            .expect("manifest.server_events must be an array")
+            .iter()
+            .map(|v| {
+                v.as_str()
+                    .expect("server event names must be strings")
+                    .to_string()
+            })
+            .collect();
+        manifest_events.sort();
+
+        let mut constants = vec![
+            EVENT_SESSION_ACTIVE.to_string(),
+            EVENT_SHARE_LINK_GENERATED.to_string(),
+            EVENT_SHARE_LINK_OPENED.to_string(),
+        ];
+        constants.sort();
+
+        assert_eq!(
+            constants, manifest_events,
+            "Rust server event constants must exactly match manifest.server_events"
+        );
+    }
+
+    /// `session_active` must be enqueued from exactly one call site. The
+    /// server is the sole `session_active` emitter; that only holds if a
+    /// second server emit can't silently creep in. `enqueue_event` is
+    /// private to this module, so the only emit paths are `enqueue_event(...)`
+    /// here and `track_event(...)` callers crate-wide — we scan source for
+    /// both. Patterns are assembled at runtime so they don't self-match
+    /// this test file.
+    #[test]
+    fn session_active_emitted_from_exactly_one_site() {
+        let src_root = concat!(env!("CARGO_MANIFEST_DIR"), "/src");
+        let mut files = Vec::new();
+        collect_rs_files(std::path::Path::new(src_root), &mut files);
+        assert!(!files.is_empty(), "expected .rs files under src/");
+
+        let enqueue = ".enqueue_event(";
+        let track = ".track_event(";
+        let const_arg = "EVENT_SESSION_ACTIVE";
+        let lit_arg = "\"session_active\"";
+        let patterns = [
+            format!("{enqueue}{const_arg}"),
+            format!("{enqueue}{lit_arg}"),
+            format!("{track}{const_arg}"),
+            format!("{track}{lit_arg}"),
+        ];
+
+        let mut sites = 0usize;
+        for file in &files {
+            let content = std::fs::read_to_string(file).expect("readable source file");
+            for pat in &patterns {
+                sites += content.matches(pat.as_str()).count();
+            }
+        }
+
+        assert_eq!(
+            sites, 1,
+            "session_active must be emitted from exactly one call site (found {sites})"
+        );
+    }
+
+    fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rs_files(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
     }
 }

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,28 @@
+# Analytics
+
+AURA uses [Mixpanel](https://mixpanel.com) for product analytics — to understand
+how the product is used so we can improve it.
+
+## Privacy posture
+
+- **Anonymous by default.** Users are identified only by their ZERO `user_id`
+  (an opaque UUID). No email, name, wallet address, or display name is sent.
+- **No content.** Prompts, messages, file contents, file paths, project/task
+  names, and model outputs are never sent.
+- **Opt-out.** Tracking respects the in-app opt-out toggle and the browser
+  Do-Not-Track / Global Privacy Control signals, and is a safe no-op when opted
+  out or when no analytics token is configured.
+
+## How it works (for contributors)
+
+- Client events go through a single `track()` wrapper
+  (`interface/src/lib/analytics.ts`), typed against a central registry
+  (`interface/src/lib/analytics-registry.ts`). **Adding, renaming, or removing a
+  client event requires updating the registry** — a contract test fails CI
+  otherwise, so tracking can't silently drift.
+- `session_active` (the basis for active-user metrics) is emitted **only by the
+  server**, keyed to the ZERO `user_id` and de-duplicated per user per day, so a
+  user is counted once regardless of how many devices or builds they use.
+- Release builds for every surface (desktop, web, mobile) fail if the analytics
+  token didn't reach the bundle, so a build never silently ships with analytics
+  disabled.

--- a/docs/render-deployment.md
+++ b/docs/render-deployment.md
@@ -9,7 +9,7 @@ Single Web Service that builds both frontend and backend. The backend serves the
 | **Type** | Web Service |
 | **Repository** | `cypher-asi/aura-os` |
 | **Branch** | `main` |
-| **Build Command** | `cd interface && npm ci && APP_VERSION="$RENDER_GIT_COMMIT" APP_CHANNEL=web npm run build && cd .. && cargo build --release -p aura-os-server` |
+| **Build Command** | `cd interface && npm ci && export APP_VERSION="$RENDER_GIT_COMMIT" APP_CHANNEL=web && npm run build && node ../infra/scripts/release/desktop-frontend-assets-validate.mjs --dist dist --require-analytics && cd .. && cargo build --release -p aura-os-server` |
 | **Start Command** | `./target/release/aura-os-server` |
 | **Plan** | Starter ($7/mo) or higher |
 
@@ -44,7 +44,11 @@ Single Web Service that builds both frontend and backend. The backend serves the
 | `MIXPANEL_TOKEN` | Mixpanel project token. Enables **server-side** analytics (`session_active` True DAU backstop + share events). The server logs a loud warning at startup if unset. |
 | `VITE_MIXPANEL_TOKEN` | Same Mixpanel token, consumed by the Vite build so the **web client** SDK sends engagement events. Without it the browser SDK silently no-ops. |
 
-`APP_VERSION` in the build command stamps a real version into the bundle so analytics events are not bucketed under `app_version = "0.0.0"`. `RENDER_GIT_COMMIT` is provided automatically by Render; if omitted, the build falls back to `git describe` and then to a commit-stamped version.
+`APP_VERSION` in the build command stamps a real version into the bundle so analytics events are not bucketed under `app_version = "0.0.0"`. `RENDER_GIT_COMMIT` is provided automatically by Render; if omitted, the build falls back to `git describe` and then to a commit-stamped version. It is `export`ed (not set inline on `npm run build` only) so the analytics validator below sees it too.
+
+The `desktop-frontend-assets-validate.mjs --require-analytics` step **fails the build** if `VITE_MIXPANEL_TOKEN` is missing/empty or was not actually inlined into the bundle, or if `APP_VERSION` is empty/`0.0.0`. This is the web equivalent of the desktop release guard — a config regression that would silently ship a no-op web analytics SDK now breaks the deploy loudly instead of going unnoticed. `VITE_MIXPANEL_TOKEN` must be present in the Render service env (above) for it to pass.
+
+> **Apply on the Render dashboard:** this build command lives in the `aura-app` Render service settings — update it there to match the command above; this doc is the record, not the source of truth Render reads.
 
 ### Optional
 

--- a/infra/scripts/release/desktop-frontend-assets-validate.mjs
+++ b/infra/scripts/release/desktop-frontend-assets-validate.mjs
@@ -136,7 +136,18 @@ export function validateAnalyticsBakedIn(distDir, env = process.env) {
     );
   }
 
-  return { appVersion, tokenBaked: true };
+  const versionBaked = files.some(
+    (file) => file.endsWith(".js") && fs.readFileSync(file, "utf8").includes(appVersion),
+  );
+  if (!versionBaked) {
+    throw new Error(
+      `APP_VERSION ("${appVersion}") was set in the environment but was not inlined ` +
+        "into the built frontend, so analytics events would report the package.json " +
+        '"0.0.0" fallback instead. Ensure APP_VERSION is exported before the build.',
+    );
+  }
+
+  return { appVersion, tokenBaked: true, versionBaked: true };
 }
 
 function validateDistAssets(distDir, options = {}) {

--- a/infra/scripts/release/desktop-frontend-assets-validate.test.mjs
+++ b/infra/scripts/release/desktop-frontend-assets-validate.test.mjs
@@ -44,14 +44,15 @@ test("findBrokenCssModuleExports detects rolldown CSS export stubs", () => {
   assert.deepEqual(findBrokenCssModuleExports(js), ["github_dark_min_exports"]);
 });
 
-test("validateAnalyticsBakedIn passes when token is inlined and version is real", () => {
+test("validateAnalyticsBakedIn passes when token and version are both inlined", () => {
   const token = "mp_token_1234567890";
-  const dist = makeDist(`var t="${token}";console.log(t);`);
+  const appVersion = "0.1.0-nightly.640.1";
+  const dist = makeDist(`var t="${token}";var v="${appVersion}";console.log(t,v);`);
   const result = validateAnalyticsBakedIn(dist, {
     VITE_MIXPANEL_TOKEN: token,
-    APP_VERSION: "0.1.0-nightly.640.1",
+    APP_VERSION: appVersion,
   });
-  assert.deepEqual(result, { appVersion: "0.1.0-nightly.640.1", tokenBaked: true });
+  assert.deepEqual(result, { appVersion, tokenBaked: true, versionBaked: true });
 });
 
 test("validateAnalyticsBakedIn throws when token env is empty", () => {
@@ -80,5 +81,18 @@ test("validateAnalyticsBakedIn throws when token did not reach the bundle", () =
         APP_VERSION: "0.1.0",
       }),
     /was not inlined into the built frontend/,
+  );
+});
+
+test("validateAnalyticsBakedIn throws when version is set but not inlined", () => {
+  const token = "mp_token_1234567890";
+  const dist = makeDist(`var t="${token}";`);
+  assert.throws(
+    () =>
+      validateAnalyticsBakedIn(dist, {
+        VITE_MIXPANEL_TOKEN: token,
+        APP_VERSION: "9.9.9-not-in-bundle",
+      }),
+    /APP_VERSION.*was not inlined/s,
   );
 });

--- a/interface/android/fastlane/Fastfile
+++ b/interface/android/fastlane/Fastfile
@@ -128,6 +128,13 @@ private_lane :sync_android_web_assets do
   # before Gradle packages the native shell.
   root = interface_root.shellescape
   sh("cd #{root} && npm run build")
+  # On release/store builds (CI sets REQUIRE_ANALYTICS=1) fail loudly if the
+  # Mixpanel token / app version did not reach the bundle, so a config
+  # regression can't silently ship a store app whose analytics SDK no-ops.
+  # Local builds leave REQUIRE_ANALYTICS unset and skip this.
+  if ENV["REQUIRE_ANALYTICS"] == "1"
+    sh("cd #{root} && node ../infra/scripts/release/desktop-frontend-assets-validate.mjs --dist dist --require-analytics")
+  end
   sh("cd #{root} && npx cap sync android")
 end
 

--- a/interface/ios/fastlane/Fastfile
+++ b/interface/ios/fastlane/Fastfile
@@ -160,6 +160,13 @@ private_lane :sync_ios_web_assets do
   # would archive for a store build.
   root = interface_root.shellescape
   sh("cd #{root} && npm run build")
+  # On release/store builds (CI sets REQUIRE_ANALYTICS=1) fail loudly if the
+  # Mixpanel token / app version did not reach the bundle, so a config
+  # regression can't silently ship a store app whose analytics SDK no-ops.
+  # Local builds leave REQUIRE_ANALYTICS unset and skip this.
+  if ENV["REQUIRE_ANALYTICS"] == "1"
+    sh("cd #{root} && node ../infra/scripts/release/desktop-frontend-assets-validate.mjs --dist dist --require-analytics")
+  end
   sh("cd #{root} && npx cap sync ios")
 end
 

--- a/interface/src/components/AppShell/AppShell.tsx
+++ b/interface/src/components/AppShell/AppShell.tsx
@@ -409,39 +409,11 @@ function useOnboardingHydration() {
     hydrateForUser(user.user_id);
     if (trackedUserIdRef.current !== user.user_id) {
       trackedUserIdRef.current = user.user_id;
-      import("../../lib/analytics").then(({ track, identifyUser }) => {
+      import("../../lib/analytics").then(({ identifyUser }) => {
         identifyUser(user.user_id);
-        track("session_active");
       });
     }
   }, [user?.user_id, hydrateForUser]);
-
-  // Re-fire session_active so True DAU counts users who leave the
-  // app open across days. Three triggers:
-  //   1. visibilitychange — web tab switched back
-  //   2. window focus — desktop app restored
-  //   3. hourly interval — covers apps that stay focused overnight
-  // Mixpanel deduplicates uniques per day so repeated fires on the
-  // same day don't inflate the count.
-  useEffect(() => {
-    if (!user?.user_id) return;
-    const fireSessionActive = () => {
-      import("../../lib/analytics").then(({ track }) => {
-        track("session_active");
-      });
-    };
-    const handleVisibility = () => {
-      if (document.visibilityState === "visible") fireSessionActive();
-    };
-    document.addEventListener("visibilitychange", handleVisibility);
-    window.addEventListener("focus", fireSessionActive);
-    const interval = setInterval(fireSessionActive, 60 * 60 * 1000);
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibility);
-      window.removeEventListener("focus", fireSessionActive);
-      clearInterval(interval);
-    };
-  }, [user?.user_id]);
 }
 
 function AppContent() {

--- a/interface/src/lib/analytics-contract.test.ts
+++ b/interface/src/lib/analytics-contract.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Analytics event contract test.
+ *
+ * Guarantees the client analytics layer can't silently drift:
+ *  1. Every `track(...)` call site (static import, dynamic `import()`
+ *     destructure, or alias) uses a string-LITERAL event name.
+ *  2. The set of event names used at call sites === the registry keys
+ *     exactly (catches unregistered events AND dead registry entries).
+ *  3. `session_active` is never emitted from the client (it is server-only).
+ *  4. Required props (per the registry) are present wherever the props arg
+ *     is a static object literal; non-static cases are reported, not silently
+ *     skipped.
+ *  5. The registry's `SERVER_EVENTS` matches the shared `analytics-events.json`
+ *     manifest. The Rust server test checks that same manifest against its
+ *     event-name constants, so registry + manifest + Rust constants all agree
+ *     on the server event names.
+ *
+ * Uses the TypeScript compiler API to resolve the `track` binding through the
+ * AST — NOT grep, which is brittle here: it misses dynamic-import (`await
+ * import`) call sites and matches unrelated `track(` identifiers.
+ *
+ * Scope: matches `track` bound as a value (static `import { track }`, dynamic
+ * `import().then(({ track }))` / `await import`, and aliases). It does NOT
+ * match namespace access (`analytics.track(...)`) or re-wrapped exports — none
+ * exist today; extend the analyzer if that pattern is introduced.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { ANALYTICS_EVENTS, SERVER_EVENTS } from "./analytics-registry";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url)); // interface/src/lib
+const SRC_ROOT = path.resolve(HERE, ".."); // interface/src
+
+/** A single resolved `track(...)` call site. */
+interface CallSite {
+  file: string;
+  line: number;
+  /** event name, or null when the first arg is not a string literal */
+  event: string | null;
+  /** object-literal prop keys, or null when not statically knowable */
+  propsKeys: string[] | null;
+}
+
+/** basename of a module specifier, e.g. "../../lib/analytics" -> "analytics". */
+function specifierBasename(spec: string): string {
+  const noQuery = spec.split("?")[0];
+  const parts = noQuery.split("/");
+  return parts[parts.length - 1] ?? "";
+}
+
+/** True for the analytics wrapper module (NOT analytics-registry). */
+function isAnalyticsModule(spec: string): boolean {
+  return specifierBasename(spec) === "analytics";
+}
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue;
+      out.push(...collectSourceFiles(full));
+    } else if (
+      /\.tsx?$/.test(entry.name) &&
+      !/\.test\.tsx?$/.test(entry.name) &&
+      !/\.d\.ts$/.test(entry.name)
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Resolve every `track(...)` call site that targets the analytics wrapper. */
+function analyzeFile(file: string): CallSite[] {
+  const text = fs.readFileSync(file, "utf8");
+  const sf = ts.createSourceFile(
+    file,
+    text,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  let importsAnalytics = false;
+  const trackNames = new Set<string>();
+
+  // Pass 1: find whether the file pulls in the analytics module and the local
+  // name(s) bound to its `track` export (static imports + dynamic destructures).
+  const collectBindings = (node: ts.Node): void => {
+    // static: import { track [as x] } from "...analytics"
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      isAnalyticsModule(node.moduleSpecifier.text)
+    ) {
+      importsAnalytics = true;
+      const clause = node.importClause;
+      if (
+        clause &&
+        !clause.isTypeOnly &&
+        clause.namedBindings &&
+        ts.isNamedImports(clause.namedBindings)
+      ) {
+        for (const spec of clause.namedBindings.elements) {
+          if (spec.isTypeOnly) continue;
+          const imported = (spec.propertyName ?? spec.name).text;
+          if (imported === "track") trackNames.add(spec.name.text);
+        }
+      }
+    }
+    // dynamic: import("...analytics")
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments[0] &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      isAnalyticsModule(node.arguments[0].text)
+    ) {
+      importsAnalytics = true;
+    }
+    ts.forEachChild(node, collectBindings);
+  };
+  collectBindings(sf);
+
+  // Dynamic-import destructures: `({ track }) => ...` / `const { track } = await import(...)`.
+  // Only meaningful when the file dynamically imports analytics.
+  if (importsAnalytics) {
+    const collectDestructures = (node: ts.Node): void => {
+      if (ts.isObjectBindingPattern(node)) {
+        for (const el of node.elements) {
+          const source =
+            el.propertyName && ts.isIdentifier(el.propertyName)
+              ? el.propertyName.text
+              : ts.isIdentifier(el.name)
+                ? el.name.text
+                : undefined;
+          if (source === "track" && ts.isIdentifier(el.name)) {
+            trackNames.add(el.name.text);
+          }
+        }
+      }
+      ts.forEachChild(node, collectDestructures);
+    };
+    collectDestructures(sf);
+  }
+
+  if (trackNames.size === 0) return [];
+
+  // Pass 2: collect calls to those bindings.
+  const sites: CallSite[] = [];
+  const collectCalls = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      trackNames.has(node.expression.text)
+    ) {
+      const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+      const arg0 = node.arguments[0];
+      const event = arg0 && ts.isStringLiteral(arg0) ? arg0.text : null;
+
+      const arg1 = node.arguments[1];
+      let propsKeys: string[] | null;
+      if (!arg1) {
+        propsKeys = [];
+      } else if (ts.isObjectLiteralExpression(arg1)) {
+        propsKeys = [];
+        for (const p of arg1.properties) {
+          if (
+            (ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p)) &&
+            ts.isIdentifier(p.name)
+          ) {
+            propsKeys.push(p.name.text);
+          } else {
+            // spread / computed key -> can't statically know the full key set
+            propsKeys = null;
+            break;
+          }
+        }
+      } else {
+        propsKeys = null; // props passed via a variable/expression
+      }
+
+      sites.push({ file: path.relative(SRC_ROOT, file), line: line + 1, event, propsKeys });
+    }
+    ts.forEachChild(node, collectCalls);
+  };
+  collectCalls(sf);
+  return sites;
+}
+
+const REGISTRY: Record<string, { props?: readonly string[] }> = ANALYTICS_EVENTS;
+
+describe("analytics event contract", () => {
+  const sites = collectSourceFiles(SRC_ROOT).flatMap(analyzeFile);
+  const registryKeys = new Set(Object.keys(REGISTRY));
+
+  it("finds the client track() call sites (analyzer sanity)", () => {
+    // Guards against a broken analyzer silently finding nothing, which would
+    // make every other assertion below vacuously pass.
+    expect(sites.length).toBeGreaterThan(20);
+  });
+
+  it("every track() call uses a string-literal event name", () => {
+    const nonLiteral = sites.filter((s) => s.event === null).map((s) => `${s.file}:${s.line}`);
+    expect(nonLiteral, `non-literal event names at: ${nonLiteral.join(", ")}`).toEqual([]);
+  });
+
+  it("call-site event names match the registry exactly (both directions)", () => {
+    const used = new Set(
+      sites.map((s) => s.event).filter((e): e is string => e !== null),
+    );
+    const unregistered = [...used].filter((e) => !registryKeys.has(e)).sort();
+    const dead = [...registryKeys].filter((e) => !used.has(e)).sort();
+    expect(unregistered, "events used at a call site but missing from the registry").toEqual([]);
+    expect(dead, "registry entries with no client call site").toEqual([]);
+  });
+
+  it("never emits session_active from the client (server-only)", () => {
+    const clientSessionActive = sites
+      .filter((s) => s.event === "session_active")
+      .map((s) => `${s.file}:${s.line}`);
+    expect(clientSessionActive, "client session_active emit sites").toEqual([]);
+  });
+
+  it("registry SERVER_EVENTS matches the shared manifest (registry<->Rust bridge)", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(HERE, "analytics-events.json"), "utf8"),
+    ) as { server_events: string[] };
+    expect([...SERVER_EVENTS].sort()).toEqual([...manifest.server_events].sort());
+  });
+
+  it("includes required props wherever statically checkable", () => {
+    const missing: string[] = [];
+    const skipped: string[] = [];
+    for (const s of sites) {
+      if (s.event === null) continue;
+      const required = REGISTRY[s.event]?.props ?? [];
+      if (required.length === 0) continue;
+      if (s.propsKeys === null) {
+        skipped.push(`${s.event} @ ${s.file}:${s.line}`);
+        continue;
+      }
+      const present = new Set(s.propsKeys);
+      const miss = required.filter((p) => !present.has(p));
+      if (miss.length) missing.push(`${s.event} @ ${s.file}:${s.line} missing [${miss.join(", ")}]`);
+    }
+    // Surface (don't hide) call sites whose props can't be statically checked.
+    if (skipped.length) {
+      // eslint-disable-next-line no-console
+      console.warn(`[analytics-contract] required props not statically checkable: ${skipped.join("; ")}`);
+    }
+    expect(missing, "call sites missing a required prop").toEqual([]);
+  });
+});

--- a/interface/src/lib/analytics-events.json
+++ b/interface/src/lib/analytics-events.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Cross-language analytics contract. Source of truth for client events is analytics-registry.ts (ANALYTICS_EVENTS); this file is the bridge the Rust server tests check against. The TS contract test asserts SERVER_EVENTS in the registry matches server_events here; the Rust test (mixpanel.rs) asserts its EVENT_* constants match server_events here. Keep server_events in sync with both.",
+  "server_events": ["session_active", "share_link_generated", "share_link_opened"]
+}

--- a/interface/src/lib/analytics-registry.ts
+++ b/interface/src/lib/analytics-registry.ts
@@ -62,12 +62,17 @@ export const ANALYTICS_EVENTS = {
 
 export type AnalyticsEventName = keyof typeof ANALYTICS_EVENTS;
 
+// Canonical "engaged" set: a user performed a meaningful PRODUCT action
+// (created/ran work, generated content, hired an agent). This must stay in
+// sync with the Mixpanel "Engaged DAU" chart (Uniques of these events).
+// Deliberately excludes support/meta actions like feedback_created.
 export const ENGAGED_BUNDLE = [
   "chat_message_sent",
   "task_created",
   "task_run_started",
   "project_created",
   "agent_created",
+  "process_created",
   "process_triggered",
   "note_created",
   "aura3d_image_generated",

--- a/interface/src/lib/analytics-registry.ts
+++ b/interface/src/lib/analytics-registry.ts
@@ -1,0 +1,83 @@
+// interface/src/lib/analytics-registry.ts
+// Canonical inventory of client analytics events. Do NOT re-derive via
+// grep/search — dynamic-import call sites make string search unreliable; the
+// contract test enforces this set against the actual call sites instead.
+// 45 client events; session_active is server-only and deliberately absent.
+export const ANALYTICS_EVENTS = {
+  // lifecycle / auth
+  app_opened: {}, // main.tsx:76
+  user_logged_in: {}, // auth-store.ts:222
+  user_signed_up: { props: ["has_invite_code"] }, // auth-store.ts:238
+  // chat
+  chat_message_sent: { props: ["model", "mode"] }, // ChatInputBar.tsx:804
+  chat_new_chat: {}, // use-fresh-canvas.ts:145
+  model_selected: { props: ["model_name", "effort"] }, // chat-ui-store.ts:458
+  mode_selected: { props: ["mode"] }, // chat-ui-store.ts:598
+  file_attached: { props: ["file_count"] }, // useFileAttachments.ts:244,334
+  // projects / tasks / process
+  project_created: { props: ["environment"] }, // use-new-project-form.ts:196
+  project_opened: {}, // project-list-projects-explorer.tsx:297 (dyn)
+  task_created: {}, // AddTaskForm.tsx:115
+  task_run_started: { props: ["model"] }, // RunTaskButton.tsx:45
+  process_created: {}, // ProcessForm.tsx:47
+  process_triggered: {}, // ProcessMainPanel.tsx:48
+  note_created: {}, // NotesNav.tsx:341 (dyn)
+  // agents / marketplace / 3D
+  agent_created: {}, // useAgentEditorForm.ts:435
+  agent_selected: {}, // agent-store.ts:395
+  marketplace_agent_hired: {}, // HireProjectPickerModal.tsx:62
+  aura3d_image_generated: { props: ["model"] }, // ImageGeneration.tsx:140
+  aura3d_model_generated: {}, // ModelGeneration.tsx:208
+  // integrations / settings / feedback
+  integration_connected: { props: ["provider"] }, // IntegrationEditor.tsx:170,207
+  settings_opened: {}, // OrgSettingsPanel.tsx:205
+  invite_code_copied: {}, // InviteModal.tsx:38 / OrgSettingsRewards.tsx:32 (source optional)
+  feedback_created: { props: ["category", "product"] }, // NewFeedbackModal.tsx:165
+  bug_report_created: { props: ["severity"] }, // BugReportConsentModal.tsx:120
+  // billing
+  tier_modal_opened: {}, // TierSubscriptionModal.tsx:94
+  subscription_checkout_started: { props: ["plan"] }, // TierSubscriptionModal.tsx:107
+  credits_checkout_started: { props: ["amount_usd"] }, // BuyCreditsModal.tsx:56
+  // onboarding
+  onboarding_started: {}, // WelcomeModal.tsx:61
+  onboarding_welcome_completed: {}, // WelcomeModal.tsx:71
+  onboarding_welcome_skipped: { props: ["at_step"] }, // WelcomeModal.tsx:77
+  onboarding_task_clicked: { props: ["task_id"] }, // OnboardingChecklist.tsx:36
+  onboarding_task_completed: { props: ["task_id", "progress"] }, // useOnboardingTaskWatcher.ts:42+
+  onboarding_completed: {},
+  onboarding_checklist_dismissed: { props: ["tasks_completed"] },
+  onboarding_reopened: {}, // use-menu-actions.ts:225
+  onboarding_agent_configured: {}, // useApplyAgentOnboarding.ts:42
+  // public / marketing
+  public_page_viewed: {}, // use-public-shell-analytics.ts:18
+  public_gate_shown: {}, // use-public-shell-analytics.ts:37
+  public_session_started: {}, // public-chat-store.ts:268
+  public_message_sent: { props: ["mode"] },
+  public_login_clicked: { props: ["source"] },
+  public_signup_clicked: { props: ["source"] },
+  public_download_clicked: { props: ["source"] },
+  public_create_agent_clicked: { props: ["source"] },
+} as const satisfies Record<string, { props?: readonly string[] }>;
+// 45 entries — the complete client analytics event set.
+
+export type AnalyticsEventName = keyof typeof ANALYTICS_EVENTS;
+
+export const ENGAGED_BUNDLE = [
+  "chat_message_sent",
+  "task_created",
+  "task_run_started",
+  "project_created",
+  "agent_created",
+  "process_triggered",
+  "note_created",
+  "aura3d_image_generated",
+  "aura3d_model_generated",
+  "marketplace_agent_hired",
+] as const satisfies readonly AnalyticsEventName[];
+
+// Server events listed for the cross-language check (not used by TS emit):
+export const SERVER_EVENTS = [
+  "session_active",
+  "share_link_generated",
+  "share_link_opened",
+] as const;

--- a/interface/src/lib/analytics.test.ts
+++ b/interface/src/lib/analytics.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Analytics pipeline test.
+ *
+ * Proves the `track()` wrapper actually forwards to the Mixpanel SDK (and stays
+ * a safe no-op without a token). This guards the "token present but pipeline
+ * dead" failure mode that the build guard and contract test don't cover: a
+ * refactor that silently disconnects the wrapper from the SDK would leave every
+ * call site intact (contract test passes) and the token baked in (build guard
+ * passes) yet send nothing. Here we assert the SDK is actually called.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mp = vi.hoisted(() => ({
+  init: vi.fn(),
+  track: vi.fn(),
+  register: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+  opt_out_tracking: vi.fn(),
+  opt_in_tracking: vi.fn(),
+}));
+
+vi.mock("mixpanel-browser", () => ({ default: mp }));
+vi.mock("./build-info", () => ({
+  getAppPlatform: () => "web",
+  getAppVersion: () => "test-version",
+}));
+
+/** Load a fresh copy of the analytics module with a chosen build-time token. */
+async function loadAnalytics(token: string) {
+  vi.resetModules();
+  Object.values(mp).forEach((fn) => fn.mockReset());
+  vi.stubEnv("VITE_MIXPANEL_TOKEN", token);
+  return import("./analytics");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("analytics pipeline", () => {
+  it("initAnalytics() forwards to mixpanel.init when a token is present", async () => {
+    const a = await loadAnalytics("test-token-123");
+    a.initAnalytics();
+    expect(mp.init).toHaveBeenCalledTimes(1);
+    expect(mp.init).toHaveBeenCalledWith("test-token-123", expect.any(Object));
+  });
+
+  it("track() forwards the event to mixpanel.track after init", async () => {
+    const a = await loadAnalytics("test-token-123");
+    a.initAnalytics();
+    a.track("app_opened");
+    expect(mp.track).toHaveBeenCalledWith("app_opened", undefined);
+  });
+
+  it("track() forwards event properties through to the SDK", async () => {
+    const a = await loadAnalytics("test-token-123");
+    a.initAnalytics();
+    a.track("chat_message_sent", { model: "opus", mode: "code" });
+    expect(mp.track).toHaveBeenCalledWith("chat_message_sent", { model: "opus", mode: "code" });
+  });
+
+  it("identifyUser() forwards identity + is_authenticated to the SDK", async () => {
+    const a = await loadAnalytics("test-token-123");
+    a.initAnalytics();
+    a.identifyUser("user-123");
+    expect(mp.identify).toHaveBeenCalledWith("user-123");
+    expect(mp.register).toHaveBeenCalledWith({ is_authenticated: true });
+  });
+
+  it("is a safe no-op when the token is absent (the build guard is the real protection)", async () => {
+    const a = await loadAnalytics("");
+    a.initAnalytics();
+    a.track("app_opened");
+    expect(mp.init).not.toHaveBeenCalled();
+    expect(mp.track).not.toHaveBeenCalled();
+  });
+});

--- a/interface/src/lib/analytics.ts
+++ b/interface/src/lib/analytics.ts
@@ -12,13 +12,12 @@
 import mixpanel from "mixpanel-browser";
 
 import { getAppPlatform, getAppVersion } from "./build-info";
+import type { AnalyticsEventName } from "./analytics-registry";
 
 const MIXPANEL_TOKEN = import.meta.env.VITE_MIXPANEL_TOKEN?.trim() ?? "";
 const OPT_OUT_KEY = "aura-analytics-opt-out";
 
 let initialized = false;
-let identified = false;
-let lastSessionActiveDate = "";
 
 /** Check if the browser signals Do Not Track or Global Privacy Control. */
 function browserSignalsDNT(): boolean {
@@ -81,19 +80,9 @@ export function registerProperty(key: string, value: unknown): void {
 }
 
 /** Track an event. Safe no-op if not initialized or opted out. */
-export function track(event: string, properties?: Record<string, unknown>): void {
+export function track(event: AnalyticsEventName, properties?: Record<string, unknown>): void {
   if (!initialized) return;
   try {
-    // Co-fire session_active once per calendar day for authenticated
-    // users so True DAU is always >= Engaged DAU. Any tracked event
-    // from an identified user guarantees a session_active that day.
-    if (event !== "session_active" && identified) {
-      const today = new Date().toDateString();
-      if (lastSessionActiveDate !== today) {
-        lastSessionActiveDate = today;
-        mixpanel.track("session_active");
-      }
-    }
     mixpanel.track(event, properties);
   } catch {
     // Silent fail.
@@ -106,7 +95,6 @@ export function identifyUser(userId: string): void {
   try {
     mixpanel.identify(userId);
     mixpanel.register({ is_authenticated: true });
-    identified = true;
   } catch {
     // Silent fail.
   }
@@ -118,8 +106,6 @@ export function resetUser(): void {
   try {
     mixpanel.reset();
     mixpanel.register({ is_authenticated: false });
-    identified = false;
-    lastSessionActiveDate = "";
   } catch {
     // Silent fail.
   }

--- a/interface/src/mobile/chat/MobileChatInputBar/MobileChatInputBar.tsx
+++ b/interface/src/mobile/chat/MobileChatInputBar/MobileChatInputBar.tsx
@@ -40,6 +40,7 @@ import {
 import { ModeSelector, ModelMenuGroup } from "../../../components/InputBarShell";
 import { useIsStreaming } from "../../../hooks/stream/hooks";
 import { useChatUI } from "../../../stores/chat-ui-store";
+import { track } from "../../../lib/analytics";
 import styles from "./MobileChatInputBar.module.css";
 
 function AttachmentPreviews({
@@ -362,10 +363,14 @@ export const MobileChatInputBar = forwardRef<ChatInputBarHandle, ChatInputBarPro
 
     const submitMessage = useCallback(() => {
       if (!canSend) return;
+      // Mirror ChatInputBar.handleSubmit: emit before onSend so the engaged
+      // signal fires regardless of any downstream send/runtime failure.
+      // Mobile previously omitted this, so mobile chat sends were untracked.
+      track("chat_message_sent", { model: selectedModel, mode: selectedMode });
       // Mode lives in the per-stream store; the panel state reads it
       // when constructing the resolved send.
       onSend(input, undefined, undefined);
-    }, [canSend, input, onSend]);
+    }, [canSend, input, onSend, selectedModel, selectedMode]);
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (slashMenuOpen && ["ArrowDown", "ArrowUp", "Enter", "Tab", "Escape"].includes(event.key)) {


### PR DESCRIPTION
## Summary
Rebuilds product analytics for accuracy and reliability across web, mobile, and
desktop. True DAU (`session_active`) now has a single emitter (the server), a
typed event registry + contract tests prevent silent tracking regressions, and
build-time guards ensure analytics can't ship without its token.

## Problems addressed
- True DAU was ~2x inflated: client and server both emitted `session_active` per
  user/day with no shared dedup, plus client-side presence firing (focus/
  visibility/hourly) counted open-but-idle tabs.
- A build config change had silently dropped the client analytics token with no
  guardrail (the metrics "cliff").
- Mobile store builds shipped without the analytics token — production mobile
  analytics was dead.
- Mobile chat sends were untracked (separate input component missing the call).
- The desktop bundled local server had no analytics token, so desktop True DAU
  depended entirely on the now-removed client emit.

## Changes
- **Single emitter:** server is the sole source of `session_active`; removed the
  client co-fire and presence/focus/hourly firing. Ties True DAU to authenticated
  server activity (excludes bots, public loads, login bounces).
- **Typed registry + contract tests:** canonical typed event set, `track()` typed
  to it, AST contract test (call-sites <-> registry, zero client `session_active`,
  required props, server-events manifest in sync), pipeline test (wrapper actually
  forwards to the SDK), and server tests (event constants match manifest;
  `session_active` from exactly one site).
- **Build guards:** `--require-analytics` verifies token + version are baked into
  every shipping surface (web, desktop release, mobile store + nightly). Mobile
  store builds now bake the token; desktop bakes the server-side token for its
  local server.
- **Coverage:** mobile chat now emits `chat_message_sent`; `ENGAGED_BUNDLE` set to
  a deliberate meaningful-product-action set.
- **CI gate:** `analytics-contract.yml` runs the contract/pipeline/server tests on
  push to main and PRs.
- **Incidental:** fixes a pre-existing server *test build* break (three
  `AgentPermissions` test initializers were missing the `tool_permissions` field).
  Production builds were unaffected; this is required for the new cargo-test CI
  gate to compile.

## Verification
- Contract/pipeline/server tests pass (mutation-tested); node validator 7/7.
- Live-verified against a test analytics project: server `session_active` (web +
  desktop local server), client engaged/lifecycle events, single-emitter behavior,
  correct per-platform tagging.

## Post-deploy (re-baseline, not a regression)
- True DAU steps down to its true level (removes ~2x double-count + idle-presence
  inflation), won't hit zero; mobile data appears (was dead).
- Dashboard follow-ups (no code): align the Engaged DAU chart to the new bundle
  (adds `task_run_started`, `marketplace_agent_hired`; removes `feedback_created`);
  redefine Retention as engaged->engaged (currently presence->presence).
