### PR TITLE
feat(skills): edit existing user-authored skills

### DIFF
--- a/apps/aura-os-server/src/handlers/harness_proxy/local/create.rs
+++ b/apps/aura-os-server/src/handlers/harness_proxy/local/create.rs
@@ -40,31 +40,47 @@ struct CreateSkillResponse {
     installed_on_agent: bool,
 }
 
-fn build_skill_frontmatter(payload: &CreateSkillBody) -> String {
-    let mut frontmatter = format!(
-        "---\ndescription: \"{}\"\n",
-        yaml_escape_scalar(&payload.description)
-    );
-    if let Some(ref tools) = payload.allowed_tools {
+/// Render the YAML frontmatter block for a user-authored skill.
+///
+/// Shared by the create and update flows so both emit byte-for-byte the
+/// same frontmatter shape — crucially including the `source:
+/// "user-created"` marker that `list_my_skills` / `delete_my_skill` rely
+/// on to tell user skills apart from shop-installed ones. Keeping a single
+/// renderer prevents the two endpoints from drifting.
+pub(super) fn render_skill_frontmatter(
+    description: &str,
+    allowed_tools: Option<&[String]>,
+    model: Option<&str>,
+    context: Option<&str>,
+    user_invocable: bool,
+    model_invocable: bool,
+) -> String {
+    let mut frontmatter = format!("---\ndescription: \"{}\"\n", yaml_escape_scalar(description));
+    if let Some(tools) = allowed_tools {
         frontmatter.push_str(&format!("allowed_tools: [{}]\n", tools.join(", ")));
     }
-    if let Some(ref model) = payload.model {
+    if let Some(model) = model {
         frontmatter.push_str(&format!("model: \"{}\"\n", yaml_escape_scalar(model)));
     }
-    if let Some(ref context) = payload.context {
+    if let Some(context) = context {
         frontmatter.push_str(&format!("context: \"{}\"\n", yaml_escape_scalar(context)));
     }
-    frontmatter.push_str(&format!(
-        "user_invocable: {}\n",
-        payload.user_invocable.unwrap_or(true)
-    ));
-    frontmatter.push_str(&format!(
-        "model_invocable: {}\n",
-        payload.model_invocable.unwrap_or(false)
-    ));
+    frontmatter.push_str(&format!("user_invocable: {user_invocable}\n"));
+    frontmatter.push_str(&format!("model_invocable: {model_invocable}\n"));
     frontmatter.push_str(&format!("source: \"{USER_CREATED_SOURCE_MARKER}\"\n"));
     frontmatter.push_str("---\n");
     frontmatter
+}
+
+fn build_skill_frontmatter(payload: &CreateSkillBody) -> String {
+    render_skill_frontmatter(
+        &payload.description,
+        payload.allowed_tools.as_deref(),
+        payload.model.as_deref(),
+        payload.context.as_deref(),
+        payload.user_invocable.unwrap_or(true),
+        payload.model_invocable.unwrap_or(false),
+    )
 }
 
 async fn maybe_install_on_agent(

--- a/apps/aura-os-server/src/handlers/harness_proxy/local/mod.rs
+++ b/apps/aura-os-server/src/handlers/harness_proxy/local/mod.rs
@@ -9,15 +9,18 @@
 //! * [`create`] — create-skill and install-from-shop flows.
 //! * [`discover`] — read-only skill content / on-disk discovery.
 //! * [`manage`] — list user-created skills and delete them.
+//! * [`update`] — rewrite an existing user-created skill's SKILL.md.
 
 mod create;
 mod discover;
 mod frontmatter;
 mod manage;
+mod update;
 
 pub(crate) use create::{create_skill, install_from_shop};
 pub(crate) use discover::{discover_skill_paths, get_skill_content};
 pub(crate) use manage::{delete_my_skill, list_my_skills};
+pub(crate) use update::update_my_skill;
 
 /// Marker written into the YAML frontmatter of every skill created via the
 /// `POST /api/harness/skills` endpoint. Used by `list_my_skills` to separate

--- a/apps/aura-os-server/src/handlers/harness_proxy/local/update.rs
+++ b/apps/aura-os-server/src/handlers/harness_proxy/local/update.rs
@@ -81,9 +81,17 @@ pub(crate) async fn update_my_skill(
     // harness catalog FIRST (the harness writes its own marker-less
     // SKILL.md on this POST), then stamp our marker-bearing file last so
     // it wins the race and the skill keeps showing up under "My Skills".
-    state
+    //
+    // Unlike create, this POST is checked rather than fire-and-forget: it is
+    // the harness call that reloads the in-memory skill registry, and that
+    // registry — not the on-disk file — is what agents resolve a skill's
+    // content from. If it fails, the edit would NOT go live (every agent
+    // keeps serving the old body), so writing the new file below and
+    // returning 200 would be a lie. Fail loud and leave the on-disk skill
+    // untouched so disk and the live registry stay consistent (both pre-edit).
+    let registered = state
         .harness_http
-        .post_json_ignore_result(
+        .post_json_ok(
             "api/skills",
             serde_json::json!({
                 "name": name,
@@ -95,6 +103,9 @@ pub(crate) async fn update_my_skill(
             .to_string(),
         )
         .await;
+    if !registered {
+        return Err(StatusCode::BAD_GATEWAY);
+    }
 
     std::fs::write(&skill_path, &content).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 

--- a/apps/aura-os-server/src/handlers/harness_proxy/local/update.rs
+++ b/apps/aura-os-server/src/handlers/harness_proxy/local/update.rs
@@ -1,0 +1,113 @@
+//! `PUT /api/harness/skills/mine/{name}` (update) flow for
+//! user-authored skills.
+
+use axum::extract::{Path, State};
+use axum::http::{header, StatusCode};
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Deserialize;
+
+use crate::state::AppState;
+
+use super::create::render_skill_frontmatter;
+use super::frontmatter::extract_frontmatter_field;
+use super::{create_skill_name_valid, user_skills_root, USER_CREATED_SOURCE_MARKER};
+
+#[derive(Deserialize)]
+pub(crate) struct UpdateSkillBody {
+    pub description: String,
+    pub body: Option<String>,
+    pub allowed_tools: Option<Vec<String>>,
+    pub model: Option<String>,
+    pub context: Option<String>,
+    pub user_invocable: Option<bool>,
+    pub model_invocable: Option<bool>,
+}
+
+#[derive(serde::Serialize)]
+struct UpdateSkillResponse {
+    name: String,
+    path: String,
+    updated: bool,
+}
+
+/// Rewrite an existing user-authored skill's `SKILL.md` (frontmatter +
+/// body). Mirrors the create flow's write logic so the on-disk shape stays
+/// identical — same frontmatter renderer (carrying the `source:
+/// "user-created"` marker) and the same harness-first/write-last ordering
+/// so our marker-bearing file wins over the harness's own clobbering write.
+///
+/// Preconditions (matching `delete_my_skill`):
+/// - `<skills_root>/<name>/SKILL.md` must already exist (else 404). This is
+///   strictly an *edit* of an existing skill — renaming/creating goes
+///   through the create endpoint.
+/// - The existing file must carry the `source: "user-created"` marker
+///   (else 403). This stops the endpoint from being used to overwrite a
+///   shop-installed skill that happens to share the on-disk layout.
+pub(crate) async fn update_my_skill(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(payload): Json<UpdateSkillBody>,
+) -> Result<axum::response::Response, StatusCode> {
+    if !create_skill_name_valid(&name) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let skill_dir = user_skills_root()
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?
+        .join(&name);
+    let skill_path = skill_dir.join("SKILL.md");
+
+    // Existence + ownership check before touching anything. Editing a skill
+    // that doesn't exist is a 404; editing a non-user-created skill is a 403.
+    let existing = std::fs::read_to_string(&skill_path).map_err(|_| StatusCode::NOT_FOUND)?;
+    let source = extract_frontmatter_field(&existing, "source").unwrap_or_default();
+    if source != USER_CREATED_SOURCE_MARKER {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let frontmatter = render_skill_frontmatter(
+        &payload.description,
+        payload.allowed_tools.as_deref(),
+        payload.model.as_deref(),
+        payload.context.as_deref(),
+        payload.user_invocable.unwrap_or(true),
+        payload.model_invocable.unwrap_or(false),
+    );
+    let body_text = payload.body.clone().unwrap_or_default();
+    let content = format!("{frontmatter}\n{body_text}");
+
+    // Mirror create's ordering: register the updated content with the
+    // harness catalog FIRST (the harness writes its own marker-less
+    // SKILL.md on this POST), then stamp our marker-bearing file last so
+    // it wins the race and the skill keeps showing up under "My Skills".
+    state
+        .harness_http
+        .post_json_ignore_result(
+            "api/skills",
+            serde_json::json!({
+                "name": name,
+                "description": payload.description,
+                "body": body_text,
+                "user_invocable": payload.user_invocable.unwrap_or(true),
+                "model_invocable": payload.model_invocable.unwrap_or(false),
+            })
+            .to_string(),
+        )
+        .await;
+
+    std::fs::write(&skill_path, &content).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let resp = UpdateSkillResponse {
+        name,
+        path: skill_path.to_string_lossy().into_owned(),
+        updated: true,
+    };
+    let body = serde_json::to_string(&resp).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok((
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        body,
+    )
+        .into_response())
+}

--- a/apps/aura-os-server/src/handlers/harness_proxy/mod.rs
+++ b/apps/aura-os-server/src/handlers/harness_proxy/mod.rs
@@ -6,7 +6,7 @@ mod skills;
 
 pub(crate) use local::{
     create_skill, delete_my_skill, discover_skill_paths, get_skill_content, install_from_shop,
-    list_my_skills, skill_exists_on_disk,
+    list_my_skills, skill_exists_on_disk, update_my_skill,
 };
 pub(crate) use memory::{
     create_event, create_fact, create_procedure, delete_event, delete_fact, delete_procedure,

--- a/apps/aura-os-server/src/harness_gateway.rs
+++ b/apps/aura-os-server/src/harness_gateway.rs
@@ -67,6 +67,21 @@ impl HarnessHttpGateway {
         }
     }
 
+    /// POST JSON and report whether the harness accepted it (2xx status).
+    ///
+    /// Unlike [`Self::post_json_ignore_result`], the caller can react to a
+    /// failed registration instead of silently proceeding. Use this when the
+    /// harness call is load-bearing — e.g. the skill-edit path, where this
+    /// POST is what reloads the harness's in-memory skill registry and is the
+    /// only thing that makes an edit go live. Returns `false` on any
+    /// transport failure or non-2xx status.
+    pub(crate) async fn post_json_ok(&self, path: &str, body: String) -> bool {
+        match self.proxy_json(Method::POST, path, None, Some(body)).await {
+            Ok(resp) => resp.status().is_success(),
+            Err(_) => false,
+        }
+    }
+
     /// Fire-and-forget style POST used when the caller does not need the harness response.
     pub(crate) async fn post_json_ignore_result(&self, path: &str, body: String) {
         let path = path.trim_start_matches('/');

--- a/apps/aura-os-server/src/router/harness_proxy.rs
+++ b/apps/aura-os-server/src/router/harness_proxy.rs
@@ -1,4 +1,4 @@
-use axum::routing::{delete, get, post};
+use axum::routing::{delete, get, post, put};
 use axum::Router;
 
 use crate::handlers::harness_proxy;
@@ -72,7 +72,7 @@ pub(super) fn harness_proxy_routes() -> Router<AppState> {
         )
         .route(
             "/api/harness/skills/mine/:name",
-            delete(harness_proxy::delete_my_skill),
+            put(harness_proxy::update_my_skill).delete(harness_proxy::delete_my_skill),
         )
         .route("/api/harness/skills/:name", get(harness_proxy::get_skill))
         .route(

--- a/apps/aura-os-server/tests/harness_proxy_test/main.rs
+++ b/apps/aura-os-server/tests/harness_proxy_test/main.rs
@@ -13,3 +13,4 @@ mod proxy_forwards;
 mod skills_create;
 mod skills_delete;
 mod skills_list;
+mod skills_update;

--- a/apps/aura-os-server/tests/harness_proxy_test/mocks.rs
+++ b/apps/aura-os-server/tests/harness_proxy_test/mocks.rs
@@ -176,6 +176,39 @@ pub(crate) async fn start_recording_mock_harness() -> (String, Arc<Mutex<Vec<(St
     (url, calls)
 }
 
+/// Mock harness whose `POST /api/skills` always fails with a 500. Models
+/// the harness being unreachable/erroring during a skill edit so tests can
+/// assert the edit path fails loud (502) instead of silently serving stale
+/// content behind a 200. Other routes succeed so an initial create (which
+/// treats the harness POST as best-effort) still lands its marker file.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub(crate) async fn start_failing_skills_mock_harness() -> String {
+    let fail_post = |_req: Request<Body>| async move {
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({ "error": "boom" })),
+        )
+            .into_response()
+    };
+    let ok_post =
+        |_req: Request<Body>| async move { axum::Json(json!({ "ok": true })).into_response() };
+
+    let mock_app = Router::new()
+        .route("/api/skills", post(fail_post))
+        .route("/api/agents/:agent_id/skills", post(ok_post));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://{addr}");
+
+    tokio::spawn(async move {
+        axum::serve(listener, mock_app).await.ok();
+    });
+
+    url
+}
+
 /// Mock harness that reports the current installation state for each
 /// agent_id from a shared map. Used by the `delete_my_skill_*` cascade
 /// tests below to exercise the server-side precondition that blocks a

--- a/apps/aura-os-server/tests/harness_proxy_test/skills_update.rs
+++ b/apps/aura-os-server/tests/harness_proxy_test/skills_update.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use tower::ServiceExt;
 
 use super::common::*;
-use super::mocks::start_recording_mock_harness;
+use super::mocks::{start_failing_skills_mock_harness, start_recording_mock_harness};
 use super::HARNESS_URL_ENV_LOCK;
 
 // `dirs::home_dir()` on Windows ignores env vars and reads the real user
@@ -129,6 +129,66 @@ async fn update_my_skill_rewrites_file_and_reregisters() {
     assert_eq!(reregister_body["name"], "edit-me");
     assert_eq!(reregister_body["description"], "Updated description");
     assert_eq!(reregister_body["body"], "# Updated body");
+}
+
+/// If the harness rejects the re-register POST, the edit must fail loud
+/// (502) and leave the on-disk SKILL.md untouched — never report success
+/// for a change that didn't go live. That harness POST is the only thing
+/// that reloads the live skill registry, so a silent failure would serve
+/// stale content behind a 200.
+#[tokio::test]
+async fn update_my_skill_harness_failure_returns_502_and_leaves_file() {
+    let _guard = HARNESS_URL_ENV_LOCK.lock().await;
+    let mock_url = start_failing_skills_mock_harness().await;
+    unsafe {
+        std::env::set_var("LOCAL_HARNESS_URL", &mock_url);
+    }
+    let home_dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("HOME", home_dir.path());
+    }
+    let (app, _, _db) = build_test_app_with_mocks().await;
+
+    // Create lands its marker file even though the harness POST is best-effort
+    // and fails here, so we have a real user-authored skill to try to edit.
+    let req = json_request(
+        "POST",
+        "/api/harness/skills",
+        Some(json!({
+            "name": "edit-me",
+            "description": "Original description",
+            "body": "# Original body",
+        })),
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let skill_path = home_dir
+        .path()
+        .join(aura_os_core::Channel::current().skills_home_name())
+        .join("skills")
+        .join("edit-me")
+        .join("SKILL.md");
+    let before = std::fs::read_to_string(&skill_path).unwrap();
+
+    // The edit's re-register POST hits the failing harness → 502.
+    let req = json_request(
+        "PUT",
+        "/api/harness/skills/mine/edit-me",
+        Some(json!({
+            "description": "Updated description",
+            "body": "# Updated body",
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+    // The file must be exactly as it was — no partial "disk new / registry old".
+    let after = std::fs::read_to_string(&skill_path).unwrap();
+    assert_eq!(
+        before, after,
+        "a failed re-register must not rewrite the skill file"
+    );
 }
 
 /// Editing a skill that does not exist on disk is a 404.

--- a/apps/aura-os-server/tests/harness_proxy_test/skills_update.rs
+++ b/apps/aura-os-server/tests/harness_proxy_test/skills_update.rs
@@ -1,0 +1,217 @@
+#![cfg(unix)]
+
+use axum::http::StatusCode;
+use serde_json::json;
+use tower::ServiceExt;
+
+use super::common::*;
+use super::mocks::start_recording_mock_harness;
+use super::HARNESS_URL_ENV_LOCK;
+
+// `dirs::home_dir()` on Windows ignores env vars and reads the real user
+// profile from the OS, so these tests redirect `HOME` and only run on Unix to
+// avoid polluting a developer's real ~/.aura/skills/.
+
+/// Happy path: editing a user-authored skill rewrites SKILL.md (frontmatter
+/// + body), preserves the `user-created` marker so it stays under "My
+/// Skills", and re-registers the new content with the harness catalog.
+#[tokio::test]
+async fn update_my_skill_rewrites_file_and_reregisters() {
+    let _guard = HARNESS_URL_ENV_LOCK.lock().await;
+    let (mock_url, calls) = start_recording_mock_harness().await;
+    unsafe {
+        std::env::set_var("LOCAL_HARNESS_URL", &mock_url);
+    }
+    let home_dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("HOME", home_dir.path());
+    }
+    let (app, _, _db) = build_test_app_with_mocks().await;
+
+    // Author a skill via the real create path so it carries the marker.
+    let req = json_request(
+        "POST",
+        "/api/harness/skills",
+        Some(json!({
+            "name": "edit-me",
+            "description": "Original description",
+            "body": "# Original body",
+        })),
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // Now edit it.
+    let req = json_request(
+        "PUT",
+        "/api/harness/skills/mine/edit-me",
+        Some(json!({
+            "description": "Updated description",
+            "body": "# Updated body",
+            "user_invocable": false,
+            "model_invocable": true,
+        })),
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    assert_eq!(body["name"], "edit-me");
+    assert_eq!(body["updated"], true);
+
+    // SKILL.md must reflect the new content and KEEP the user-created marker.
+    let skill_path = home_dir
+        .path()
+        .join(aura_os_core::Channel::current().skills_home_name())
+        .join("skills")
+        .join("edit-me")
+        .join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_path).unwrap();
+    assert!(
+        content.contains("description: \"Updated description\""),
+        "expected updated description, got:\n{content}"
+    );
+    assert!(
+        content.contains("# Updated body"),
+        "expected updated body, got:\n{content}"
+    );
+    assert!(
+        !content.contains("# Original body"),
+        "old body must be gone, got:\n{content}"
+    );
+    assert!(
+        content.contains("user_invocable: false"),
+        "expected user_invocable flag to be persisted, got:\n{content}"
+    );
+    assert!(
+        content.contains("model_invocable: true"),
+        "expected model_invocable flag to be persisted, got:\n{content}"
+    );
+    assert!(
+        content.contains("source: \"user-created\""),
+        "user-created marker must survive an edit, got:\n{content}"
+    );
+
+    // And list_my_skills still reports it with the updated metadata.
+    let req = json_request("GET", "/api/harness/skills/mine", None);
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let arr = body.as_array().expect("response should be a JSON array");
+    let entry = arr
+        .iter()
+        .find(|e| e["name"] == "edit-me")
+        .expect("edited skill should still be listed");
+    assert_eq!(entry["description"], "Updated description");
+    assert_eq!(entry["user_invocable"], false);
+    assert_eq!(entry["model_invocable"], true);
+
+    // The edit must have re-registered the new content with the harness.
+    for _ in 0..50 {
+        if calls
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(uri, b)| uri == "/api/skills" && b.contains("Updated description"))
+            .count()
+            >= 1
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    let captured = calls.lock().unwrap().clone();
+    let reregister = captured
+        .iter()
+        .find(|(uri, b)| uri == "/api/skills" && b.contains("Updated description"))
+        .expect("expected a re-register POST to /api/skills with updated content");
+    let reregister_body: serde_json::Value =
+        serde_json::from_str(&reregister.1).expect("re-register body is valid JSON");
+    assert_eq!(reregister_body["name"], "edit-me");
+    assert_eq!(reregister_body["description"], "Updated description");
+    assert_eq!(reregister_body["body"], "# Updated body");
+}
+
+/// Editing a skill that does not exist on disk is a 404.
+#[tokio::test]
+async fn update_my_skill_missing_returns_404() {
+    let _guard = HARNESS_URL_ENV_LOCK.lock().await;
+    let (mock_url, _calls) = start_recording_mock_harness().await;
+    unsafe {
+        std::env::set_var("LOCAL_HARNESS_URL", &mock_url);
+    }
+    let home_dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("HOME", home_dir.path());
+    }
+    let (app, _, _db) = build_test_app_with_mocks().await;
+
+    let req = json_request(
+        "PUT",
+        "/api/harness/skills/mine/no-such-skill",
+        Some(json!({ "description": "x" })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+/// Editing a skill that lacks the `user-created` marker (e.g. a
+/// shop-installed one sharing the on-disk layout) is refused with 403 and
+/// must not touch the file.
+#[tokio::test]
+async fn update_my_skill_refuses_non_user_created() {
+    let _guard = HARNESS_URL_ENV_LOCK.lock().await;
+    let (mock_url, _calls) = start_recording_mock_harness().await;
+    unsafe {
+        std::env::set_var("LOCAL_HARNESS_URL", &mock_url);
+    }
+    let home_dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("HOME", home_dir.path());
+    }
+    let (app, _, _db) = build_test_app_with_mocks().await;
+
+    let shop_dir = home_dir
+        .path()
+        .join(aura_os_core::Channel::current().skills_home_name())
+        .join("skills")
+        .join("shop-skill");
+    std::fs::create_dir_all(&shop_dir).unwrap();
+    let original = "---\ndescription: \"From shop\"\nuser_invocable: true\n---\n# Shop body\n";
+    std::fs::write(shop_dir.join("SKILL.md"), original).unwrap();
+
+    let req = json_request(
+        "PUT",
+        "/api/harness/skills/mine/shop-skill",
+        Some(json!({ "description": "hijacked", "body": "# pwned" })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    // The file must be untouched.
+    let content = std::fs::read_to_string(shop_dir.join("SKILL.md")).unwrap();
+    assert_eq!(content, original, "shop skill file must NOT be modified");
+}
+
+/// Invalid skill name in the path is a 400 (mirrors create/delete name
+/// validation).
+#[tokio::test]
+async fn update_my_skill_invalid_name_returns_400() {
+    let _guard = HARNESS_URL_ENV_LOCK.lock().await;
+    let (mock_url, _calls) = start_recording_mock_harness().await;
+    unsafe {
+        std::env::set_var("LOCAL_HARNESS_URL", &mock_url);
+    }
+    let home_dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("HOME", home_dir.path());
+    }
+    let (app, _, _db) = build_test_app_with_mocks().await;
+
+    let req = json_request(
+        "PUT",
+        "/api/harness/skills/mine/Bad_Name",
+        Some(json!({ "description": "x" })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/interface/src/apps/agents/AgentInfoPanel/SkillEditorModal.tsx
+++ b/interface/src/apps/agents/AgentInfoPanel/SkillEditorModal.tsx
@@ -1,15 +1,15 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { Modal, Input, Textarea, Button, Spinner, Text } from "@cypher-asi/zui";
 import { api } from "../../../api/client";
 import styles from "../components/AgentEditorModal/AgentEditorModal.module.css";
 
 interface SkillEditorModalProps {
   isOpen: boolean;
+  /** Name of the user-authored skill to edit; `null` when closed. */
+  skillName: string | null;
   onClose: () => void;
-  onCreated: () => void;
+  onSaved: () => void;
 }
-
-const NAME_RE = /^[a-z0-9-]{1,64}$/;
 
 /**
  * Pull a user-facing message off an unknown rejection. The harness API
@@ -25,46 +25,74 @@ function extractApiErrorMessage(err: unknown): string | undefined {
   return undefined;
 }
 
-export function SkillEditorModal({ isOpen, onClose, onCreated }: SkillEditorModalProps) {
-  const [name, setName] = useState("");
+/**
+ * Frontmatter fields the edit UI does not surface but must round-trip on
+ * save. The update endpoint re-renders the whole SKILL.md frontmatter from
+ * the request, so any field we don't send back is silently dropped — we
+ * load these from the existing skill and pass them straight through.
+ */
+interface PreservedFields {
+  allowed_tools?: string[];
+  model?: string;
+  context?: string;
+  model_invocable: boolean;
+}
+
+/**
+ * Edit an existing user-authored skill: pre-fills from the skill's current
+ * SKILL.md (description / instructions / flags), keeps the name read-only
+ * (renaming means delete + recreate), and saves via `updateMySkill`.
+ *
+ * The body is loaded before any save is allowed because the update handler
+ * writes `body.unwrap_or_default()` — saving with an unloaded (empty) body
+ * would clobber the user's instructions.
+ */
+export function SkillEditorModal({ isOpen, skillName, onClose, onSaved }: SkillEditorModalProps) {
   const [description, setDescription] = useState("");
   const [body, setBody] = useState("");
   const [userInvocable, setUserInvocable] = useState(true);
+  const [preserved, setPreserved] = useState<PreservedFields>({ model_invocable: false });
+  const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
-  const [nameError, setNameError] = useState("");
-  const nameRef = useRef<HTMLInputElement>(null);
+  const descRef = useRef<HTMLInputElement>(null);
 
-  const reset = useCallback(() => {
-    setName("");
-    setDescription("");
-    setBody("");
-    setUserInvocable(true);
-    setSaving(false);
+  useEffect(() => {
+    if (!isOpen || !skillName) return;
+    let cancelled = false;
+    setLoading(true);
     setError("");
-    setNameError("");
-  }, []);
-
-  const handleClose = useCallback(() => {
-    reset();
-    onClose();
-  }, [reset, onClose]);
+    api.harnessSkills
+      .getSkill(skillName)
+      .then((skill) => {
+        if (cancelled) return;
+        const fm = (skill.frontmatter ?? {}) as Record<string, unknown>;
+        setDescription(skill.description ?? "");
+        setBody(skill.body ?? "");
+        setUserInvocable(skill.user_invocable ?? true);
+        setPreserved({
+          allowed_tools: Array.isArray(fm.allowed_tools)
+            ? (fm.allowed_tools as string[])
+            : undefined,
+          model: typeof fm.model === "string" ? fm.model : undefined,
+          context: typeof fm.context === "string" ? fm.context : undefined,
+          model_invocable: skill.model_invocable ?? false,
+        });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(extractApiErrorMessage(err) ?? "Failed to load skill");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, skillName]);
 
   const handleSave = useCallback(async () => {
+    if (!skillName) return;
     setError("");
-    setNameError("");
-
-    const slug = name.trim().toLowerCase().replace(/\s+/g, "-");
-    if (!slug) {
-      setNameError("Name is required");
-      nameRef.current?.focus();
-      return;
-    }
-    if (!NAME_RE.test(slug)) {
-      setNameError("Lowercase letters, digits, and hyphens only (1-64 chars)");
-      nameRef.current?.focus();
-      return;
-    }
     if (!description.trim()) {
       setError("Description is required");
       return;
@@ -72,88 +100,98 @@ export function SkillEditorModal({ isOpen, onClose, onCreated }: SkillEditorModa
 
     setSaving(true);
     try {
-      await api.harnessSkills.createSkill({
-        name: slug,
+      await api.harnessSkills.updateMySkill(skillName, {
         description: description.trim(),
         body: body.trim(),
         user_invocable: userInvocable,
+        model_invocable: preserved.model_invocable,
+        // Round-trip the fields the UI doesn't expose so the update
+        // doesn't render a frontmatter that drops them.
+        ...(preserved.allowed_tools ? { allowed_tools: preserved.allowed_tools } : {}),
+        ...(preserved.model ? { model: preserved.model } : {}),
+        ...(preserved.context ? { context: preserved.context } : {}),
       });
-      onCreated();
-      handleClose();
+      onSaved();
+      onClose();
     } catch (err: unknown) {
-      setError(extractApiErrorMessage(err) ?? "Failed to create skill");
+      setError(extractApiErrorMessage(err) ?? "Failed to save skill");
     } finally {
       setSaving(false);
     }
-  }, [name, description, body, userInvocable, onCreated, handleClose]);
+  }, [skillName, description, body, userInvocable, preserved, onSaved, onClose]);
 
   return (
     <Modal
       isOpen={isOpen}
-      onClose={handleClose}
-      title="Create Skill"
+      onClose={onClose}
+      title={skillName ? `Edit ${skillName}` : "Edit Skill"}
       size="md"
-      initialFocusRef={nameRef as React.RefObject<HTMLElement>}
+      initialFocusRef={descRef as React.RefObject<HTMLElement>}
       footer={
         <div className={styles.footer}>
-          <Button variant="ghost" onClick={handleClose} disabled={saving}>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={handleSave} disabled={saving}>
-            {saving ? <><Spinner size="sm" /> Creating...</> : "Create Skill"}
+          <Button variant="primary" onClick={handleSave} disabled={saving || loading}>
+            {saving ? <><Spinner size="sm" /> Saving...</> : "Save Changes"}
           </Button>
         </div>
       }
     >
       <div className={styles.form}>
-        <div className={styles.fieldGroup}>
-          <label className={styles.label}>Name *</label>
-          <Input
-            ref={nameRef}
-            value={name}
-            onChange={(e) => { setName(e.target.value); setNameError(""); }}
-            placeholder="e.g. deploy"
-            validationMessage={nameError}
-          />
-          <Text size="xs" variant="muted">
-            Lowercase letters, digits, and hyphens only
-          </Text>
-        </div>
+        {loading ? (
+          <div className={styles.fieldGroup}>
+            <Text size="sm" variant="muted">
+              <Spinner size="sm" /> Loading skill...
+            </Text>
+          </div>
+        ) : (
+          <>
+            <div className={styles.fieldGroup}>
+              <label className={styles.label}>Name</label>
+              <Input value={skillName ?? ""} disabled />
+              <Text size="xs" variant="muted">
+                Skill name can't be changed — delete and recreate to rename
+              </Text>
+            </div>
 
-        <div className={styles.fieldGroup}>
-          <label className={styles.label}>Description *</label>
-          <Input
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="e.g. Deploy the application to production"
-          />
-        </div>
+            <div className={styles.fieldGroup}>
+              <label className={styles.label}>Description *</label>
+              <Input
+                ref={descRef}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="e.g. Deploy the application to production"
+              />
+            </div>
 
-        <div className={styles.fieldGroup}>
-          <label className={styles.label}>Instructions</label>
-          <Textarea
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            placeholder="Markdown instructions for this skill..."
-            rows={8}
-            mono
-          />
-        </div>
+            <div className={styles.fieldGroup}>
+              <label className={styles.label}>Instructions</label>
+              <Textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                placeholder="Markdown instructions for this skill..."
+                rows={8}
+                mono
+              />
+            </div>
 
-        <div className={styles.fieldGroup}>
-          <label className={styles.label}>
-            <input
-              type="checkbox"
-              checked={userInvocable}
-              onChange={(e) => setUserInvocable(e.target.checked)}
-              style={{ marginRight: 6 }}
-            />
-            User invocable
-          </label>
-          <Text size="xs" variant="muted">
-            Allow users to trigger this skill directly
-          </Text>
-        </div>
+            <div className={styles.fieldGroup}>
+              <label className={styles.label}>
+                <input
+                  type="checkbox"
+                  checked={userInvocable}
+                  onChange={(e) => setUserInvocable(e.target.checked)}
+                  style={{ marginRight: 6 }}
+                />
+                User invocable
+              </label>
+              <Text size="xs" variant="muted">
+                Allow users to trigger this skill directly
+              </Text>
+            </div>
+          </>
+        )}
 
         {error && <Text variant="muted" size="sm" className={styles.error}>{error}</Text>}
       </div>

--- a/interface/src/apps/agents/AgentInfoPanel/SkillsTab.test.tsx
+++ b/interface/src/apps/agents/AgentInfoPanel/SkillsTab.test.tsx
@@ -107,6 +107,18 @@ vi.mock("./CreateSkillModal", () => ({
   CreateSkillModal: () => null,
 }));
 
+// Flatten the edit modal to a marker that echoes the skill it was opened
+// for, so we can assert the row's "Edit skill" action wires through to it.
+vi.mock("./SkillEditorModal", () => ({
+  SkillEditorModal: ({
+    isOpen,
+    skillName,
+  }: {
+    isOpen: boolean;
+    skillName: string | null;
+  }) => (isOpen ? <div data-testid="edit-modal">{skillName}</div> : null),
+}));
+
 vi.mock("../../../components/SkillShopModal", () => ({
   SkillShopModal: () => null,
 }));
@@ -226,6 +238,36 @@ describe("SkillsTab", () => {
     // Regression: we must not quietly uninstall from the current agent.
     // That would mask the real "installed elsewhere" state from the user.
     expect(mockUninstallAgentSkill).not.toHaveBeenCalled();
+  });
+
+  it("opens the editor for a My Skills row via the Edit action", async () => {
+    mockListSkills.mockResolvedValue([]);
+    mockListAgentSkills.mockResolvedValue([]);
+    mockListMySkills.mockResolvedValue([
+      {
+        name: "editable-skill",
+        description: "x",
+        path: "/tmp/editable-skill/SKILL.md",
+        user_invocable: true,
+        model_invocable: false,
+      },
+    ]);
+
+    render(<SkillsTab agent={baseAgent} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("editable-skill")).toBeDefined();
+    });
+
+    // Editor is closed until the row's "Edit skill" action fires.
+    expect(screen.queryByTestId("edit-modal")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("menu-edit"));
+
+    await waitFor(() => {
+      const modal = screen.getByTestId("edit-modal");
+      expect(modal.textContent).toContain("editable-skill");
+    });
   });
 
   it("does not pre-uninstall from current agent on successful delete", async () => {

--- a/interface/src/apps/agents/AgentInfoPanel/SkillsTab.tsx
+++ b/interface/src/apps/agents/AgentInfoPanel/SkillsTab.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect, useCallback } from "react";
 import { Text, Button, ButtonMore, Modal } from "@cypher-asi/zui";
-import { Zap, Loader2, Plus, Trash2, FilePlus2, Store } from "lucide-react";
+import { Zap, Loader2, Plus, Trash2, Pencil, FilePlus2, Store } from "lucide-react";
 import { api } from "../../../api/client";
 import type { MySkillEntry, SkillInstalledAgentRef } from "../../../shared/api/harness-skills";
 import { useAgentSidekickStore } from "../stores/agent-sidekick-store";
@@ -9,6 +9,7 @@ import {
   type SidekickListSection,
 } from "../../../components/SidekickList";
 import { CreateSkillModal } from "./CreateSkillModal";
+import { SkillEditorModal } from "./SkillEditorModal";
 import { SkillShopModal } from "../../../components/SkillShopModal";
 import type { Agent, HarnessSkill, HarnessSkillInstallation } from "../../../shared/types";
 import styles from "./SkillsTab.module.css";
@@ -38,6 +39,9 @@ interface SkillRowActionsProps {
   installed: boolean;
   loading: boolean;
   onAction: () => void;
+  /** When provided, the row shows an "Edit skill" action in its menu.
+   *  Only passed for user-authored ("My Skills") rows. */
+  onEdit?: () => void;
   /** When provided, the row shows a "Delete skill" action in its menu.
    *  Only passed for user-authored ("My Skills") rows — deleting
    *  removes the SKILL.md file and is a different operation from
@@ -57,6 +61,7 @@ function SkillRowActions({
   installed,
   loading,
   onAction,
+  onEdit,
   onDelete,
 }: SkillRowActionsProps) {
   const menuItems: Array<
@@ -66,6 +71,9 @@ function SkillRowActions({
     menuItems.push({ id: "uninstall", label: "Uninstall", icon: <Trash2 size={14} /> });
   } else if (onDelete) {
     menuItems.push({ id: "install", label: "Install", icon: <Plus size={14} /> });
+  }
+  if (onEdit) {
+    menuItems.push({ id: "edit", label: "Edit skill", icon: <Pencil size={14} /> });
   }
   if (onDelete) {
     if (menuItems.length > 0) {
@@ -77,6 +85,8 @@ function SkillRowActions({
   const handleSelect = (id: string) => {
     if (id === "delete") {
       onDelete?.();
+    } else if (id === "edit") {
+      onEdit?.();
     } else {
       onAction();
     }
@@ -89,7 +99,7 @@ function SkillRowActions({
       </div>
     );
   }
-  if (installed || onDelete) {
+  if (installed || onDelete || onEdit) {
     return (
       <ButtonMore
         items={menuItems}
@@ -204,6 +214,9 @@ export function SkillsTab({ agent }: SkillsTabProps) {
   // confirmation modal. `null` = modal closed.
   const [pendingDeleteName, setPendingDeleteName] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  // Name of the user-authored skill the user clicked "Edit skill" on;
+  // drives the edit modal. `null` = modal closed.
+  const [editingSkill, setEditingSkill] = useState<string | null>(null);
   // Populated from a 409 response body when the server refuses to delete
   // because the skill is still installed elsewhere. The modal renders these
   // inline so the user knows exactly which agents to clean up first.
@@ -336,6 +349,10 @@ export function SkillsTab({ agent }: SkillsTabProps) {
     setPendingDeleteName(name);
   }, []);
 
+  const requestEditMySkill = useCallback((name: string) => {
+    setEditingSkill(name);
+  }, []);
+
   const closeDeleteConfirm = useCallback(() => {
     // Don't let the user dismiss the modal mid-delete — the in-flight
     // request would still complete and leave the UI in a half-state.
@@ -400,7 +417,12 @@ export function SkillsTab({ agent }: SkillsTabProps) {
     const skillRow = (
       prefix: string,
       skill: HarnessSkill,
-      opts: { installed: boolean; onAction: () => void; onDelete?: () => void },
+      opts: {
+        installed: boolean;
+        onAction: () => void;
+        onEdit?: () => void;
+        onDelete?: () => void;
+      },
     ) => ({
       id: `${prefix}:${skill.name}`,
       icon: <Zap size={14} />,
@@ -413,6 +435,7 @@ export function SkillsTab({ agent }: SkillsTabProps) {
           installed={opts.installed}
           loading={!!actionLoading[skill.name]}
           onAction={opts.onAction}
+          onEdit={opts.onEdit}
           onDelete={opts.onDelete}
         />
       ),
@@ -440,6 +463,7 @@ export function SkillsTab({ agent }: SkillsTabProps) {
             installed,
             onAction: () =>
               installed ? handleUninstall(skill.name) : handleInstall(skill.name),
+            onEdit: () => requestEditMySkill(skill.name),
             onDelete: () => requestDeleteMySkill(skill.name),
           });
         }),
@@ -470,6 +494,7 @@ export function SkillsTab({ agent }: SkillsTabProps) {
     viewSkill,
     handleInstall,
     handleUninstall,
+    requestEditMySkill,
     requestDeleteMySkill,
   ]);
 
@@ -524,6 +549,13 @@ export function SkillsTab({ agent }: SkillsTabProps) {
         blockingAgents={blockingAgents}
         onClose={closeDeleteConfirm}
         onConfirm={confirmDeleteMySkill}
+      />
+
+      <SkillEditorModal
+        isOpen={editingSkill !== null}
+        skillName={editingSkill}
+        onClose={() => setEditingSkill(null)}
+        onSaved={() => fetchData({ silent: true })}
       />
     </div>
   );

--- a/interface/src/shared/api/harness-skills.test.ts
+++ b/interface/src/shared/api/harness-skills.test.ts
@@ -211,6 +211,32 @@ describe("harnessSkillsApi", () => {
     );
   });
 
+  it("updateMySkill sends PUT /api/harness/skills/mine/:name with the payload", async () => {
+    const data = {
+      description: "Updated",
+      body: "# new body",
+      user_invocable: false,
+      model_invocable: true,
+      allowed_tools: ["read", "write"],
+    };
+    const fetchMock = mockFetch(200, {
+      name: "my-skill",
+      path: "/root/.aura/skills/my-skill/SKILL.md",
+      updated: true,
+    });
+    globalThis.fetch = fetchMock;
+    const result = await harnessSkillsApi.updateMySkill("my-skill", data);
+    expect(result).toEqual({
+      name: "my-skill",
+      path: "/root/.aura/skills/my-skill/SKILL.md",
+      updated: true,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/harness/skills/mine/my-skill",
+      expect.objectContaining({ method: "PUT", body: JSON.stringify(data) }),
+    );
+  });
+
   it("installFromShop sends POST with name and category", async () => {
     const fetchMock = mockFetch(200, { name: "web-search", path: "/skills/web-search", installed: true });
     globalThis.fetch = fetchMock;

--- a/interface/src/shared/api/harness-skills.ts
+++ b/interface/src/shared/api/harness-skills.ts
@@ -33,6 +33,29 @@ export const harnessSkillsApi = {
     apiFetch<{ name: string; deleted: boolean }>(`/api/harness/skills/mine/${name}`, {
       method: "DELETE",
     }),
+  /**
+   * Rewrite an existing user-authored skill's SKILL.md (frontmatter +
+   * body). Only `description` is required; any omitted optional field is
+   * re-rendered as absent, so callers must round-trip `allowed_tools` /
+   * `model` / `context` they want to preserve. Rejects with
+   * `ApiClientError` 404 (no such user skill) or 403 (not user-created).
+   */
+  updateMySkill: (
+    name: string,
+    data: {
+      description: string;
+      body?: string;
+      allowed_tools?: string[];
+      model?: string;
+      context?: string;
+      user_invocable?: boolean;
+      model_invocable?: boolean;
+    },
+  ) =>
+    apiFetch<{ name: string; path: string; updated: boolean }>(`/api/harness/skills/mine/${name}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
   getSkill: (name: string) =>
     apiFetch<HarnessSkill>(`/api/harness/skills/${name}`),
   createSkill: (data: {


### PR DESCRIPTION
## What

Adds an **edit** path for user-authored skills, alongside the existing create/delete.

- **Backend:** new `PUT /api/harness/skills/mine/{name}` that rewrites the skill's `SKILL.md` (frontmatter + body). Guards: 404 (no such user skill), 403 (not user-created — protects shop-installed skills sharing the on-disk layout), 400 (invalid name). Extracts a shared `render_skill_frontmatter` so create and edit emit byte-identical frontmatter (incl. the `source: "user-created"` marker), and mirrors create's harness-first / write-last ordering so the marker-bearing file wins.
- **Frontend:** an "Edit skill" action on "My Skills" rows opens a `SkillEditorModal` that pre-fills from `getSkill`, keeps the name read-only, and round-trips fields the UI doesn't surface (`allowed_tools` / `model` / `context` / `model_invocable`) so an edit never drops them.

## How edits propagate

Skill content lives in one in-memory registry keyed by name; per-agent install stores only a name reference, not a content copy. The edit re-registers with the harness, which reloads that registry, so **every agent with the skill installed picks up the new content on next use — no re-install, no versioning step**. Verified live against the real harness: re-register → both `GET` and the activation path serve the new content.

Because that re-register is what makes the edit go live, the edit path checks its result and fails loud (502, file left untouched) rather than rewriting the file and returning 200 behind a failed reload.

## Tests

- Backend: rewrite+reregister, 404, 403, 400, and harness-failure → 502 + file untouched.
- Frontend: `updateMySkill` client + edit-action wiring.
- Full `harness_proxy_test` suite green (24/24); frontend skill tests green (23/23).
