### PR TITLE
Fix rapid multiline prompt input

### DIFF
--- a/interface/src/components/InputBarShell/InputBarShell.test.tsx
+++ b/interface/src/components/InputBarShell/InputBarShell.test.tsx
@@ -1,11 +1,15 @@
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { vi } from "vitest";
 
 vi.mock("./InputBarShell.module.css", () => ({
   default: new Proxy({}, { get: (_t, prop) => String(prop) }),
 }));
 
-import { InputBarShell, type InputBarShellProps } from "./InputBarShell";
+import {
+  ENTER_SUBMIT_GRACE_MS,
+  InputBarShell,
+  type InputBarShellProps,
+} from "./InputBarShell";
 
 function makeProps(
   overrides: Partial<InputBarShellProps> = {},
@@ -172,6 +176,85 @@ describe("InputBarShell", () => {
         delete (HTMLTextAreaElement.prototype as { scrollHeight?: unknown })
           .scrollHeight;
       }
+    }
+  });
+
+  it("submits on Enter after a short grace period", () => {
+    vi.useFakeTimers();
+    const onSubmit = vi.fn();
+
+    try {
+      const { container } = render(
+        <InputBarShell {...makeProps({ value: "send me", onSubmit })} />,
+      );
+      const textarea = container.querySelector("textarea")!;
+      textarea.setSelectionRange(7, 7);
+
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      act(() => {
+        vi.advanceTimersByTime(ENTER_SUBMIT_GRACE_MS);
+      });
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not double-submit when Send is clicked during the Enter grace period", () => {
+    vi.useFakeTimers();
+    const onSubmit = vi.fn();
+
+    try {
+      const { container } = render(
+        <InputBarShell {...makeProps({ value: "send me", onSubmit })} />,
+      );
+      const textarea = container.querySelector("textarea")!;
+      textarea.setSelectionRange(7, 7);
+
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      fireEvent.click(container.querySelector('button[aria-label="Send"]')!);
+      act(() => {
+        vi.advanceTimersByTime(ENTER_SUBMIT_GRACE_MS);
+      });
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("treats rapid text after Enter as a multiline input burst", () => {
+    vi.useFakeTimers();
+    const onSubmit = vi.fn();
+    const onValueChange = vi.fn();
+
+    try {
+      const { container } = render(
+        <InputBarShell
+          {...makeProps({
+            value: "Line one",
+            onSubmit,
+            onValueChange,
+          })}
+        />,
+      );
+      const textarea = container.querySelector("textarea")!;
+      textarea.setSelectionRange("Line one".length, "Line one".length);
+
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      fireEvent.change(textarea, {
+        target: { value: "Line oneLine two" },
+      });
+      act(() => {
+        vi.advanceTimersByTime(ENTER_SUBMIT_GRACE_MS);
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(onValueChange).toHaveBeenLastCalledWith("Line one\nLine two");
+    } finally {
+      vi.useRealTimers();
     }
   });
 

--- a/interface/src/components/InputBarShell/InputBarShell.tsx
+++ b/interface/src/components/InputBarShell/InputBarShell.tsx
@@ -17,6 +17,39 @@ import { ArrowUp } from "lucide-react";
 import styles from "./InputBarShell.module.css";
 import { useInputAutosize } from "./useInputAutosize";
 
+export const ENTER_SUBMIT_GRACE_MS = 100;
+
+interface PendingEnterSubmit {
+  valueBeforeEnter: string;
+  selectionStart: number;
+  selectionEnd: number;
+  timerId: number;
+}
+
+function valueWithPendingNewline(
+  valueBeforeEnter: string,
+  nextValue: string,
+  selectionStart: number,
+  selectionEnd: number,
+): string {
+  const prefix = valueBeforeEnter.slice(0, selectionStart);
+  const suffix = valueBeforeEnter.slice(selectionEnd);
+  if (
+    !nextValue.startsWith(prefix) ||
+    !nextValue.endsWith(suffix) ||
+    nextValue.length < prefix.length + suffix.length
+  ) {
+    return nextValue;
+  }
+
+  const insertedText = nextValue.slice(
+    prefix.length,
+    nextValue.length - suffix.length,
+  );
+  if (!insertedText) return nextValue;
+  return `${prefix}\n${insertedText}${suffix}`;
+}
+
 export interface InputBarShellHandle {
   focus: () => void;
   blur: () => void;
@@ -222,6 +255,7 @@ function InputBarShellInner(
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const contentMirrorRef = useRef<HTMLDivElement>(null);
   const baselineMirrorRef = useRef<HTMLDivElement>(null);
+  const pendingEnterSubmitRef = useRef<PendingEnterSubmit | null>(null);
   const isMultiLine = useInputAutosize(
     { textareaRef, contentMirrorRef, baselineMirrorRef },
     value,
@@ -240,16 +274,73 @@ function InputBarShellInner(
   const sendEnabled = isSendEnabled ?? value.trim().length > 0;
   const canSubmit = sendEnabled && !disabled;
 
+  const clearPendingEnterSubmit = useCallback(() => {
+    const pending = pendingEnterSubmitRef.current;
+    if (pending) {
+      window.clearTimeout(pending.timerId);
+      pendingEnterSubmitRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearPendingEnterSubmit, [clearPendingEnterSubmit]);
+
+  useEffect(() => {
+    if (!canSubmit) clearPendingEnterSubmit();
+  }, [canSubmit, clearPendingEnterSubmit]);
+
+  const submitImmediately = useCallback(() => {
+    clearPendingEnterSubmit();
+    if (canSubmit) onSubmit();
+  }, [canSubmit, clearPendingEnterSubmit, onSubmit]);
+
+  const handleValueChange = useCallback(
+    (nextValue: string) => {
+      const pending = pendingEnterSubmitRef.current;
+      if (!pending) {
+        onValueChange(nextValue);
+        return;
+      }
+
+      window.clearTimeout(pending.timerId);
+      pendingEnterSubmitRef.current = null;
+      onValueChange(
+        valueWithPendingNewline(
+          pending.valueBeforeEnter,
+          nextValue,
+          pending.selectionStart,
+          pending.selectionEnd,
+        ),
+      );
+    },
+    [onValueChange],
+  );
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       onTextareaKeyDown?.(e);
       if (e.defaultPrevented) return;
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
-        if (canSubmit) onSubmit();
+        if (!canSubmit) return;
+        clearPendingEnterSubmit();
+
+        const textarea = e.currentTarget;
+        const selectionStart = textarea.selectionStart ?? value.length;
+        const selectionEnd = textarea.selectionEnd ?? selectionStart;
+        const timerId = window.setTimeout(() => {
+          pendingEnterSubmitRef.current = null;
+          onSubmit();
+        }, ENTER_SUBMIT_GRACE_MS);
+
+        pendingEnterSubmitRef.current = {
+          valueBeforeEnter: value,
+          selectionStart,
+          selectionEnd,
+          timerId,
+        };
       }
     },
-    [onTextareaKeyDown, canSubmit, onSubmit],
+    [onTextareaKeyDown, canSubmit, clearPendingEnterSubmit, onSubmit, value],
   );
 
   const wrapperClassName = [
@@ -304,9 +395,7 @@ function InputBarShellInner(
     <button
       type="button"
       className={styles.sendButton}
-      onClick={() => {
-        if (canSubmit) onSubmit();
-      }}
+      onClick={submitImmediately}
       disabled={!canSubmit}
       aria-label={sendAriaLabel}
     >
@@ -364,7 +453,7 @@ function InputBarShellInner(
             ref={textareaRef}
             className={styles.textarea}
             value={value}
-            onChange={(e) => onValueChange(e.target.value)}
+            onChange={(e) => handleValueChange(e.target.value)}
             onKeyDown={handleKeyDown}
             onPaste={onTextareaPaste}
             placeholder={placeholder}

--- a/interface/src/features/chat-ui/ChatInputBar/ChatInputBar.test.tsx
+++ b/interface/src/features/chat-ui/ChatInputBar/ChatInputBar.test.tsx
@@ -91,6 +91,7 @@ vi.mock("./useFileAttachments", () => ({
 
 import { ChatInputBar } from "../ChatInputBar";
 import { MobileChatInputBar } from "../../../mobile/chat/MobileChatInputBar";
+import { ENTER_SUBMIT_GRACE_MS } from "../../../components/InputBarShell/InputBarShell";
 import type { AttachmentItem } from "../ChatInputBar";
 
 function makeProps(overrides: Partial<Parameters<typeof ChatInputBar>[0]> = {}) {
@@ -231,17 +232,24 @@ describe("ChatInputBar", () => {
     }
   });
 
-  it("calls onSend on Enter key (without shift)", async () => {
-    const user = userEvent.setup();
+  it("calls onSend on Enter key (without shift)", () => {
+    vi.useFakeTimers();
     const onSend = vi.fn();
-    render(<ChatInputBar {...makeProps({ input: "Test message", onSend })} />);
 
-    const textarea = screen.getByPlaceholderText("/ for commands, @ for context");
-    await user.click(textarea);
-    await user.keyboard("{Enter}");
-    // Mode is now read from the per-stream store inside `useChatPanelState.handleSend`,
-    // so the input bar no longer threads `generationMode` through this callback.
-    expect(onSend).toHaveBeenCalledWith("Test message", undefined, undefined);
+    try {
+      render(<ChatInputBar {...makeProps({ input: "Test message", onSend })} />);
+
+      const textarea = screen.getByPlaceholderText("/ for commands, @ for context");
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      act(() => {
+        vi.advanceTimersByTime(ENTER_SUBMIT_GRACE_MS);
+      });
+      // Mode is now read from the per-stream store inside `useChatPanelState.handleSend`,
+      // so the input bar no longer threads `generationMode` through this callback.
+      expect(onSend).toHaveBeenCalledWith("Test message", undefined, undefined);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not call onSend on Shift+Enter", async () => {


### PR DESCRIPTION
## Summary
- Preserve rapid multiline prompt bursts instead of submitting the first Enter immediately.
- Keep normal Enter submit behavior and avoid double-submit when Send is clicked during the grace window.

## Verification
- npm test -- InputBarShell.test.tsx ChatInputBar.test.tsx
- npm run build

## Production app check
- Confirmed the currently installed app still splits rapid multiline input; this PR fixes that code path for the next release.