### PR TITLE
Add Loop Engineering mode

### DIFF
--- a/apps/aura-os-server/src/dto.rs
+++ b/apps/aura-os-server/src/dto.rs
@@ -98,6 +98,8 @@ pub(crate) struct LoopStatusResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_agent_instances: Option<Vec<AgentInstanceId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub loop_engineering: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cooldown_remaining_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cooldown_reason: Option<String>,

--- a/apps/aura-os-server/src/handlers/agents/chat/busy.rs
+++ b/apps/aura-os-server/src/handlers/agents/chat/busy.rs
@@ -188,6 +188,7 @@ mod tests {
             automaton_id: automaton_id.to_string(),
             project_id: ProjectId::new(),
             template_agent_id: template,
+            loop_engineering: None,
             harness_base_url: "http://127.0.0.1:1".to_string(),
             paused,
             alive: Arc::new(AtomicBool::new(alive)),

--- a/apps/aura-os-server/src/handlers/billing.rs
+++ b/apps/aura-os-server/src/handlers/billing.rs
@@ -62,7 +62,11 @@ fn is_transient_billing_error(err: &aura_os_billing::BillingError) -> bool {
     use aura_os_billing::BillingError;
     matches!(
         err,
-        BillingError::Request(_) | BillingError::ServerError { status: 500..=599, .. }
+        BillingError::Request(_)
+            | BillingError::ServerError {
+                status: 500..=599,
+                ..
+            }
     )
 }
 
@@ -80,8 +84,7 @@ pub(crate) async fn require_credits(
     const CACHE_TTL: Duration = Duration::from_secs(60);
     // Short backoffs applied only to transient billing failures (transport
     // blips / 5xx). The happy path and definitive answers never sleep.
-    const RETRY_BACKOFFS: [Duration; 2] =
-        [Duration::from_millis(100), Duration::from_millis(250)];
+    const RETRY_BACKOFFS: [Duration; 2] = [Duration::from_millis(100), Duration::from_millis(250)];
 
     {
         let mut cache = state.credit_cache.lock().await;

--- a/apps/aura-os-server/src/handlers/dev_loop.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop.rs
@@ -5,6 +5,7 @@ mod event_kinds;
 #[allow(dead_code)]
 pub(crate) mod health;
 mod limits;
+mod loop_engineering;
 mod progress;
 mod registry;
 mod run;

--- a/apps/aura-os-server/src/handlers/dev_loop.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop.rs
@@ -5,7 +5,7 @@ mod event_kinds;
 #[allow(dead_code)]
 pub(crate) mod health;
 mod limits;
-mod loop_engineering;
+pub mod loop_engineering;
 mod progress;
 mod registry;
 mod run;

--- a/apps/aura-os-server/src/handlers/dev_loop/adapter/run_single.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/adapter/run_single.rs
@@ -56,6 +56,7 @@ pub(crate) async fn run_single_task(
         jwt,
         model: params.model,
         mode: RunMode::SingleTask { task_id },
+        loop_engineering: None,
     };
     // run::run_automaton owns the cleanup-on-failure for the
     // ephemeral row at the pre-refactor failure points

--- a/apps/aura-os-server/src/handlers/dev_loop/adapter/start_loop.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/adapter/start_loop.rs
@@ -8,6 +8,7 @@
 //! materialisation, stream connect, forwarder spawn, registry insert,
 //! `loop_started` emit) to [`super::super::run::run_automaton`].
 
+use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
@@ -18,6 +19,7 @@ use crate::dto::LoopStatusResponse;
 use crate::error::ApiResult;
 use crate::state::{AppState, AuthJwt, AuthSession};
 
+use super::super::loop_engineering::parse_start_loop_request;
 use super::super::run::{run_automaton, RunMode, RunRequest};
 use super::super::types::LoopQueryParams;
 use super::common::{loop_user_id, resolve_loop_instance_id};
@@ -28,8 +30,10 @@ pub(crate) async fn start_loop(
     session: AuthSession,
     Path(project_id): Path<ProjectId>,
     Query(params): Query<LoopQueryParams>,
+    body: Bytes,
 ) -> ApiResult<(StatusCode, Json<LoopStatusResponse>)> {
     let agent_instance_id = resolve_loop_instance_id(&state, project_id, &params).await?;
+    let loop_engineering = parse_start_loop_request(&body)?;
     let req = RunRequest {
         loop_user_id: loop_user_id(&session),
         user_id: session.0.user_id.clone(),
@@ -40,6 +44,7 @@ pub(crate) async fn start_loop(
         jwt,
         model: params.model,
         mode: RunMode::Automation,
+        loop_engineering,
     };
     let outcome = run_automaton(req).await?;
     let (status, body) = outcome.into_loop_response();

--- a/apps/aura-os-server/src/handlers/dev_loop/loop_engineering.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/loop_engineering.rs
@@ -145,6 +145,7 @@ For each iteration:
 5. Compare verifier output against every success criterion.
 6. Continue only when a criterion still lacks evidence and the iteration budget remains.
 7. Stop when the criteria are satisfied, blocked by missing access, or the budget is exhausted.
+8. Before calling `task_done`, write a visible "Loop Engineering Final Report" in the assistant transcript and copy the same report into the `task_done.notes` field. Do not call `task_done` with terse notes like "done" or "implemented".
 </loop_protocol>
 
 <learning_protocol>
@@ -159,13 +160,14 @@ After every iteration, keep a compact learning ledger with:
 </learning_protocol>
 
 <final_report>
-When the loop stops, report:
+When the loop stops, the visible "Loop Engineering Final Report" and the `task_done.notes` field must include:
 - final status: passed, failed, or blocked
 - evidence for each success criterion
 - commands run and their outcomes
 - changes made
 - remaining risks
 - learnings worth carrying into future Aura evals, skills, or workflow defaults
+If the report does not include these sections, the loop is not complete yet.
 </final_report>
 </loop_engineering_mode>"#,
         goal = contract.goal,
@@ -366,6 +368,9 @@ mod tests {
         assert!(prompt.contains("Maximum iterations: 3"));
         assert!(prompt.contains("Tests: `npm test -- --run`"));
         assert!(prompt.contains("learning ledger"));
+        assert!(prompt.contains("Loop Engineering Final Report"));
+        assert!(prompt.contains("task_done.notes"));
+        assert!(prompt.contains("Do not call `task_done` with terse notes"));
     }
 
     #[test]

--- a/apps/aura-os-server/src/handlers/dev_loop/loop_engineering.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/loop_engineering.rs
@@ -1,0 +1,376 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ApiError, ApiResult};
+
+const DEFAULT_MAX_ITERATIONS: u8 = 4;
+const MAX_ITERATIONS_LIMIT: u8 = 12;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StartLoopRequest {
+    #[serde(default)]
+    pub(crate) loop_engineering: Option<LoopEngineeringContract>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LoopEngineeringContract {
+    pub(crate) goal: String,
+    #[serde(default)]
+    pub(crate) success_criteria: Vec<String>,
+    #[serde(default)]
+    pub(crate) verifier_commands: Vec<VerifierCommand>,
+    #[serde(default = "default_max_iterations")]
+    pub(crate) max_iterations: u8,
+    #[serde(default)]
+    pub(crate) approval_policy: ApprovalPolicy,
+    #[serde(default)]
+    pub(crate) learning: LearningPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VerifierCommand {
+    pub(crate) label: String,
+    pub(crate) command: String,
+    #[serde(default)]
+    pub(crate) expected_outcome: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ApprovalPolicy {
+    ProposeOnly,
+    ApplyWithinWorkspace,
+}
+
+impl Default for ApprovalPolicy {
+    fn default() -> Self {
+        Self::ApplyWithinWorkspace
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LearningPolicy {
+    #[serde(default = "default_true")]
+    pub(crate) capture_trace: bool,
+    #[serde(default = "default_true")]
+    pub(crate) propose_evals: bool,
+    #[serde(default = "default_true")]
+    pub(crate) propose_skills: bool,
+    #[serde(default = "default_true")]
+    pub(crate) summarize_regressions: bool,
+}
+
+impl Default for LearningPolicy {
+    fn default() -> Self {
+        Self {
+            capture_trace: true,
+            propose_evals: true,
+            propose_skills: true,
+            summarize_regressions: true,
+        }
+    }
+}
+
+pub(crate) fn parse_start_loop_request(body: &[u8]) -> ApiResult<Option<LoopEngineeringContract>> {
+    if body.iter().all(u8::is_ascii_whitespace) {
+        return Ok(None);
+    }
+    let request: StartLoopRequest = serde_json::from_slice(body)
+        .map_err(|err| ApiError::bad_request(format!("invalid loop start body: {err}")))?;
+    request.loop_engineering.map(normalize_contract).transpose()
+}
+
+pub(crate) fn augment_system_prompt(
+    base_prompt: &str,
+    contract: Option<&LoopEngineeringContract>,
+) -> Option<String> {
+    let base = base_prompt.trim();
+    match contract {
+        Some(contract) if base.is_empty() => Some(render_loop_engineering_prompt(contract)),
+        Some(contract) => Some(format!(
+            "{base}\n\n{}",
+            render_loop_engineering_prompt(contract)
+        )),
+        None if base.is_empty() => None,
+        None => Some(base.to_string()),
+    }
+}
+
+pub(crate) fn render_loop_engineering_prompt(contract: &LoopEngineeringContract) -> String {
+    let success = numbered_lines(&contract.success_criteria);
+    let verifiers = verifier_lines(&contract.verifier_commands);
+    let learning = learning_lines(contract.learning);
+    let approval = match contract.approval_policy {
+        ApprovalPolicy::ProposeOnly => {
+            "Propose changes and stop before applying code or configuration edits."
+        }
+        ApprovalPolicy::ApplyWithinWorkspace => {
+            "Apply safe, scoped changes inside the current workspace and keep user approval gates for destructive or external actions."
+        }
+    };
+
+    format!(
+        r#"<loop_engineering_mode>
+You are running in Aura Loop Engineering Mode. This is an iterative engineering loop, not a one-shot task.
+
+<goal>
+{goal}
+</goal>
+
+<success_criteria>
+{success}
+</success_criteria>
+
+<verifier_commands>
+{verifiers}
+</verifier_commands>
+
+<iteration_budget>
+Maximum iterations: {max_iterations}
+</iteration_budget>
+
+<approval_policy>
+{approval}
+</approval_policy>
+
+<loop_protocol>
+For each iteration:
+1. State the current hypothesis and the smallest useful change.
+2. Inspect the relevant code, product state, logs, or tool output before editing.
+3. Make only scoped changes that serve the goal and preserve existing behavior.
+4. Run the listed verifier commands. If no verifier commands are listed, discover the project's own test, build, lint, or smoke commands and run the smallest set that can prove the criteria.
+5. Compare verifier output against every success criterion.
+6. Continue only when a criterion still lacks evidence and the iteration budget remains.
+7. Stop when the criteria are satisfied, blocked by missing access, or the budget is exhausted.
+</loop_protocol>
+
+<learning_protocol>
+{learning}
+After every iteration, keep a compact learning ledger with:
+- hypothesis
+- evidence gathered
+- verifier results
+- confirmed cause or remaining uncertainty
+- next action
+- reusable eval, skill, or workflow improvement if one is justified
+</learning_protocol>
+
+<final_report>
+When the loop stops, report:
+- final status: passed, failed, or blocked
+- evidence for each success criterion
+- commands run and their outcomes
+- changes made
+- remaining risks
+- learnings worth carrying into future Aura evals, skills, or workflow defaults
+</final_report>
+</loop_engineering_mode>"#,
+        goal = contract.goal,
+        success = success,
+        verifiers = verifiers,
+        max_iterations = contract.max_iterations,
+        approval = approval,
+        learning = learning,
+    )
+}
+
+fn normalize_contract(mut contract: LoopEngineeringContract) -> ApiResult<LoopEngineeringContract> {
+    contract.goal = contract.goal.trim().to_string();
+    contract.success_criteria = normalize_strings(contract.success_criteria);
+    contract.verifier_commands = normalize_verifiers(contract.verifier_commands);
+
+    if contract.goal.is_empty() {
+        return Err(ApiError::bad_request("loop engineering goal is required"));
+    }
+    if contract.success_criteria.is_empty() {
+        return Err(ApiError::bad_request(
+            "loop engineering needs at least one success criterion",
+        ));
+    }
+    if contract.max_iterations == 0 || contract.max_iterations > MAX_ITERATIONS_LIMIT {
+        return Err(ApiError::bad_request(format!(
+            "loop engineering maxIterations must be between 1 and {MAX_ITERATIONS_LIMIT}"
+        )));
+    }
+    Ok(contract)
+}
+
+fn normalize_strings(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .take(12)
+        .collect()
+}
+
+fn normalize_verifiers(values: Vec<VerifierCommand>) -> Vec<VerifierCommand> {
+    values
+        .into_iter()
+        .filter_map(|mut value| {
+            value.label = value.label.trim().to_string();
+            value.command = value.command.trim().to_string();
+            value.expected_outcome = value
+                .expected_outcome
+                .map(|expected| expected.trim().to_string())
+                .filter(|expected| !expected.is_empty());
+            (!value.command.is_empty()).then_some(value)
+        })
+        .take(8)
+        .collect()
+}
+
+fn numbered_lines(values: &[String]) -> String {
+    values
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| format!("{}. {}", idx + 1, value))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn verifier_lines(values: &[VerifierCommand]) -> String {
+    if values.is_empty() {
+        return "No explicit verifier commands supplied. Discover project-native verification commands before declaring success.".to_string();
+    }
+    values
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| {
+            let label = if value.label.is_empty() {
+                format!("Verifier {}", idx + 1)
+            } else {
+                value.label.clone()
+            };
+            match value.expected_outcome.as_deref() {
+                Some(expected) => format!(
+                    "{}. {}: `{}`\n   Expected: {}",
+                    idx + 1,
+                    label,
+                    value.command,
+                    expected
+                ),
+                None => format!("{}. {}: `{}`", idx + 1, label, value.command),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn learning_lines(policy: LearningPolicy) -> String {
+    let mut lines = Vec::new();
+    if policy.capture_trace {
+        lines.push("- Capture concise iteration traces tied to evidence, not assumptions.");
+    }
+    if policy.propose_evals {
+        lines.push("- Propose an eval or status probe when the issue would be valuable to catch automatically.");
+    }
+    if policy.propose_skills {
+        lines.push("- Propose reusable skill or workflow updates when repeated manual reasoning can be productized.");
+    }
+    if policy.summarize_regressions {
+        lines.push("- Call out regressions and likely culprit changes only when there is supporting evidence.");
+    }
+    if lines.is_empty() {
+        return "- Learning capture is disabled for this run.".to_string();
+    }
+    lines.join("\n")
+}
+
+fn default_max_iterations() -> u8 {
+    DEFAULT_MAX_ITERATIONS
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contract() -> LoopEngineeringContract {
+        LoopEngineeringContract {
+            goal: " Fix date-only persistence ".to_string(),
+            success_criteria: vec![
+                " 2026-06-23 displays as the same calendar date ".to_string(),
+                " Existing tests still pass ".to_string(),
+            ],
+            verifier_commands: vec![VerifierCommand {
+                label: " Tests ".to_string(),
+                command: " npm test -- --run ".to_string(),
+                expected_outcome: Some(" all tests pass ".to_string()),
+            }],
+            max_iterations: 3,
+            approval_policy: ApprovalPolicy::ApplyWithinWorkspace,
+            learning: LearningPolicy::default(),
+        }
+    }
+
+    #[test]
+    fn empty_start_body_preserves_legacy_automation_start() {
+        let parsed = parse_start_loop_request(b"   ").unwrap();
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn parses_and_normalizes_loop_engineering_contract() {
+        let body = serde_json::to_vec(&StartLoopRequest {
+            loop_engineering: Some(contract()),
+        })
+        .unwrap();
+
+        let parsed = parse_start_loop_request(&body).unwrap().unwrap();
+
+        assert_eq!(parsed.goal, "Fix date-only persistence");
+        assert_eq!(
+            parsed.success_criteria,
+            vec![
+                "2026-06-23 displays as the same calendar date",
+                "Existing tests still pass"
+            ]
+        );
+        assert_eq!(parsed.verifier_commands[0].label, "Tests");
+        assert_eq!(parsed.verifier_commands[0].command, "npm test -- --run");
+        assert_eq!(
+            parsed.verifier_commands[0].expected_outcome.as_deref(),
+            Some("all tests pass")
+        );
+    }
+
+    #[test]
+    fn rejects_contract_without_goal() {
+        let mut contract = contract();
+        contract.goal = " ".to_string();
+        let body = serde_json::to_vec(&StartLoopRequest {
+            loop_engineering: Some(contract),
+        })
+        .unwrap();
+
+        let err = parse_start_loop_request(&body).unwrap_err();
+
+        assert_eq!(err.0, axum::http::StatusCode::BAD_REQUEST);
+        assert!(err.1 .0.error.contains("goal is required"));
+    }
+
+    #[test]
+    fn augmented_prompt_contains_loop_protocol_and_verifiers() {
+        let contract = normalize_contract(contract()).unwrap();
+        let prompt = augment_system_prompt("Base prompt", Some(&contract)).unwrap();
+
+        assert!(prompt.starts_with("Base prompt"));
+        assert!(prompt.contains("Aura Loop Engineering Mode"));
+        assert!(prompt.contains("Maximum iterations: 3"));
+        assert!(prompt.contains("Tests: `npm test -- --run`"));
+        assert!(prompt.contains("learning ledger"));
+    }
+
+    #[test]
+    fn plain_prompt_is_unchanged_without_contract() {
+        let prompt = augment_system_prompt(" Base prompt ", None).unwrap();
+        assert_eq!(prompt, "Base prompt");
+    }
+}

--- a/apps/aura-os-server/src/handlers/dev_loop/loop_engineering.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/loop_engineering.rs
@@ -170,7 +170,7 @@ When the loop stops, the visible "Loop Engineering Final Report" and the `task_d
 If the report does not include these sections, the loop is not complete yet.
 </final_report>
 </loop_engineering_mode>"#,
-        goal = contract.goal,
+        goal = prompt_escape(&contract.goal),
         success = success,
         verifiers = verifiers,
         max_iterations = contract.max_iterations,
@@ -229,7 +229,7 @@ fn numbered_lines(values: &[String]) -> String {
     values
         .iter()
         .enumerate()
-        .map(|(idx, value)| format!("{}. {}", idx + 1, value))
+        .map(|(idx, value)| format!("{}. {}", idx + 1, prompt_escape(value)))
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -245,21 +245,30 @@ fn verifier_lines(values: &[VerifierCommand]) -> String {
             let label = if value.label.is_empty() {
                 format!("Verifier {}", idx + 1)
             } else {
-                value.label.clone()
+                prompt_escape(&value.label)
             };
+            let command = prompt_escape(&value.command);
             match value.expected_outcome.as_deref() {
                 Some(expected) => format!(
                     "{}. {}: `{}`\n   Expected: {}",
                     idx + 1,
                     label,
-                    value.command,
-                    expected
+                    command,
+                    prompt_escape(expected)
                 ),
-                None => format!("{}. {}: `{}`", idx + 1, label, value.command),
+                None => format!("{}. {}: `{}`", idx + 1, label, command),
             }
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn prompt_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('`', "\\`")
 }
 
 fn learning_lines(policy: LearningPolicy) -> String {
@@ -377,5 +386,25 @@ mod tests {
     fn plain_prompt_is_unchanged_without_contract() {
         let prompt = augment_system_prompt(" Base prompt ", None).unwrap();
         assert_eq!(prompt, "Base prompt");
+    }
+
+    #[test]
+    fn prompt_escapes_contract_text() {
+        let mut contract = normalize_contract(contract()).unwrap();
+        contract.goal = "Fix <script> & `date`".to_string();
+        contract.success_criteria = vec!["Do not emit </loop_engineering_mode>".to_string()];
+        contract.verifier_commands = vec![VerifierCommand {
+            label: "Run <tests>".to_string(),
+            command: "npm test -- `weird`".to_string(),
+            expected_outcome: Some("passes & reports <green>".to_string()),
+        }];
+
+        let prompt = render_loop_engineering_prompt(&contract);
+
+        assert!(prompt.contains("Fix &lt;script&gt; &amp; \\`date\\`"));
+        assert!(prompt.contains("Do not emit &lt;/loop_engineering_mode&gt;"));
+        assert!(prompt.contains("Run &lt;tests&gt;: `npm test -- \\`weird\\``"));
+        assert!(prompt.contains("Expected: passes &amp; reports &lt;green&gt;"));
+        assert!(!prompt.contains("Do not emit </loop_engineering_mode>"));
     }
 }

--- a/apps/aura-os-server/src/handlers/dev_loop/registry.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/registry.rs
@@ -160,7 +160,8 @@ pub(super) async fn status_response(
     project_id: ProjectId,
     agent_instance_id: Option<AgentInstanceId>,
 ) -> LoopStatusResponse {
-    let (active, paused) = snapshot_active_and_paused(state, project_id).await;
+    let (active, paused, loop_engineering) =
+        snapshot_active_paused_and_mode(state, project_id, agent_instance_id).await;
     // `current_task_id` lives on `LoopActivity` (Phase 5: LoopHandle is
     // the single authoritative source). Walk the loop registry for
     // every Automation / TaskRun loop bound to this project and pull
@@ -174,6 +175,7 @@ pub(super) async fn status_response(
         project_id: Some(project_id),
         agent_instance_id,
         active_agent_instances: Some(active),
+        loop_engineering,
         cooldown_remaining_ms: None,
         cooldown_reason: None,
         cooldown_kind: None,
@@ -185,10 +187,11 @@ pub(super) async fn status_response(
 /// with whether ANY automaton in the project is currently paused.
 /// Carved out of [`status_response`] so its body stays inside the
 /// 50-line per-function budget. Lock acquisition is identical.
-async fn snapshot_active_and_paused(
+async fn snapshot_active_paused_and_mode(
     state: &AppState,
     project_id: ProjectId,
-) -> (Vec<AgentInstanceId>, bool) {
+    agent_instance_id: Option<AgentInstanceId>,
+) -> (Vec<AgentInstanceId>, bool, Option<serde_json::Value>) {
     let reg = state.automaton_registry.lock().await;
     let active: Vec<AgentInstanceId> = reg
         .iter()
@@ -198,7 +201,12 @@ async fn snapshot_active_and_paused(
     let paused = reg
         .iter()
         .any(|((pid, _), entry)| *pid == project_id && entry.paused);
-    (active, paused)
+    let loop_engineering = reg
+        .iter()
+        .filter(|((pid, _), _)| *pid == project_id)
+        .filter(|((_, agent_id), _)| agent_instance_id.map_or(true, |wanted| *agent_id == wanted))
+        .find_map(|(_, entry)| entry.loop_engineering.clone());
+    (active, paused, loop_engineering)
 }
 
 /// Walk the loop registry for every `Automation`/`TaskRun` loop in

--- a/apps/aura-os-server/src/handlers/dev_loop/run/automaton.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/run/automaton.rs
@@ -53,6 +53,7 @@ pub(super) async fn start_automaton(
         jwt: Some(req.jwt.clone()),
         user_id: Some(req.user_id.clone()),
         task_id: prep.task_id_str.clone(),
+        loop_engineering: req.loop_engineering.as_ref(),
     })
     .await;
 

--- a/apps/aura-os-server/src/handlers/dev_loop/run/register.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/run/register.rs
@@ -291,6 +291,10 @@ async fn finalize_registration(inputs: FinalizeInputs<'_>) {
             automaton_id: started.automaton_id.clone(),
             project_id: req.project_id,
             template_agent_id: prep.start.agent_id,
+            loop_engineering: req
+                .loop_engineering
+                .as_ref()
+                .and_then(|contract| serde_json::to_value(contract).ok()),
             harness_base_url: prep.start.harness_base_url.clone(),
             paused: false,
             alive: handles.alive.clone(),

--- a/apps/aura-os-server/src/handlers/dev_loop/run/request.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/run/request.rs
@@ -8,6 +8,8 @@
 
 use aura_os_core::{AgentInstanceId, ProjectId, TaskId, UserId};
 
+use super::super::loop_engineering::LoopEngineeringContract;
+
 use crate::state::AppState;
 
 /// Mode flag selecting between long-lived dev-loop bootstrap and
@@ -59,6 +61,10 @@ pub(in crate::handlers::dev_loop) struct RunRequest {
     /// instance / agent default inside `resolve_start_context`.
     pub(in crate::handlers::dev_loop) model: Option<String>,
     pub(in crate::handlers::dev_loop) mode: RunMode,
+    /// Optional Loop Engineering contract layered onto a normal
+    /// long-lived dev-loop run. `None` keeps legacy automation and
+    /// single-task starts on their existing prompt path.
+    pub(in crate::handlers::dev_loop) loop_engineering: Option<LoopEngineeringContract>,
     /// Resolved typed user id for [`aura_os_events::LoopId`]
     /// construction. The adapter resolves this from the auth session
     /// (via `loop_user_id`) before dispatching.

--- a/apps/aura-os-server/src/handlers/dev_loop/start/params.rs
+++ b/apps/aura-os-server/src/handlers/dev_loop/start/params.rs
@@ -11,6 +11,7 @@ use crate::handlers::agents::workspace_tools::{
 };
 use crate::state::AppState;
 
+use super::super::loop_engineering::{augment_system_prompt, LoopEngineeringContract};
 use super::super::types::StartContext;
 
 /// Inputs for [`build_start_params`]. Bundled to keep the helper
@@ -23,6 +24,7 @@ pub(crate) struct StartParamsInputs<'a> {
     pub(crate) jwt: Option<String>,
     pub(crate) user_id: Option<String>,
     pub(crate) task_id: Option<String>,
+    pub(crate) loop_engineering: Option<&'a LoopEngineeringContract>,
 }
 
 pub(crate) async fn build_start_params(inputs: StartParamsInputs<'_>) -> AutomatonStartParams {
@@ -33,6 +35,7 @@ pub(crate) async fn build_start_params(inputs: StartParamsInputs<'_>) -> Automat
         jwt,
         user_id,
         task_id,
+        loop_engineering,
     } = inputs;
     let installed_tools = resolve_installed_tools(state, ctx, jwt.as_deref()).await;
     let installed_integrations = resolve_installed_integrations(state, ctx, jwt.as_deref()).await;
@@ -55,6 +58,7 @@ pub(crate) async fn build_start_params(inputs: StartParamsInputs<'_>) -> Automat
         installed_integrations,
         aura_org_id,
         aura_session_id,
+        loop_engineering,
     })
 }
 
@@ -71,6 +75,7 @@ struct AssembleInputs<'a> {
     installed_integrations: Option<Vec<aura_os_harness::InstalledIntegration>>,
     aura_org_id: Option<String>,
     aura_session_id: Option<String>,
+    loop_engineering: Option<&'a LoopEngineeringContract>,
 }
 
 /// Project all the resolved-once inputs onto a fresh
@@ -89,6 +94,7 @@ fn assemble_automaton_start_params(inputs: AssembleInputs<'_>) -> AutomatonStart
         installed_integrations,
         aura_org_id,
         aura_session_id,
+        loop_engineering,
     } = inputs;
     let (git_repo_url, git_branch) = git_fields(ctx);
     AutomatonStartParams {
@@ -136,7 +142,7 @@ fn assemble_automaton_start_params(inputs: AssembleInputs<'_>) -> AutomatonStart
         // blank agent rows produce no `<agent_*>` bytes.
         agent_identity: start_agent_identity(ctx),
         agent_skills: ctx.agent_skills.clone(),
-        agent_system_prompt: Some(ctx.agent_system_prompt.clone()).filter(|s| !s.trim().is_empty()),
+        agent_system_prompt: augment_system_prompt(&ctx.agent_system_prompt, loop_engineering),
         // Forward the typed project descriptor so dev-loop / task-run
         // automata render the same `<project_context>` as chat and the
         // harness's `agents_md_from_workspace()` can locate `AGENTS.md`

--- a/apps/aura-os-server/src/handlers/harness_proxy/local/create.rs
+++ b/apps/aura-os-server/src/handlers/harness_proxy/local/create.rs
@@ -55,7 +55,10 @@ pub(super) fn render_skill_frontmatter(
     user_invocable: bool,
     model_invocable: bool,
 ) -> String {
-    let mut frontmatter = format!("---\ndescription: \"{}\"\n", yaml_escape_scalar(description));
+    let mut frontmatter = format!(
+        "---\ndescription: \"{}\"\n",
+        yaml_escape_scalar(description)
+    );
     if let Some(tools) = allowed_tools {
         frontmatter.push_str(&format!("allowed_tools: [{}]\n", tools.join(", ")));
     }

--- a/apps/aura-os-server/src/lib/handlers_test_support.rs
+++ b/apps/aura-os-server/src/lib/handlers_test_support.rs
@@ -99,6 +99,7 @@ pub fn build_active_automaton_for_test(
         automaton_id: automaton_id.to_string(),
         project_id,
         template_agent_id: template,
+        loop_engineering: None,
         harness_base_url: "http://127.0.0.1:1".to_string(),
         paused: false,
         alive: Arc::new(std::sync::atomic::AtomicBool::new(true)),

--- a/apps/aura-os-server/src/state/mod.rs
+++ b/apps/aura-os-server/src/state/mod.rs
@@ -74,6 +74,10 @@ pub struct ActiveAutomaton {
     /// without doing async `agent_instance_service.get_instance`
     /// lookups while the registry mutex is held.
     pub template_agent_id: AgentId,
+    /// Normalized Loop Engineering contract for runs started through
+    /// that mode. Plain automation and single-task runs keep this
+    /// empty so the normal loop surface is unchanged.
+    pub loop_engineering: Option<serde_json::Value>,
     pub harness_base_url: String,
     pub paused: bool,
     /// Set to `true` while the `forward_automaton_events` task for this

--- a/apps/aura-os-server/tests/api_tests/loop_stop.rs
+++ b/apps/aura-os-server/tests/api_tests/loop_stop.rs
@@ -29,6 +29,72 @@ async fn loop_stop_without_running_is_idempotent() {
 }
 
 #[tokio::test]
+async fn loop_status_includes_active_loop_engineering_contract() {
+    use aura_os_core::AgentInstanceId;
+    use aura_os_server::ActiveAutomaton;
+
+    let (app, state, _db) = build_test_app();
+
+    let pid = ProjectId::new();
+    let aiid = AgentInstanceId::new();
+    let contract = serde_json::json!({
+        "goal": "Fix checkout flakes and prove the regression is gone",
+        "successCriteria": ["Checkout passes", "Regression test covers it"],
+        "verifierCommands": [
+            {
+                "label": "Checkout test",
+                "command": "npm test -- checkout",
+                "expectedOutcome": "passes"
+            }
+        ],
+        "maxIterations": 5,
+        "approvalPolicy": "apply_within_workspace",
+        "learning": {
+            "captureTrace": true,
+            "proposeEvals": true,
+            "proposeSkills": true,
+            "summarizeRegressions": true
+        }
+    });
+    {
+        let mut reg = state.automaton_registry.lock().await;
+        reg.insert(
+            (pid, aiid),
+            ActiveAutomaton {
+                automaton_id: "auto-loop-engineering".into(),
+                project_id: pid,
+                template_agent_id: AgentId::new(),
+                loop_engineering: Some(contract),
+                harness_base_url: "http://127.0.0.1:1".to_string(),
+                paused: false,
+                alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                forwarder: None,
+                ws_reader_handle: None,
+                loop_handle: None,
+                last_forwarder_event_at: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
+                session_id: None,
+            },
+        );
+    }
+
+    let req = json_request("GET", &format!("/api/projects/{pid}/loop/status"), None);
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+
+    assert_eq!(body["running"], true);
+    assert_eq!(
+        body["loop_engineering"]["goal"],
+        "Fix checkout flakes and prove the regression is gone"
+    );
+    assert_eq!(body["loop_engineering"]["maxIterations"], 5);
+    assert_eq!(
+        body["loop_engineering"]["verifierCommands"][0]["command"],
+        "npm test -- checkout"
+    );
+}
+
+#[tokio::test]
 async fn loop_stop_clears_registry_even_when_harness_unreachable() {
     // If the registry has a live entry but the harness at harness_base_url
     // is unreachable, `client.stop()` errors. The handler should still
@@ -51,6 +117,7 @@ async fn loop_stop_clears_registry_even_when_harness_unreachable() {
                 automaton_id: "auto-1".into(),
                 project_id: pid,
                 template_agent_id: AgentId::new(),
+                loop_engineering: None,
                 harness_base_url: unreachable_harness,
                 paused: false,
                 alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -151,6 +218,7 @@ async fn loop_stop_publishes_loop_ended_synchronously() {
                 automaton_id: "auto-1".into(),
                 project_id: pid,
                 template_agent_id,
+                loop_engineering: None,
                 harness_base_url: unreachable_harness,
                 paused: false,
                 alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),

--- a/interface/src/components/AutomationBar/AutomationBar.module.css
+++ b/interface/src/components/AutomationBar/AutomationBar.module.css
@@ -1,3 +1,8 @@
+.automationStack {
+  width: 100%;
+  min-width: 0;
+}
+
 .automationBar {
   display: flex;
   align-items: center;
@@ -82,4 +87,136 @@
 .automationControls button.playButtonActive,
 .automationControls button.playButtonActive > * {
   overflow: visible;
+}
+
+.automationControls button.loopModeActive {
+  background: color-mix(in srgb, var(--accent-9, #7c8cff) 14%, transparent);
+}
+
+.loopEngineeringPanel {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3) var(--space-3);
+  border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+}
+
+.loopField {
+  display: grid;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.loopFieldLabel {
+  font-weight: 600;
+  opacity: 0.82;
+}
+
+.loopTextarea,
+.loopInput,
+.loopNumberInput,
+.loopSelect {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  background: var(--surface-1, rgba(0, 0, 0, 0.18));
+  color: inherit;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.loopTextarea {
+  min-height: 68px;
+  resize: vertical;
+  padding: var(--space-2);
+}
+
+.loopInput,
+.loopNumberInput,
+.loopSelect {
+  height: 28px;
+  padding: 0 var(--space-2);
+}
+
+.loopNumberInput {
+  max-width: 88px;
+}
+
+.loopVerifierHeader,
+.loopPanelFooter,
+.loopOptions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.loopVerifierHeader {
+  justify-content: space-between;
+}
+
+.loopVerifierList {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.loopVerifierRow {
+  display: grid;
+  grid-template-columns: minmax(72px, 0.6fr) minmax(120px, 1.2fr) minmax(120px, 1fr) auto;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+.loopOptions {
+  flex-wrap: wrap;
+}
+
+.loopInlineField {
+  display: grid;
+  gap: var(--space-1);
+  min-width: 120px;
+}
+
+.loopLearningGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-1);
+}
+
+.loopToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  height: 28px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  border-radius: 6px;
+  background: var(--surface-1, rgba(0, 0, 0, 0.16));
+}
+
+.loopMeta {
+  flex: 1;
+  min-width: 0;
+  opacity: 0.72;
+}
+
+.loopPanelFooter {
+  justify-content: space-between;
+}
+
+@media (max-width: 560px) {
+  .loopVerifierRow {
+    grid-template-columns: 1fr auto;
+  }
+
+  .loopVerifierRow .loopInput:nth-child(2),
+  .loopVerifierRow .loopInput:nth-child(3) {
+    grid-column: 1 / -1;
+  }
+
+  .loopLearningGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }

--- a/interface/src/components/AutomationBar/AutomationBar.module.css
+++ b/interface/src/components/AutomationBar/AutomationBar.module.css
@@ -93,6 +93,51 @@
   background: color-mix(in srgb, var(--accent-9, #7c8cff) 14%, transparent);
 }
 
+.loopModeBadge {
+  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--accent-9, #7c8cff) 30%, transparent);
+  border-radius: 999px;
+  color: var(--accent-11, #b8c0ff);
+  background: color-mix(in srgb, var(--accent-9, #7c8cff) 10%, transparent);
+  white-space: nowrap;
+}
+
+.loopActiveSummary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  background: color-mix(in srgb, var(--accent-9, #7c8cff) 8%, transparent);
+}
+
+.loopActiveCopy {
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+
+.loopActiveTitle {
+  font-weight: 600;
+}
+
+.loopActiveGoal,
+.loopActiveMeta {
+  min-width: 0;
+  opacity: 0.74;
+}
+
+.loopActiveGoal {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loopActiveMeta {
+  white-space: nowrap;
+}
+
 .loopEngineeringPanel {
   display: grid;
   gap: var(--space-2);
@@ -218,5 +263,14 @@
 
   .loopLearningGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .loopActiveSummary {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .loopActiveMeta {
+    grid-column: 2;
+    white-space: normal;
   }
 }

--- a/interface/src/components/AutomationBar/AutomationBar.test.tsx
+++ b/interface/src/components/AutomationBar/AutomationBar.test.tsx
@@ -242,6 +242,44 @@ describe("AutomationBar", () => {
     });
   });
 
+  it("shows the active Loop Engineering contract from loop status", async () => {
+    mockGetLoopStatus.mockResolvedValue({
+      active_agent_instances: ["loop-agent-1"],
+      paused: false,
+      loop_engineering: {
+        goal: "Fix checkout flakes and prove the regression is gone",
+        successCriteria: ["Checkout passes", "Regression test covers it"],
+        verifierCommands: [
+          {
+            label: "Checkout test",
+            command: "npm test -- checkout",
+            expectedOutcome: "passes",
+          },
+        ],
+        maxIterations: 5,
+        approvalPolicy: "apply_within_workspace",
+        learning: {
+          captureTrace: true,
+          proposeEvals: true,
+          proposeSkills: true,
+          summarizeRegressions: true,
+        },
+      },
+    });
+
+    renderBar();
+
+    await waitFor(() => {
+      expect(screen.getByText("Loop Engineering active")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Fix checkout flakes and prove the regression is gone"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Loop Engineering")).toBeInTheDocument();
+    expect(screen.getByText(/5 iterations \/ 2 criteria \/ 1 verifier/))
+      .toBeInTheDocument();
+  });
+
   it("shows paused status", async () => {
     mockGetLoopStatus.mockResolvedValue({ active_agent_instances: ["a1"], paused: true });
     renderBar();

--- a/interface/src/components/AutomationBar/AutomationBar.test.tsx
+++ b/interface/src/components/AutomationBar/AutomationBar.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@cypher-asi/zui", () => ({
 
 const mockGetLoopStatus = vi.fn();
 const mockStartLoop = vi.fn();
+const mockStartLoopEngineering = vi.fn();
 const mockPauseLoop = vi.fn();
 const mockStopLoop = vi.fn();
 const mockResumeLoop = vi.fn();
@@ -72,6 +73,7 @@ vi.mock("../../api/client", () => {
     api: {
       getLoopStatus: (...args: unknown[]) => mockGetLoopStatus(...args),
       startLoop: (...args: unknown[]) => mockStartLoop(...args),
+      startLoopEngineering: (...args: unknown[]) => mockStartLoopEngineering(...args),
       pauseLoop: (...args: unknown[]) => mockPauseLoop(...args),
       stopLoop: (...args: unknown[]) => mockStopLoop(...args),
       resumeLoop: (...args: unknown[]) => mockResumeLoop(...args),
@@ -199,6 +201,10 @@ beforeEach(() => {
     // jsdom always supports localStorage, but stay defensive.
   }
   mockGetLoopStatus.mockResolvedValue({ active_agent_instances: [], paused: false });
+  mockStartLoopEngineering.mockResolvedValue({
+    active_agent_instances: ["loop-agent-1"],
+    agent_instance_id: "loop-agent-1",
+  });
   // The bar resolves the project's `Loop`-role instance on mount so
   // pause/resume/stop scope to it; default to a mature project that
   // already has one.
@@ -318,6 +324,64 @@ describe("AutomationBar", () => {
     await user.click(screen.getByTitle("Start"));
     expect(mockStartLoop).toHaveBeenCalledWith(
       "proj-1",
+      undefined,
+      "aura-claude-opus-4-7",
+    );
+  });
+
+  it("starts Loop Engineering with a goal, criteria, verifier, model, and learning policy", async () => {
+    const user = userEvent.setup();
+    useAutomationLoopStore
+      .getState()
+      .setLoopModel("proj-1" as ProjectId, "aura-claude-opus-4-7");
+    renderBar();
+    await waitFor(() => expect(mockListAgentInstances).toHaveBeenCalledWith("proj-1"));
+
+    await user.click(screen.getByTitle("Loop Engineering"));
+    await user.type(
+      screen.getByLabelText("Goal"),
+      "Fix the action-item date drift",
+    );
+    await user.click(screen.getByTitle("Add verifier"));
+    await user.type(screen.getByLabelText("Verifier 1 label"), "Tests");
+    await user.type(
+      screen.getByLabelText("Verifier 1 command"),
+      "npm test -- --run",
+    );
+    await user.type(
+      screen.getByLabelText("Verifier 1 expected outcome"),
+      "All tests pass",
+    );
+    await user.click(screen.getByRole("button", { name: "Start Loop Engineering" }));
+
+    await waitFor(() => expect(mockStartLoopEngineering).toHaveBeenCalled());
+    expect(mockStartLoopEngineering).toHaveBeenCalledWith(
+      "proj-1",
+      {
+        loopEngineering: expect.objectContaining({
+          goal: "Fix the action-item date drift",
+          successCriteria: [
+            "Requested behavior works end to end",
+            "Existing tests, build, or project-native smoke checks pass",
+            "Final report includes evidence, changes, risks, and learnings",
+          ],
+          verifierCommands: [
+            {
+              label: "Tests",
+              command: "npm test -- --run",
+              expectedOutcome: "All tests pass",
+            },
+          ],
+          maxIterations: 4,
+          approvalPolicy: "apply_within_workspace",
+          learning: {
+            captureTrace: true,
+            proposeEvals: true,
+            proposeSkills: true,
+            summarizeRegressions: true,
+          },
+        }),
+      },
       undefined,
       "aura-claude-opus-4-7",
     );

--- a/interface/src/components/AutomationBar/AutomationBar.tsx
+++ b/interface/src/components/AutomationBar/AutomationBar.tsx
@@ -23,6 +23,7 @@ export function AutomationBar({ projectId }: AutomationBarProps) {
     handlePause, handleStop, handleStopConfirm,
     stopError, clearStopError,
     startError, clearStartError, handleResetAndRetry,
+    loopEngineeringContract,
   } = useAutomationStatus(projectId);
 
   // Whether the start error is the structured "harness has a stale
@@ -47,6 +48,15 @@ export function AutomationBar({ projectId }: AutomationBarProps) {
   // old `starting || preparing` spinner did.
   const loopWorking =
     status === "starting" || status === "preparing" || status === "active";
+  const loopEngineeringActive =
+    loopEngineeringContract != null &&
+    status !== "idle" &&
+    status !== "stopped";
+  const activeLoopEngineering = loopEngineeringActive
+    ? loopEngineeringContract
+    : null;
+  const verifierCount = activeLoopEngineering?.verifierCommands.length ?? 0;
+  const criteriaCount = activeLoopEngineering?.successCriteria.length ?? 0;
 
   return (
     <>
@@ -57,6 +67,11 @@ export function AutomationBar({ projectId }: AutomationBarProps) {
               Automation
             </Text>
             <StatusBadge status={status} />
+            {loopEngineeringActive ? (
+              <Text size="xs" className={styles.loopModeBadge}>
+                Loop Engineering
+              </Text>
+            ) : null}
             {agentCount > 1 && (
               <Text size="xs" className={styles.automationAgentCount}>
                 {agentCount} agents
@@ -120,6 +135,25 @@ export function AutomationBar({ projectId }: AutomationBarProps) {
             onStart={handleStartLoopEngineering}
           />
         )}
+        {activeLoopEngineering && !loopEngineeringOpen ? (
+          <div className={styles.loopActiveSummary} role="status">
+            <BrainCircuit size={14} />
+            <div className={styles.loopActiveCopy}>
+              <Text size="xs" className={styles.loopActiveTitle}>
+                Loop Engineering active
+              </Text>
+              <Text size="xs" className={styles.loopActiveGoal}>
+                {activeLoopEngineering.goal}
+              </Text>
+            </div>
+            <Text size="xs" className={styles.loopActiveMeta}>
+              {activeLoopEngineering.maxIterations} iteration
+              {activeLoopEngineering.maxIterations === 1 ? "" : "s"} /{" "}
+              {criteriaCount} criteria / {verifierCount || "auto"} verifier
+              {verifierCount === 1 ? "" : "s"}
+            </Text>
+          </div>
+        ) : null}
       </div>
 
       <ModalConfirm

--- a/interface/src/components/AutomationBar/AutomationBar.tsx
+++ b/interface/src/components/AutomationBar/AutomationBar.tsx
@@ -1,10 +1,12 @@
+import { useState } from "react";
 import { Button, Text, ModalConfirm } from "@cypher-asi/zui";
-import { Pause, Square } from "lucide-react";
+import { BrainCircuit, Pause, Square } from "lucide-react";
 import { StatusBadge } from "../StatusBadge";
 import { PlayLoopGlyph } from "../PlayLoopGlyph";
 import type { ProjectId } from "../../shared/types";
 import { useAutomationStatus } from "./useAutomationStatus";
 import { AutomationModelPicker } from "./AutomationModelPicker";
+import { LoopEngineeringPanel } from "./LoopEngineeringPanel";
 import styles from "./AutomationBar.module.css";
 
 interface AutomationBarProps {
@@ -12,10 +14,13 @@ interface AutomationBarProps {
 }
 
 export function AutomationBar({ projectId }: AutomationBarProps) {
+  const [loopEngineeringOpen, setLoopEngineeringOpen] = useState(false);
   const {
     status, agentCount, canPlay, canPause, canStop,
+    canStartLoopEngineering,
     confirmStop, setConfirmStop,
-    handleStart, handlePause, handleStop, handleStopConfirm,
+    handleStart, handleStartLoopEngineering,
+    handlePause, handleStop, handleStopConfirm,
     stopError, clearStopError,
     startError, clearStartError, handleResetAndRetry,
   } = useAutomationStatus(projectId);
@@ -45,52 +50,76 @@ export function AutomationBar({ projectId }: AutomationBarProps) {
 
   return (
     <>
-      <div className={styles.automationBar}>
-        <div className={styles.automationLabel}>
-          <Text size="sm" className={styles.automationLabelBold}>
-            Automation
-          </Text>
-          <StatusBadge status={status} />
-          {agentCount > 1 && (
-            <Text size="xs" className={styles.automationAgentCount}>{agentCount} agents</Text>
-          )}
+      <div className={styles.automationStack}>
+        <div className={styles.automationBar}>
+          <div className={styles.automationLabel}>
+            <Text size="sm" className={styles.automationLabelBold}>
+              Automation
+            </Text>
+            <StatusBadge status={status} />
+            {agentCount > 1 && (
+              <Text size="xs" className={styles.automationAgentCount}>
+                {agentCount} agents
+              </Text>
+            )}
+          </div>
+          <div className={styles.automationModelSlot}>
+            <AutomationModelPicker
+              projectId={projectId}
+              disabled={modelPickerDisabled}
+            />
+          </div>
+          <div className={styles.automationControls}>
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<BrainCircuit size={14} />}
+              onClick={() => setLoopEngineeringOpen((open) => !open)}
+              title="Loop Engineering"
+              className={
+                loopEngineeringOpen ? styles.loopModeActive : undefined
+              }
+            >
+              Loop
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              icon={<PlayLoopGlyph active={loopWorking} size={14} />}
+              onClick={handleStart}
+              disabled={!canPlay}
+              title={status === "paused" ? "Resume" : "Start"}
+              className={loopWorking ? styles.playButtonActive : undefined}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              icon={<Pause size={14} />}
+              onClick={handlePause}
+              disabled={!canPause}
+              title="Pause"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              icon={<Square size={14} />}
+              onClick={handleStop}
+              disabled={!canStop}
+              title="Stop"
+            />
+          </div>
         </div>
-        <div className={styles.automationModelSlot}>
-          <AutomationModelPicker
+
+        {loopEngineeringOpen && (
+          <LoopEngineeringPanel
             projectId={projectId}
-            disabled={modelPickerDisabled}
+            canStart={canStartLoopEngineering}
+            onStart={handleStartLoopEngineering}
           />
-        </div>
-        <div className={styles.automationControls}>
-          <Button
-            variant="ghost"
-            size="sm"
-            iconOnly
-            icon={<PlayLoopGlyph active={loopWorking} size={14} />}
-            onClick={handleStart}
-            disabled={!canPlay}
-            title={status === "paused" ? "Resume" : "Start"}
-            className={loopWorking ? styles.playButtonActive : undefined}
-          />
-          <Button
-            variant="ghost"
-            size="sm"
-            iconOnly
-            icon={<Pause size={14} />}
-            onClick={handlePause}
-            disabled={!canPause}
-            title="Pause"
-          />
-          <Button
-            variant="ghost"
-            size="sm"
-            iconOnly
-            icon={<Square size={14} />}
-            onClick={handleStop}
-            disabled={!canStop}
-            title="Stop"
-          />
-        </div>
+        )}
       </div>
 
       <ModalConfirm

--- a/interface/src/components/AutomationBar/LoopEngineeringPanel.tsx
+++ b/interface/src/components/AutomationBar/LoopEngineeringPanel.tsx
@@ -1,0 +1,416 @@
+import { useEffect, useMemo, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { Button, Text } from "@cypher-asi/zui";
+import { Plus, Trash2 } from "lucide-react";
+
+import type {
+  LoopEngineeringApprovalPolicy,
+  LoopEngineeringContract,
+  LoopEngineeringLearningPolicy,
+  LoopEngineeringVerifierCommand,
+} from "../../shared/api/loop";
+import type { ProjectId } from "../../shared/types";
+import styles from "./AutomationBar.module.css";
+
+interface LoopEngineeringPanelProps {
+  projectId: ProjectId;
+  canStart: boolean;
+  onStart: (contract: LoopEngineeringContract) => Promise<void>;
+}
+
+interface LoopEngineeringDraft {
+  goal: string;
+  successCriteriaText: string;
+  verifierCommands: LoopEngineeringVerifierCommand[];
+  maxIterations: number;
+  approvalPolicy: LoopEngineeringApprovalPolicy;
+  learning: LoopEngineeringLearningPolicy;
+}
+
+const DRAFT_KEY_PREFIX = "aura-loop-engineering-draft:project:";
+
+const DEFAULT_DRAFT: LoopEngineeringDraft = {
+  goal: "",
+  successCriteriaText: [
+    "Requested behavior works end to end",
+    "Existing tests, build, or project-native smoke checks pass",
+    "Final report includes evidence, changes, risks, and learnings",
+  ].join("\n"),
+  verifierCommands: [],
+  maxIterations: 4,
+  approvalPolicy: "apply_within_workspace",
+  learning: {
+    captureTrace: true,
+    proposeEvals: true,
+    proposeSkills: true,
+    summarizeRegressions: true,
+  },
+};
+
+export function LoopEngineeringPanel({
+  projectId,
+  canStart,
+  onStart,
+}: LoopEngineeringPanelProps) {
+  const [draft, setDraft] = useState<LoopEngineeringDraft>(() =>
+    loadDraft(projectId),
+  );
+
+  useEffect(() => {
+    setDraft(loadDraft(projectId));
+  }, [projectId]);
+
+  useEffect(() => {
+    persistDraft(projectId, draft);
+  }, [projectId, draft]);
+
+  const contract = useMemo(() => draftToContract(draft), [draft]);
+  const canSubmit =
+    canStart &&
+    contract.goal.length > 0 &&
+    contract.successCriteria.length > 0;
+
+  const updateVerifier = (
+    index: number,
+    patch: Partial<LoopEngineeringVerifierCommand>,
+  ) => {
+    setDraft((current) => {
+      const next = current.verifierCommands.map((command, i) =>
+        i === index ? { ...command, ...patch } : command,
+      );
+      return { ...current, verifierCommands: next };
+    });
+  };
+
+  const removeVerifier = (index: number) => {
+    setDraft((current) => ({
+      ...current,
+      verifierCommands: current.verifierCommands.filter((_, i) => i !== index),
+    }));
+  };
+
+  const addVerifier = () => {
+    setDraft((current) => ({
+      ...current,
+      verifierCommands: [
+        ...current.verifierCommands,
+        { label: "", command: "", expectedOutcome: "" },
+      ],
+    }));
+  };
+
+  return (
+    <div className={styles.loopEngineeringPanel}>
+      <label className={styles.loopField}>
+        <Text size="xs" className={styles.loopFieldLabel}>
+          Goal
+        </Text>
+        <textarea
+          className={styles.loopTextarea}
+          value={draft.goal}
+          onChange={(event) =>
+            setDraft((current) => ({ ...current, goal: event.target.value }))
+          }
+          placeholder="Fix the broken flow, verify it, and capture learnings"
+          rows={3}
+        />
+      </label>
+
+      <label className={styles.loopField}>
+        <Text size="xs" className={styles.loopFieldLabel}>
+          Success criteria
+        </Text>
+        <textarea
+          className={styles.loopTextarea}
+          value={draft.successCriteriaText}
+          onChange={(event) =>
+            setDraft((current) => ({
+              ...current,
+              successCriteriaText: event.target.value,
+            }))
+          }
+          rows={3}
+        />
+      </label>
+
+      <div className={styles.loopVerifierHeader}>
+        <Text size="xs" className={styles.loopFieldLabel}>
+          Verifier commands
+        </Text>
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={<Plus size={13} />}
+          onClick={addVerifier}
+          title="Add verifier"
+          aria-label="Add verifier"
+        />
+      </div>
+
+      <div className={styles.loopVerifierList}>
+        {draft.verifierCommands.map((verifier, index) => (
+          <div className={styles.loopVerifierRow} key={index}>
+            <input
+              className={styles.loopInput}
+              aria-label={`Verifier ${index + 1} label`}
+              value={verifier.label}
+              onChange={(event) =>
+                updateVerifier(index, { label: event.target.value })
+              }
+              placeholder="Tests"
+            />
+            <input
+              className={styles.loopInput}
+              aria-label={`Verifier ${index + 1} command`}
+              value={verifier.command}
+              onChange={(event) =>
+                updateVerifier(index, { command: event.target.value })
+              }
+              placeholder="npm test -- --run"
+            />
+            <input
+              className={styles.loopInput}
+              aria-label={`Verifier ${index + 1} expected outcome`}
+              value={verifier.expectedOutcome ?? ""}
+              onChange={(event) =>
+                updateVerifier(index, { expectedOutcome: event.target.value })
+              }
+              placeholder="All tests pass"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              icon={<Trash2 size={13} />}
+              onClick={() => removeVerifier(index)}
+              title={`Remove verifier ${index + 1}`}
+              aria-label={`Remove verifier ${index + 1}`}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.loopOptions}>
+        <label className={styles.loopInlineField}>
+          <Text size="xs" className={styles.loopFieldLabel}>
+            Iterations
+          </Text>
+          <input
+            className={styles.loopNumberInput}
+            type="number"
+            min={1}
+            max={12}
+            value={draft.maxIterations}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                maxIterations: Number(event.target.value),
+              }))
+            }
+          />
+        </label>
+        <label className={styles.loopInlineField}>
+          <Text size="xs" className={styles.loopFieldLabel}>
+            Approval
+          </Text>
+          <select
+            className={styles.loopSelect}
+            value={draft.approvalPolicy}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                approvalPolicy:
+                  event.target.value as LoopEngineeringApprovalPolicy,
+              }))
+            }
+          >
+            <option value="apply_within_workspace">Apply scoped fixes</option>
+            <option value="propose_only">Propose only</option>
+          </select>
+        </label>
+      </div>
+
+      <div className={styles.loopLearningGrid}>
+        <LoopLearningToggle
+          label="Trace"
+          checked={draft.learning.captureTrace}
+          onChange={(captureTrace) => updateLearning(setDraft, { captureTrace })}
+        />
+        <LoopLearningToggle
+          label="Evals"
+          checked={draft.learning.proposeEvals}
+          onChange={(proposeEvals) =>
+            updateLearning(setDraft, { proposeEvals })
+          }
+        />
+        <LoopLearningToggle
+          label="Skills"
+          checked={draft.learning.proposeSkills}
+          onChange={(proposeSkills) =>
+            updateLearning(setDraft, { proposeSkills })
+          }
+        />
+        <LoopLearningToggle
+          label="Regressions"
+          checked={draft.learning.summarizeRegressions}
+          onChange={(summarizeRegressions) =>
+            updateLearning(setDraft, { summarizeRegressions })
+          }
+        />
+      </div>
+
+      <div className={styles.loopPanelFooter}>
+        <Text size="xs" className={styles.loopMeta}>
+          {contract.verifierCommands.length > 0
+            ? `${contract.verifierCommands.length} verifier command${contract.verifierCommands.length === 1 ? "" : "s"}`
+            : "Project-native verification will be discovered"}
+        </Text>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => void onStart(contract)}
+          disabled={!canSubmit}
+        >
+          Start Loop Engineering
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function LoopLearningToggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className={styles.loopToggle}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      <Text size="xs">{label}</Text>
+    </label>
+  );
+}
+
+function updateLearning(
+  setDraft: Dispatch<SetStateAction<LoopEngineeringDraft>>,
+  patch: Partial<LoopEngineeringLearningPolicy>,
+) {
+  setDraft((current) => ({
+    ...current,
+    learning: { ...current.learning, ...patch },
+  }));
+}
+
+function draftToContract(draft: LoopEngineeringDraft): LoopEngineeringContract {
+  return {
+    goal: draft.goal.trim(),
+    successCriteria: draft.successCriteriaText
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean),
+    verifierCommands: draft.verifierCommands
+      .map((command) => ({
+        label: command.label.trim(),
+        command: command.command.trim(),
+        expectedOutcome: command.expectedOutcome?.trim() || undefined,
+      }))
+      .filter((command) => command.command.length > 0),
+    maxIterations: clampIterations(draft.maxIterations),
+    approvalPolicy: draft.approvalPolicy,
+    learning: draft.learning,
+  };
+}
+
+function clampIterations(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_DRAFT.maxIterations;
+  return Math.min(12, Math.max(1, Math.round(value)));
+}
+
+function loadDraft(projectId: ProjectId): LoopEngineeringDraft {
+  try {
+    const raw = localStorage.getItem(draftKey(projectId));
+    if (!raw) return DEFAULT_DRAFT;
+    return normalizeDraft(JSON.parse(raw));
+  } catch {
+    return DEFAULT_DRAFT;
+  }
+}
+
+function persistDraft(projectId: ProjectId, draft: LoopEngineeringDraft): void {
+  try {
+    localStorage.setItem(draftKey(projectId), JSON.stringify(draft));
+  } catch {
+    // localStorage may be unavailable.
+  }
+}
+
+function normalizeDraft(value: unknown): LoopEngineeringDraft {
+  if (value == null || typeof value !== "object") return DEFAULT_DRAFT;
+  const draft = value as Partial<LoopEngineeringDraft>;
+  return {
+    goal: typeof draft.goal === "string" ? draft.goal : DEFAULT_DRAFT.goal,
+    successCriteriaText:
+      typeof draft.successCriteriaText === "string"
+        ? draft.successCriteriaText
+        : DEFAULT_DRAFT.successCriteriaText,
+    verifierCommands: Array.isArray(draft.verifierCommands)
+      ? draft.verifierCommands.filter(isVerifierCommand)
+      : DEFAULT_DRAFT.verifierCommands,
+    maxIterations:
+      typeof draft.maxIterations === "number"
+        ? clampIterations(draft.maxIterations)
+        : DEFAULT_DRAFT.maxIterations,
+    approvalPolicy:
+      draft.approvalPolicy === "propose_only" ||
+      draft.approvalPolicy === "apply_within_workspace"
+        ? draft.approvalPolicy
+        : DEFAULT_DRAFT.approvalPolicy,
+    learning: normalizeLearning(draft.learning),
+  };
+}
+
+function normalizeLearning(value: unknown): LoopEngineeringLearningPolicy {
+  if (value == null || typeof value !== "object") return DEFAULT_DRAFT.learning;
+  const learning = value as Partial<LoopEngineeringLearningPolicy>;
+  return {
+    captureTrace:
+      typeof learning.captureTrace === "boolean"
+        ? learning.captureTrace
+        : DEFAULT_DRAFT.learning.captureTrace,
+    proposeEvals:
+      typeof learning.proposeEvals === "boolean"
+        ? learning.proposeEvals
+        : DEFAULT_DRAFT.learning.proposeEvals,
+    proposeSkills:
+      typeof learning.proposeSkills === "boolean"
+        ? learning.proposeSkills
+        : DEFAULT_DRAFT.learning.proposeSkills,
+    summarizeRegressions:
+      typeof learning.summarizeRegressions === "boolean"
+        ? learning.summarizeRegressions
+        : DEFAULT_DRAFT.learning.summarizeRegressions,
+  };
+}
+
+function isVerifierCommand(value: unknown): value is LoopEngineeringVerifierCommand {
+  if (value == null || typeof value !== "object") return false;
+  const command = value as Partial<LoopEngineeringVerifierCommand>;
+  return (
+    typeof command.label === "string" &&
+    typeof command.command === "string" &&
+    (command.expectedOutcome == null ||
+      typeof command.expectedOutcome === "string")
+  );
+}
+
+function draftKey(projectId: ProjectId): string {
+  return `${DRAFT_KEY_PREFIX}${projectId}`;
+}

--- a/interface/src/components/AutomationBar/useAutomationStatus.ts
+++ b/interface/src/components/AutomationBar/useAutomationStatus.ts
@@ -114,6 +114,7 @@ interface AutomationStatusData {
   startError: StartLoopError | null;
   clearStartError: () => void;
   handleResetAndRetry: () => Promise<void>;
+  loopEngineeringContract: LoopEngineeringContract | null;
 }
 
 function errorMessage(err: unknown, fallback: string): string {
@@ -178,6 +179,8 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
   const [confirmStop, setConfirmStop] = useState(false);
   const [stopError, setStopError] = useState<string | null>(null);
   const [startError, setStartError] = useState<StartLoopError | null>(null);
+  const [loopEngineeringContract, setLoopEngineeringContract] =
+    useState<LoopEngineeringContract | null>(null);
 
   // Bound `Loop`-role agent instance id for this project. Read by all
   // pause / resume / stop paths so the harness's "one in-flight turn
@@ -240,6 +243,7 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
             agents: res.active_agent_instances ?? [],
             paused: Boolean(res.paused),
           });
+          setLoopEngineeringContract(res.loop_engineering ?? null);
           hydrateUiFromLoopStartResponse(res, projectId);
           rehydrateLoopActivityForProject(projectId);
         })
@@ -258,6 +262,7 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
           agents: res.active_agent_instances ?? [],
           paused: Boolean(res.paused),
         });
+        setLoopEngineeringContract(res.loop_engineering ?? null);
         // Rehydrate Run panel rows from authoritative server state
         // so the "No tasks" emptiness after refresh doesn't stay out
         // of sync with the spinning nav icon. Any missed
@@ -364,6 +369,7 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
       //   2. loop_started WS arrives     -> kind: "preparing"
       //   3. task_started WS arrives     -> kind: "active"
       dispatch({ type: "startClicked" });
+      setLoopEngineeringContract(null);
       try {
         const res = await start();
         if (res.agent_instance_id) {
@@ -374,6 +380,7 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
           agents: res.active_agent_instances ?? [],
           paused: false,
         });
+        setLoopEngineeringContract(res.loop_engineering ?? null);
         hydrateUiFromLoopStartResponse(res, projectId);
         rehydrateLoopActivityForProject(projectId);
         if (
@@ -408,6 +415,7 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
           agents: res.active_agent_instances ?? [],
           paused: false,
         });
+        setLoopEngineeringContract(res.loop_engineering ?? null);
         hydrateUiFromLoopStartResponse(res, projectId);
         rehydrateLoopActivityForProject(projectId);
       } catch (err) {
@@ -501,6 +509,7 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
         agents: res.active_agent_instances ?? [],
         paused: Boolean(res.paused),
       });
+      setLoopEngineeringContract(res.loop_engineering ?? null);
       fetchLoopStatus();
       // Also rehydrate the unified spinner store so any stale activity
       // row from the loop instance we just stopped is evicted on the
@@ -535,5 +544,6 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
     handlePause, handleStop, handleStopConfirm,
     stopError, clearStopError,
     startError, clearStartError, handleResetAndRetry,
+    loopEngineeringContract,
   };
 }

--- a/interface/src/components/AutomationBar/useAutomationStatus.ts
+++ b/interface/src/components/AutomationBar/useAutomationStatus.ts
@@ -5,7 +5,10 @@ import {
   isInsufficientCreditsError,
   dispatchInsufficientCredits,
 } from "../../api/client";
-import type { LoopStatusResponse } from "../../shared/api/loop";
+import type {
+  LoopEngineeringContract,
+  LoopStatusResponse,
+} from "../../shared/api/loop";
 import { useEventStore } from "../../stores/event-store/index";
 import { useLoopActivityStore } from "../../stores/loop-activity-store";
 import { hydrateActiveTasksFromLoopStatus } from "../../stores/run-pane-sync";
@@ -101,6 +104,8 @@ interface AutomationStatusData {
   confirmStop: boolean;
   setConfirmStop: (v: boolean) => void;
   handleStart: () => Promise<void>;
+  handleStartLoopEngineering: (contract: LoopEngineeringContract) => Promise<void>;
+  canStartLoopEngineering: boolean;
   handlePause: () => Promise<void>;
   handleStop: () => void;
   handleStopConfirm: () => Promise<void>;
@@ -349,6 +354,47 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
   const status = statusOf(state);
   const agentCount = agentsOf(state).length;
 
+  const beginFreshLoop = useCallback(
+    async (start: () => Promise<LoopStatusResponse>) => {
+      setStartError(null);
+      // Optimistically flip into `starting` so the Run button spinner
+      // and the sidekick Run/Tasks tab loaders engage immediately on
+      // click, and stay engaged without flicker across three phases:
+      //   1. request in flight           -> kind: "starting"
+      //   2. loop_started WS arrives     -> kind: "preparing"
+      //   3. task_started WS arrives     -> kind: "active"
+      dispatch({ type: "startClicked" });
+      try {
+        const res = await start();
+        if (res.agent_instance_id) {
+          setBoundLoopId(projectId, res.agent_instance_id);
+        }
+        dispatch({
+          type: "statusFetched",
+          agents: res.active_agent_instances ?? [],
+          paused: false,
+        });
+        hydrateUiFromLoopStartResponse(res, projectId);
+        rehydrateLoopActivityForProject(projectId);
+        if (
+          (res.active_agent_instances ?? []).length > 0 &&
+          (res.active_tasks ?? []).length === 0
+        ) {
+          window.setTimeout(() => fetchLoopStatus(), 500);
+        }
+      } catch (err) {
+        dispatch({ type: "startFailed" });
+        if (isInsufficientCreditsError(err)) {
+          dispatchInsufficientCredits();
+        } else {
+          setStartError(describeStartLoopError(err));
+        }
+        console.error("Failed to start loop", err);
+      }
+    },
+    [fetchLoopStatus, projectId, setBoundLoopId],
+  );
+
   const handleStart = useCallback(async () => {
     setStartError(null);
     if (state.kind === "paused") {
@@ -370,72 +416,26 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
       }
       return;
     }
-    // Optimistically flip into `starting` so the Run button spinner
-    // and the sidekick Run/Tasks tab loaders engage immediately on
-    // click, and stay engaged without flicker across three phases:
-    //   1. request in flight           -> kind: "starting"
-    //   2. loop_started WS arrives     -> kind: "preparing"
-    //   3. task_started WS arrives     -> kind: "active"
-    // Without this the spinner would flash off between the HTTP
-    // response and the `loop_started` WS event, making the ramp-up
-    // look stalled on the first (or interrupted) task of a fresh run.
-    dispatch({ type: "startClicked" });
-    try {
-      // Omit `agent_instance_id`: the backend resolves to the
-      // project's `Loop`-role instance via
-      // `ensure_default_loop_instance`, lazily creating one if this
-      // is the first Start in the project. Passing the URL's
-      // currently-viewed chat agent here would force the loop onto
-      // that chat instance and the harness's "one in-flight turn per
-      // agent_id" policy would silently abort either the chat reply
-      // or the next loop turn -- exactly the regression we're fixing.
-      const res = await api.startLoop(projectId, undefined, selectedModel);
-      // Capture the Loop instance the backend resolved to so all
-      // subsequent pause / resume / stop calls scope themselves to
-      // it. `start_loop` populates `agent_instance_id` on the
-      // response with the resolved id, regardless of whether we
-      // passed one in.
-      if (res.agent_instance_id) {
-        setBoundLoopId(projectId, res.agent_instance_id);
-      }
-      // Reconcile the optimistic `starting` state with the server's
-      // authoritative agent list so the UI updates immediately, in
-      // step with the HTTP response, instead of waiting on the
-      // `loop_started` WS event.
-      dispatch({
-        type: "statusFetched",
-        agents: res.active_agent_instances ?? [],
-        paused: false,
-      });
-      // Seed the Run panel row + Tasks list "live" dot from the response
-      // so the user sees activity without waiting for task_started.
-      hydrateUiFromLoopStartResponse(res, projectId);
-      rehydrateLoopActivityForProject(projectId);
-      if (
-        (res.active_agent_instances ?? []).length > 0 &&
-        (res.active_tasks ?? []).length === 0
-      ) {
-        // `/loop/start` snapshots before the forwarder binds the first
-        // harness task; re-fetch once so active_tasks catches up without
-        // wiping WS-seeded Run pane rows (see run-pane-sync demote guard).
-        window.setTimeout(() => fetchLoopStatus(), 500);
-      }
-    } catch (err) {
-      dispatch({ type: "startFailed" });
-      if (isInsufficientCreditsError(err)) {
-        dispatchInsufficientCredits();
-      } else {
-        // Replace the previous silent `console.error` so the click is
-        // visibly resolved one way or another. The AutomationBar
-        // renders this `startError` as a ModalConfirm with a Reset
-        // affordance for the `automation_already_running` case, which
-        // is the wedge the user hit when the harness had a stale
-        // automaton from a prior aura-os-server session.
-        setStartError(describeStartLoopError(err));
-      }
-      console.error("Failed to start loop", err);
-    }
-  }, [projectId, state.kind, selectedModel, boundLoopId, setBoundLoopId]);
+    await beginFreshLoop(() => api.startLoop(projectId, undefined, selectedModel));
+  }, [beginFreshLoop, projectId, state.kind, selectedModel, boundLoopId]);
+
+  const canStartLoopEngineering =
+    status === "idle" || status === "stopped";
+
+  const handleStartLoopEngineering = useCallback(
+    async (contract: LoopEngineeringContract) => {
+      if (!canStartLoopEngineering) return;
+      await beginFreshLoop(() =>
+        api.startLoopEngineering(
+          projectId,
+          { loopEngineering: contract },
+          undefined,
+          selectedModel,
+        ),
+      );
+    },
+    [beginFreshLoop, canStartLoopEngineering, projectId, selectedModel],
+  );
 
   const handlePause = useCallback(async () => {
     try {
@@ -531,7 +531,8 @@ export function useAutomationStatus(projectId: ProjectId): AutomationStatusData 
     starting: state.kind === "starting",
     preparing: state.kind === "preparing",
     confirmStop, setConfirmStop,
-    handleStart, handlePause, handleStop, handleStopConfirm,
+    handleStart, handleStartLoopEngineering, canStartLoopEngineering,
+    handlePause, handleStop, handleStopConfirm,
     stopError, clearStopError,
     startError, clearStartError, handleResetAndRetry,
   };

--- a/interface/src/components/Sidekick/Sidekick.module.css
+++ b/interface/src/components/Sidekick/Sidekick.module.css
@@ -19,6 +19,27 @@
   position: relative;
 }
 
+.sidekickTaskbarWithPanel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  height: var(--control-height-sm, 32px);
+}
+
+.sidekickTaskbarPanel {
+  position: fixed;
+  z-index: 90;
+  max-height: min(70vh, 620px);
+  overflow: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--color-border-main-panel);
+  border-radius: 8px;
+  background: var(--color-sidekick-bg);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.36);
+}
+
 .sidekickTabBar {
   display: flex;
   align-items: center;

--- a/interface/src/components/SidekickTaskbar/SidekickTaskbar.test.tsx
+++ b/interface/src/components/SidekickTaskbar/SidekickTaskbar.test.tsx
@@ -1,10 +1,14 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useLoopActivityStore } from "../../stores/loop-activity-store";
 import { useSidekickStore } from "../../stores/sidekick-store";
 import { SidekickTaskbar } from "./SidekickTaskbar";
+
+const { mockHandleStartLoopEngineering } = vi.hoisted(() => ({
+  mockHandleStartLoopEngineering: vi.fn(),
+}));
 
 vi.mock("../../hooks/use-aura-capabilities", () => ({
   useAuraCapabilities: () => ({ features: { linkedWorkspace: false } }),
@@ -29,17 +33,81 @@ vi.mock("../SidekickTabBar", () => ({
   SidekickTabBar: ({
     tabs,
     activeTab,
+    onInlineAction,
   }: {
-    tabs: Array<{ id: string; icon: React.ReactNode; title: string }>;
+    tabs: Array<{
+      id: string;
+      icon: React.ReactNode;
+      title: string;
+      kind?: "tab" | "action";
+    }>;
     activeTab: string;
+    onInlineAction?: (id: string) => void;
   }) => (
     <div data-testid="sidekick-tabbar" data-active-tab={activeTab}>
       {tabs.map((tab) => (
-        <span key={tab.id} data-testid={`tab-${tab.id}`}>
+        <button
+          key={tab.id}
+          data-testid={`tab-${tab.id}`}
+          onClick={() => {
+            if (tab.kind === "action") onInlineAction?.(tab.id);
+          }}
+        >
           {tab.icon}
           {tab.title}
-        </span>
+        </button>
       ))}
+    </div>
+  ),
+}));
+
+vi.mock("../AutomationBar/useAutomationStatus", () => ({
+  useAutomationStatus: () => ({
+    canStartLoopEngineering: true,
+    handleStartLoopEngineering: mockHandleStartLoopEngineering,
+    startError: null,
+    clearStartError: vi.fn(),
+  }),
+}));
+
+vi.mock("../AutomationBar/LoopEngineeringPanel", () => ({
+  LoopEngineeringPanel: ({
+    projectId,
+    canStart,
+    onStart,
+  }: {
+    projectId: string;
+    canStart: boolean;
+    onStart: (contract: unknown) => Promise<void>;
+  }) => (
+    <div data-testid="loop-engineering-panel" data-project-id={projectId}>
+      <button
+        data-testid="start-loop-engineering"
+        disabled={!canStart}
+        onClick={() =>
+          void onStart({
+            goal: "Fix a failing checkout flow",
+            successCriteria: ["Checkout completes", "Regression test passes"],
+            verifierCommands: [
+              {
+                label: "checkout test",
+                command: "npm test -- checkout",
+                expectedOutcome: "pass",
+              },
+            ],
+            maxIterations: 4,
+            approvalPolicy: "apply_within_workspace",
+            learning: {
+              captureTrace: true,
+              proposeEvals: true,
+              proposeSkills: true,
+              summarizeRegressions: true,
+            },
+          })
+        }
+      >
+        Start Loop Engineering
+      </button>
     </div>
   ),
 }));
@@ -92,6 +160,8 @@ describe("SidekickTaskbar", () => {
       canGoBack: false,
     });
     useLoopActivityStore.setState({ loops: {}, hydrated: false });
+    mockHandleStartLoopEngineering.mockReset();
+    mockHandleStartLoopEngineering.mockResolvedValue(undefined);
   });
 
   it("renders active run progress without recursive loop-activity updates", () => {
@@ -194,5 +264,43 @@ describe("SidekickTaskbar", () => {
     expect(runTab.querySelector("svg polygon")).toBeInTheDocument();
     expect(runTab.querySelector("[data-testid='play-loop-ring']"))
       .not.toBeInTheDocument();
+  });
+
+  it("opens Loop Engineering from the active sidekick taskbar and starts with a contract", async () => {
+    renderTaskbar();
+
+    fireEvent.click(screen.getByTestId("tab-loop-engineering"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("loop-engineering-panel")).toHaveAttribute(
+        "data-project-id",
+        "project-1",
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("start-loop-engineering"));
+
+    await waitFor(() =>
+      expect(mockHandleStartLoopEngineering).toHaveBeenCalledWith(
+        expect.objectContaining({
+          goal: "Fix a failing checkout flow",
+          successCriteria: ["Checkout completes", "Regression test passes"],
+          verifierCommands: [
+            {
+              label: "checkout test",
+              command: "npm test -- checkout",
+              expectedOutcome: "pass",
+            },
+          ],
+          approvalPolicy: "apply_within_workspace",
+          learning: expect.objectContaining({
+            captureTrace: true,
+            proposeEvals: true,
+            proposeSkills: true,
+            summarizeRegressions: true,
+          }),
+        }),
+      ),
+    );
   });
 });

--- a/interface/src/components/SidekickTaskbar/SidekickTaskbar.tsx
+++ b/interface/src/components/SidekickTaskbar/SidekickTaskbar.tsx
@@ -1,8 +1,18 @@
-import { useEffect, useMemo } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import { createPortal } from "react-dom";
 import { useParams } from "react-router-dom";
-import type { MenuItem } from "@cypher-asi/zui";
+import { ModalConfirm, type MenuItem } from "@cypher-asi/zui";
 import {
   Archive,
+  BrainCircuit,
   Info,
   File,
   ClipboardClock,
@@ -20,14 +30,23 @@ import { useTerminalTarget } from "../../hooks/use-terminal-target";
 import { SidekickTabBar, type TabItem } from "../SidekickTabBar";
 import { CheckLoopGlyph } from "../CheckLoopGlyph";
 import { PlayLoopGlyph } from "../PlayLoopGlyph";
+import { LoopEngineeringPanel } from "../AutomationBar/LoopEngineeringPanel";
+import { useAutomationStatus } from "../AutomationBar/useAutomationStatus";
 import {
   selectAgentInstanceActivity,
   selectProjectActivity,
   useLoopActivityStore,
 } from "../../stores/loop-activity-store";
 import { isLoopActivityActive } from "../../shared/types/aura-events";
+import type { LoopEngineeringContract } from "../../shared/api/loop";
+import type { ProjectId } from "../../shared/types";
+import styles from "../Sidekick/Sidekick.module.css";
 
 export function SidekickTaskbar() {
+  const [loopEngineeringOpen, setLoopEngineeringOpen] = useState(false);
+  const [loopPanelStyle, setLoopPanelStyle] =
+    useState<CSSProperties | null>(null);
+  const taskbarRef = useRef<HTMLDivElement>(null);
   const { activeTab, setActiveTab, showInfo, toggleInfo } = useSidekickStore(
     useShallow((s) => ({
       activeTab: s.activeTab,
@@ -53,7 +72,8 @@ export function SidekickTaskbar() {
   const runActivity = useLoopActivityStore(
     useShallow((s) => selectProjectActivity(s, projectId ?? null)),
   );
-  const tasksActive = !!tasksActivity && isLoopActivityActive(tasksActivity.status);
+  const tasksActive =
+    !!tasksActivity && isLoopActivityActive(tasksActivity.status);
   const runActive = !!runActivity && isLoopActivityActive(runActivity.status);
 
   useEffect(() => {
@@ -63,10 +83,19 @@ export function SidekickTaskbar() {
   }, [activeTab, canBrowseFiles, setActiveTab]);
   const project = ctx?.project;
   const handleArchive = ctx?.handleArchive;
-  const tabs = useMemo<TabItem[]>(
-    () => [
-      { id: "sessions", icon: <MessageSquare size={16} />, title: "Chats" },
-      { id: "terminal", icon: <SquareTerminal size={16} />, title: "Terminal" },
+  const loopProjectId = project?.project_id ?? projectId ?? null;
+  const tabs = useMemo<TabItem[]>(() => {
+    const items: TabItem[] = [
+      {
+        id: "sessions",
+        icon: <MessageSquare size={16} />,
+        title: "Chats",
+      },
+      {
+        id: "terminal",
+        icon: <SquareTerminal size={16} />,
+        title: "Terminal",
+      },
       { id: "browser", icon: <Globe size={16} />, title: "Browser" },
       { id: "specs", icon: <File size={16} />, title: "Plans" },
       {
@@ -81,6 +110,16 @@ export function SidekickTaskbar() {
         icon: <PlayLoopGlyph active={runActive} size={16} />,
         title: "Run",
       },
+      ...(loopProjectId
+        ? [
+            {
+              id: "loop-engineering",
+              kind: "action" as const,
+              icon: <BrainCircuit size={16} />,
+              title: "Loop Engineering",
+            },
+          ]
+        : []),
       {
         id: "tasks",
         // `CheckLoopGlyph` mirrors `PlayLoopGlyph`: the Check
@@ -99,13 +138,19 @@ export function SidekickTaskbar() {
       // default 320px width, so keeping Stats ahead of the more
       // secondary Log/Files tabs ensures Log/Files (not Stats) are the
       // ones that fall into the overflow "More" menu on narrow panels.
-      { id: "stats", icon: <ChartNoAxesColumnIncreasing size={16} />, title: "Stats" },
+      {
+        id: "stats",
+        icon: <ChartNoAxesColumnIncreasing size={16} />,
+        title: "Stats",
+      },
       { id: "log", icon: <ClipboardClock size={16} />, title: "Logs" },
       { id: "files", icon: <FolderClosed size={16} />, title: "Files" },
-    ],
-    [tasksActive, runActive],
-  );
-  const visibleTabs = canBrowseFiles ? tabs : tabs.filter((tab) => tab.id !== "files");
+    ];
+    return items;
+  }, [tasksActive, runActive, loopProjectId]);
+  const visibleTabs = canBrowseFiles
+    ? tabs
+    : tabs.filter((tab) => tab.id !== "files");
 
   const actions = useMemo<MenuItem[]>(() => {
     if (!project) return [];
@@ -124,14 +169,111 @@ export function SidekickTaskbar() {
     if (id === "info") toggleInfo("Project Info", null);
   };
 
+  const handleInlineAction = (id: string) => {
+    if (id === "loop-engineering") {
+      setLoopEngineeringOpen((open) => !open);
+    }
+  };
+
+  useLayoutEffect(() => {
+    if (!loopEngineeringOpen) {
+      setLoopPanelStyle(null);
+      return;
+    }
+
+    const updatePanelPosition = () => {
+      const rect = taskbarRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const viewportWidth = window.innerWidth || 1280;
+      setLoopPanelStyle({
+        top: rect.bottom + 4,
+        right: Math.max(12, viewportWidth - rect.right),
+        width: Math.min(560, viewportWidth - 24),
+      });
+    };
+
+    updatePanelPosition();
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" && taskbarRef.current
+        ? new ResizeObserver(updatePanelPosition)
+        : null;
+    if (taskbarRef.current) resizeObserver?.observe(taskbarRef.current);
+    window.addEventListener("resize", updatePanelPosition);
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updatePanelPosition);
+    };
+  }, [loopEngineeringOpen]);
+
   return (
-    <SidekickTabBar
-      tabs={visibleTabs}
-      activeTab={activeTab}
-      onTabChange={(id) => setActiveTab(id as SidekickTab)}
-      actions={actions}
-      onAction={handleAction}
-      alwaysShowMore={!!project}
-    />
+    <div ref={taskbarRef} className={styles.sidekickTaskbarWithPanel}>
+      <SidekickTabBar
+        tabs={visibleTabs}
+        activeTab={activeTab}
+        onTabChange={(id) => setActiveTab(id as SidekickTab)}
+        onInlineAction={handleInlineAction}
+        actions={actions}
+        onAction={handleAction}
+        alwaysShowMore={!!project}
+      />
+      {loopEngineeringOpen &&
+      loopProjectId &&
+      loopPanelStyle &&
+      typeof document !== "undefined"
+        ? createPortal(
+            <SidekickLoopEngineeringPanel
+              projectId={loopProjectId}
+              style={loopPanelStyle}
+            />,
+            document.body,
+          )
+        : null}
+    </div>
+  );
+}
+
+function SidekickLoopEngineeringPanel({
+  projectId,
+  style,
+}: {
+  projectId: ProjectId;
+  style: CSSProperties;
+}) {
+  const {
+    canStartLoopEngineering,
+    handleStartLoopEngineering,
+    startError,
+    clearStartError,
+  } = useAutomationStatus(projectId);
+
+  const handleStart = useCallback(
+    async (contract: LoopEngineeringContract) => {
+      await handleStartLoopEngineering(contract);
+    },
+    [handleStartLoopEngineering],
+  );
+
+  return (
+    <>
+      <div className={styles.sidekickTaskbarPanel} style={style}>
+        <LoopEngineeringPanel
+          projectId={projectId}
+          canStart={canStartLoopEngineering}
+          onStart={handleStart}
+        />
+      </div>
+
+      {startError ? (
+        <ModalConfirm
+          isOpen
+          onClose={clearStartError}
+          onConfirm={clearStartError}
+          title="Loop Engineering start failed"
+          message={startError.message}
+          confirmLabel="Dismiss"
+          cancelLabel="Close"
+        />
+      ) : null}
+    </>
   );
 }

--- a/interface/src/components/SidekickTaskbar/SidekickTaskbar.tsx
+++ b/interface/src/components/SidekickTaskbar/SidekickTaskbar.tsx
@@ -162,24 +162,8 @@ export function SidekickTaskbar() {
     ];
   }, [project]);
 
-  if (showInfo) return null;
-
-  const handleAction = (id: string) => {
-    if (id === "archive") handleArchive?.();
-    if (id === "info") toggleInfo("Project Info", null);
-  };
-
-  const handleInlineAction = (id: string) => {
-    if (id === "loop-engineering") {
-      setLoopEngineeringOpen((open) => !open);
-    }
-  };
-
   useLayoutEffect(() => {
-    if (!loopEngineeringOpen) {
-      setLoopPanelStyle(null);
-      return;
-    }
+    if (!loopEngineeringOpen) return;
 
     const updatePanelPosition = () => {
       const rect = taskbarRef.current?.getBoundingClientRect();
@@ -204,6 +188,24 @@ export function SidekickTaskbar() {
       window.removeEventListener("resize", updatePanelPosition);
     };
   }, [loopEngineeringOpen]);
+
+  if (showInfo) return null;
+
+  const handleAction = (id: string) => {
+    if (id === "archive") handleArchive?.();
+    if (id === "info") toggleInfo("Project Info", null);
+  };
+
+  const handleInlineAction = (id: string) => {
+    if (id === "loop-engineering") {
+      if (loopEngineeringOpen) {
+        setLoopEngineeringOpen(false);
+        setLoopPanelStyle(null);
+      } else {
+        setLoopEngineeringOpen(true);
+      }
+    }
+  };
 
   return (
     <div ref={taskbarRef} className={styles.sidekickTaskbarWithPanel}>

--- a/interface/src/shared/api/loop.test.ts
+++ b/interface/src/shared/api/loop.test.ts
@@ -53,6 +53,45 @@ describe("loopApi", () => {
     );
   });
 
+  it("startLoopEngineering sends the loop contract as an optional start body", async () => {
+    const fetchMock = mockFetch(200, loopStatus);
+    globalThis.fetch = fetchMock;
+    const contract = {
+      goal: "Fix checkout retries",
+      successCriteria: ["Retry errors recover", "Build passes"],
+      verifierCommands: [
+        {
+          label: "Tests",
+          command: "npm test -- --run",
+          expectedOutcome: "All tests pass",
+        },
+      ],
+      maxIterations: 4,
+      approvalPolicy: "apply_within_workspace" as const,
+      learning: {
+        captureTrace: true,
+        proposeEvals: true,
+        proposeSkills: true,
+        summarizeRegressions: true,
+      },
+    };
+
+    await loopApi.startLoopEngineering(
+      "p1" as string,
+      { loopEngineering: contract },
+      "ai1",
+      "aura-claude-opus-4-7",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/projects/p1/loop/start?agent_instance_id=ai1&model=aura-claude-opus-4-7",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ loopEngineering: contract }),
+      }),
+    );
+  });
+
   it("pauseLoop sends POST without query param", async () => {
     const fetchMock = mockFetch(204, null);
     globalThis.fetch = fetchMock;

--- a/interface/src/shared/api/loop.ts
+++ b/interface/src/shared/api/loop.ts
@@ -38,6 +38,12 @@ export interface LoopStatusResponse {
   agent_instance_id?: string | null;
   active_agent_instances?: string[];
   /**
+   * Present when the active automation run was started through Loop
+   * Engineering mode. The backend returns the normalized contract so
+   * the UI can show the actual run contract after refresh.
+   */
+  loop_engineering?: LoopEngineeringContract | null;
+  /**
    * Per-agent tasks currently streaming output, populated by the
    * server from the in-memory automaton registry. Used to rehydrate
    * the Run panel rows and the TaskList "live" indicator after a page

--- a/interface/src/shared/api/loop.ts
+++ b/interface/src/shared/api/loop.ts
@@ -47,6 +47,36 @@ export interface LoopStatusResponse {
   active_tasks?: ActiveLoopTask[];
 }
 
+export type LoopEngineeringApprovalPolicy =
+  | "propose_only"
+  | "apply_within_workspace";
+
+export interface LoopEngineeringLearningPolicy {
+  captureTrace: boolean;
+  proposeEvals: boolean;
+  proposeSkills: boolean;
+  summarizeRegressions: boolean;
+}
+
+export interface LoopEngineeringVerifierCommand {
+  label: string;
+  command: string;
+  expectedOutcome?: string;
+}
+
+export interface LoopEngineeringContract {
+  goal: string;
+  successCriteria: string[];
+  verifierCommands: LoopEngineeringVerifierCommand[];
+  maxIterations: number;
+  approvalPolicy: LoopEngineeringApprovalPolicy;
+  learning: LoopEngineeringLearningPolicy;
+}
+
+export interface StartLoopEngineeringRequest {
+  loopEngineering: LoopEngineeringContract;
+}
+
 function loopQuery(agentInstanceId?: string, model?: string | null): string {
   const params = new URLSearchParams();
   if (agentInstanceId) params.set("agent_instance_id", agentInstanceId);
@@ -61,6 +91,18 @@ export const loopApi = {
     return apiFetch<LoopStatusResponse>(
       `/api/projects/${projectId}/loop/start${params}`,
       { method: "POST" },
+    );
+  },
+  startLoopEngineering: (
+    projectId: ProjectId,
+    request: StartLoopEngineeringRequest,
+    agentInstanceId?: string,
+    model?: string | null,
+  ) => {
+    const params = loopQuery(agentInstanceId, model);
+    return apiFetch<LoopStatusResponse>(
+      `/api/projects/${projectId}/loop/start${params}`,
+      { method: "POST", body: JSON.stringify(request) },
     );
   },
   pauseLoop: (projectId: ProjectId, agentInstanceId?: string) => {


### PR DESCRIPTION
## Summary
- Add Loop Engineering as a separate automation mode layered on top of the existing loop system.
- Pass a normalized backend contract for goal, criteria, verifier commands, iteration budget, approval policy, and learning capture.
- Surface Loop Engineering from the AutomationBar and Sidekick taskbar, including active contract rehydration.
- Require final reports and harden prompt rendering by escaping user-supplied contract text.

## Verification
- npm test -- AutomationBar.test.tsx SidekickTaskbar.test.tsx loop.test.ts TypewriterText.test.tsx
- cargo test -p aura-os-server loop_engineering
- cargo test -p aura-os-server loop_status_includes_active_loop_engineering_contract
- npm run build

## Notes
- Rebased onto current main after #67 landed.
- Existing Vite dynamic import warning remains unrelated: TaskOutputPanel is both statically and dynamically imported.