### PR TITLE
fix: defer the forced-upgrade gate until the current operation finishes

### DIFF
--- a/interface/src/components/ForcedUpgrade/ForcedUpgradeOverlay.test.tsx
+++ b/interface/src/components/ForcedUpgrade/ForcedUpgradeOverlay.test.tsx
@@ -22,6 +22,11 @@ vi.mock("./useReleasesBehind", async () => {
   };
 });
 
+const anyStreamingMock = vi.fn();
+vi.mock("../../hooks/stream/hooks", () => ({
+  useIsAnyStreaming: () => anyStreamingMock(),
+}));
+
 import { ForcedUpgradeOverlay } from "./ForcedUpgradeOverlay";
 
 const installUpdate = vi.fn(() => Promise.resolve());
@@ -62,6 +67,7 @@ function setStatus(overrides: StatusOverrides = {}) {
 beforeEach(() => {
   useAuraCapabilitiesMock.mockReturnValue({ features: { nativeUpdater: true } });
   releasesBehindMock.mockReturnValue(3);
+  anyStreamingMock.mockReturnValue(false);
   setStatus();
 });
 
@@ -133,5 +139,31 @@ describe("ForcedUpgradeOverlay", () => {
     expect(screen.getByTestId("forced-upgrade-action").textContent).toContain(
       "Try again",
     );
+  });
+
+  it("defers (renders nothing) while an operation is streaming, even at the threshold", () => {
+    anyStreamingMock.mockReturnValue(true);
+    const { container } = render(<ForcedUpgradeOverlay />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the gate once the streaming operation finishes", () => {
+    anyStreamingMock.mockReturnValue(true);
+    const { container, rerender } = render(<ForcedUpgradeOverlay />);
+    expect(container).toBeEmptyDOMElement();
+
+    anyStreamingMock.mockReturnValue(false);
+    rerender(<ForcedUpgradeOverlay />);
+    expect(screen.getByTestId("forced-upgrade-overlay")).toBeInTheDocument();
+  });
+
+  it("stays latched if a stream starts after the gate is already shown", () => {
+    const { rerender } = render(<ForcedUpgradeOverlay />);
+    expect(screen.getByTestId("forced-upgrade-overlay")).toBeInTheDocument();
+
+    // A new operation starting must not dismiss an already-shown gate.
+    anyStreamingMock.mockReturnValue(true);
+    rerender(<ForcedUpgradeOverlay />);
+    expect(screen.getByTestId("forced-upgrade-overlay")).toBeInTheDocument();
   });
 });

--- a/interface/src/components/ForcedUpgrade/ForcedUpgradeOverlay.tsx
+++ b/interface/src/components/ForcedUpgrade/ForcedUpgradeOverlay.tsx
@@ -3,6 +3,7 @@ import { Button, Spinner, Text } from "@cypher-asi/zui";
 import { AlertTriangle, Download } from "lucide-react";
 import { useAuraCapabilities } from "../../hooks/use-aura-capabilities";
 import { useUpdateStatus } from "../UpdateControl/useUpdateStatus";
+import { useIsAnyStreaming } from "../../hooks/stream/hooks";
 import { FORCED_UPGRADE_THRESHOLD, useReleasesBehind } from "./useReleasesBehind";
 import styles from "./ForcedUpgradeOverlay.module.css";
 
@@ -20,6 +21,11 @@ interface GateSnapshot {
  * overlay stays up through the install lifecycle (status flips away from
  * `available` while downloading/installing) and only disappears when the
  * upgraded app relaunches.
+ *
+ * Latching is deferred while any stream is active so the gate never interrupts
+ * an in-progress turn/extraction — it appears once the user is idle. This only
+ * gates the initial latch; a stream starting after the gate is shown does not
+ * dismiss it.
  */
 export function ForcedUpgradeOverlay(): React.ReactElement | null {
   const { features } = useAuraCapabilities();
@@ -46,6 +52,11 @@ export function ForcedUpgradeOverlay(): React.ReactElement | null {
     updateBaseUrl,
   });
 
+  // Don't latch (show) the gate while an operation is streaming, so a forced
+  // upgrade never interrupts an in-progress turn/extraction. Once the user is
+  // idle the gate latches and shows — a defer, not a cancel.
+  const anyStreaming = useIsAnyStreaming();
+
   const forcedNow =
     updateAvailable &&
     releasesBehind !== null &&
@@ -60,6 +71,7 @@ export function ForcedUpgradeOverlay(): React.ReactElement | null {
   const [gate, setGate] = useState<GateSnapshot | null>(null);
   if (
     forcedNow &&
+    !anyStreaming &&
     releasesBehind !== null &&
     (gate === null ||
       gate.behind !== releasesBehind ||

--- a/interface/src/hooks/stream/hooks.ts
+++ b/interface/src/hooks/stream/hooks.ts
@@ -13,6 +13,18 @@ export function useIsStreaming(key: string): boolean {
   return useStreamStore((s) => s.entries[key]?.isStreaming ?? false);
 }
 
+/**
+ * True when ANY stream is actively streaming — a global "an operation is in
+ * progress" signal for app-level UI (e.g. deferring a blocking overlay until
+ * the user's current turn/extraction finishes). Returns a primitive bool so
+ * subscribers only re-render when the aggregate flips.
+ */
+export function useIsAnyStreaming(): boolean {
+  return useStreamStore((s) =>
+    Object.values(s.entries).some((e) => e.isStreaming),
+  );
+}
+
 export function useIsWriting(key: string): boolean {
   return useStreamStore((s) => s.entries[key]?.isWriting ?? false);
 }


### PR DESCRIPTION
## Summary
The forced-upgrade overlay (`ForcedUpgradeOverlay`, shown when ≥3 releases behind) hard-blocks the screen the moment the condition is detected — **including mid-operation**. It interrupted an in-progress task extraction during dogfooding, leaving the agent op in an unknown state.

## Fix
Defer the gate's *latch* while any stream is active: it no longer appears during an in-progress turn/extraction, and shows once the user is idle. **Defer, not cancel** — the upgrade is still forced, just not mid-operation. A stream starting *after* the gate is shown does not dismiss it.

Adds a global `useIsAnyStreaming()` selector (true when any stream is active) and gates the latch on it.

## Tests
- defers (renders nothing) while streaming, even at the threshold
- shows once the streaming op finishes
- stays latched if a stream starts after the gate is shown
- all existing overlay + stream-hook tests pass (28 total); eslint + tsc clean