### PR TITLE
Fix observability probe agent cleanup

### DIFF
--- a/apps/aura-os-server/src/handlers/agents/crud/delete.rs
+++ b/apps/aura-os-server/src/handlers/agents/crud/delete.rs
@@ -4,7 +4,7 @@ use axum::Json;
 use futures_util::future::join_all;
 use serde::Serialize;
 
-use aura_os_core::AgentId;
+use aura_os_core::{AgentId, HarnessMode};
 
 use crate::capture_auth::{
     demo_agent_id, demo_agent_instance_id, demo_project, is_capture_access_token,
@@ -26,12 +26,32 @@ pub(crate) async fn delete_agent(
     Path(agent_id): Path<AgentId>,
 ) -> ApiResult<Json<()>> {
     let client = state.require_network_client()?;
+    let network_agent = client
+        .get_agent(&agent_id.to_string(), &jwt)
+        .await
+        .map_err(map_network_error)?;
 
     if let Some(ref storage) = state.storage_client {
         let bindings = resolve_agent_project_bindings(&state, storage, &jwt, &agent_id).await?;
         if !bindings.is_empty() {
             return Err(agent_delete_conflict(&bindings));
         }
+    }
+
+    let machine_type = network_agent.machine_type.as_deref().unwrap_or("local");
+    if HarnessMode::from_machine_type(machine_type) == HarnessMode::Swarm {
+        let swarm_base_url = state.swarm_base_url.as_deref().ok_or_else(|| {
+            ApiError::service_unavailable(
+                "swarm gateway is not configured (SWARM_BASE_URL); cannot delete remote agent",
+            )
+        })?;
+        super::swarm::delete_swarm_agent(
+            client.http_client(),
+            swarm_base_url,
+            &jwt,
+            &network_agent.id,
+        )
+        .await?;
     }
 
     client

--- a/apps/aura-os-server/src/handlers/agents/crud/swarm/mod.rs
+++ b/apps/aura-os-server/src/handlers/agents/crud/swarm/mod.rs
@@ -8,6 +8,7 @@ mod recovery;
 use aura_os_core::Agent;
 
 pub(super) use provision::provision_remote_agent;
+pub(super) use recovery::delete_swarm_agent;
 pub(crate) use recovery::recover_remote_agent_pipeline;
 
 /// Result of (re)provisioning a Swarm machine for an agent. Returned by both

--- a/apps/aura-os-server/src/handlers/agents/crud/swarm/recovery.rs
+++ b/apps/aura-os-server/src/handlers/agents/crud/swarm/recovery.rs
@@ -1,6 +1,7 @@
 use aura_os_network::{NetworkAgent, NetworkClient};
 use axum::http::StatusCode;
 use axum::Json;
+use tokio::time::{sleep, Duration};
 use tracing::info;
 
 use crate::error::{ApiError, ApiResult};
@@ -166,7 +167,7 @@ fn handle_recovery_readiness_error(
     }
 }
 
-async fn delete_swarm_agent(
+pub(crate) async fn delete_swarm_agent(
     http: &reqwest::Client,
     swarm_base_url: &str,
     jwt: &str,
@@ -174,8 +175,40 @@ async fn delete_swarm_agent(
 ) -> ApiResult<()> {
     let url = format!("{}/v1/agents/{}", swarm_base_url, agent_id);
 
+    match send_swarm_delete(http, &url, jwt).await? {
+        SwarmDeleteAttempt::Deleted => return Ok(()),
+        SwarmDeleteAttempt::NeedsStop => {
+            stop_swarm_agent(http, swarm_base_url, jwt, agent_id).await?;
+        }
+    }
+
+    for attempt in 0..12 {
+        if attempt > 0 {
+            sleep(Duration::from_secs(5)).await;
+        }
+        match send_swarm_delete(http, &url, jwt).await? {
+            SwarmDeleteAttempt::Deleted => return Ok(()),
+            SwarmDeleteAttempt::NeedsStop => continue,
+        }
+    }
+
+    Err(ApiError::bad_gateway(
+        "swarm gateway did not finish stopping remote agent before deletion",
+    ))
+}
+
+enum SwarmDeleteAttempt {
+    Deleted,
+    NeedsStop,
+}
+
+async fn send_swarm_delete(
+    http: &reqwest::Client,
+    url: &str,
+    jwt: &str,
+) -> ApiResult<SwarmDeleteAttempt> {
     let resp = http
-        .delete(&url)
+        .delete(url)
         .header("Authorization", format!("Bearer {jwt}"))
         .send()
         .await
@@ -186,17 +219,59 @@ async fn delete_swarm_agent(
         })?;
 
     if resp.status().is_success() || resp.status().as_u16() == 404 {
-        return Ok(());
+        return Ok(SwarmDeleteAttempt::Deleted);
     }
 
     let status = resp.status().as_u16();
     let body = resp.text().await.unwrap_or_default();
+    if status == 409 && swarm_delete_requires_stop(&body) {
+        return Ok(SwarmDeleteAttempt::NeedsStop);
+    }
     Err(match status {
         401 => ApiError::unauthorized("swarm gateway rejected auth token"),
         _ => ApiError::bad_gateway(format!(
             "swarm gateway returned {status} during machine deletion: {body}"
         )),
     })
+}
+
+async fn stop_swarm_agent(
+    http: &reqwest::Client,
+    swarm_base_url: &str,
+    jwt: &str,
+    agent_id: &str,
+) -> ApiResult<()> {
+    let url = format!("{}/v1/agents/{}/stop", swarm_base_url, agent_id);
+    let resp = http
+        .post(&url)
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .map_err(|e| {
+            ApiError::bad_gateway(format!(
+                "swarm gateway unreachable during machine stop: {e}"
+            ))
+        })?;
+    if resp.status().is_success() {
+        return Ok(());
+    }
+    let status = resp.status().as_u16();
+    let body = resp.text().await.unwrap_or_default();
+    if status == 409 && swarm_delete_requires_stop(&body) {
+        return Ok(());
+    }
+    Err(match status {
+        401 => ApiError::unauthorized("swarm gateway rejected auth token"),
+        _ => ApiError::bad_gateway(format!(
+            "swarm gateway returned {status} during machine stop: {body}"
+        )),
+    })
+}
+
+fn swarm_delete_requires_stop(body: &str) -> bool {
+    body.contains("cannot transition from Running to Stopped")
+        || body.contains("cannot transition from Hibernating to Stopped")
+        || body.contains("cannot transition from Stopping to Stopped")
 }
 
 fn broadcast_recovery_phase(state: &AppState, agent_id: &str, phase: &str, error: Option<&str>) {

--- a/apps/aura-os-server/tests/agent_create_test/delete_remote.rs
+++ b/apps/aura-os-server/tests/agent_create_test/delete_remote.rs
@@ -1,0 +1,197 @@
+//! Remote agent deletion must release the swarm-side machine before removing
+//! the Aura/network record, otherwise stale swarm records can keep org quota
+//! exhausted even after the agent disappears from Aura.
+
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::routing::{delete, get, post};
+use axum::Json;
+use axum::Router;
+use tokio::net::TcpListener;
+use tower::ServiceExt;
+
+use aura_os_store::SettingsStore;
+
+use super::common::*;
+use super::mocks::*;
+
+#[tokio::test]
+async fn delete_remote_agent_deletes_swarm_before_network_record() {
+    let store_dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SettingsStore::open(store_dir.path()).unwrap());
+    store_zero_auth_session(&store);
+
+    let calls = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let network_url = start_mock_network_get_delete(
+        network_agent_json("remote", Some("pod-abc-123")),
+        calls.clone(),
+    )
+    .await;
+    let swarm_url = start_mock_swarm_delete(calls.clone()).await;
+
+    let app = build_app_with_swarm(
+        store,
+        store_dir.path().to_path_buf(),
+        &network_url,
+        Some(swarm_url),
+    );
+
+    let req = json_request("DELETE", &format!("/api/agents/{AGENT_UUID}"), None);
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let calls = calls.lock().await;
+    assert_eq!(
+        calls.as_slice(),
+        [
+            format!("network-get:{AGENT_UUID}"),
+            format!("swarm-delete:{AGENT_UUID}"),
+            format!("network-delete:{AGENT_UUID}"),
+        ],
+    );
+}
+
+#[tokio::test]
+async fn delete_remote_agent_stops_running_swarm_agent_before_delete_retry() {
+    let store_dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(SettingsStore::open(store_dir.path()).unwrap());
+    store_zero_auth_session(&store);
+
+    let calls = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let network_url = start_mock_network_get_delete(
+        network_agent_json("remote", Some("pod-abc-123")),
+        calls.clone(),
+    )
+    .await;
+    let swarm_url = start_mock_swarm_delete_requires_stop(calls.clone()).await;
+
+    let app = build_app_with_swarm(
+        store,
+        store_dir.path().to_path_buf(),
+        &network_url,
+        Some(swarm_url),
+    );
+
+    let req = json_request("DELETE", &format!("/api/agents/{AGENT_UUID}"), None);
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let calls = calls.lock().await;
+    assert_eq!(
+        calls.as_slice(),
+        [
+            format!("network-get:{AGENT_UUID}"),
+            format!("swarm-delete:{AGENT_UUID}:1"),
+            format!("swarm-stop:{AGENT_UUID}"),
+            format!("swarm-delete:{AGENT_UUID}:2"),
+            format!("network-delete:{AGENT_UUID}"),
+        ],
+    );
+}
+
+async fn start_mock_network_get_delete(
+    agent_json: serde_json::Value,
+    calls: Arc<tokio::sync::Mutex<Vec<String>>>,
+) -> String {
+    let get_agent_json = agent_json.clone();
+    let get_calls = calls.clone();
+    let delete_calls = calls.clone();
+    let app = Router::new().route(
+        "/api/agents/:agent_id",
+        get(move |Path(agent_id): Path<String>| {
+            let j = get_agent_json.clone();
+            let calls = get_calls.clone();
+            async move {
+                calls.lock().await.push(format!("network-get:{agent_id}"));
+                Json(j)
+            }
+        })
+        .delete(move |Path(agent_id): Path<String>| {
+            let calls = delete_calls.clone();
+            async move {
+                calls
+                    .lock()
+                    .await
+                    .push(format!("network-delete:{agent_id}"));
+                StatusCode::OK
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+    format!("http://{}", addr)
+}
+
+async fn start_mock_swarm_delete_requires_stop(
+    calls: Arc<tokio::sync::Mutex<Vec<String>>>,
+) -> String {
+    let delete_attempts = Arc::new(tokio::sync::Mutex::new(0_u8));
+    let delete_calls = calls.clone();
+    let delete_attempts_for_route = delete_attempts.clone();
+    let stop_calls = calls.clone();
+    let app = Router::new()
+        .route(
+            "/v1/agents/:agent_id",
+            delete(move |Path(agent_id): Path<String>| {
+                let calls = delete_calls.clone();
+                let attempts = delete_attempts_for_route.clone();
+                async move {
+                    let mut attempts = attempts.lock().await;
+                    *attempts += 1;
+                    calls
+                        .lock()
+                        .await
+                        .push(format!("swarm-delete:{agent_id}:{}", *attempts));
+                    if *attempts == 1 {
+                        return (
+                            StatusCode::CONFLICT,
+                            Json(serde_json::json!({
+                                "error": {
+                                    "code": "conflict",
+                                    "message": "conflict: cannot transition from Running to Stopped"
+                                }
+                            })),
+                        );
+                    }
+                    (StatusCode::NO_CONTENT, Json(serde_json::json!({})))
+                }
+            }),
+        )
+        .route(
+            "/v1/agents/:agent_id/stop",
+            post(move |Path(agent_id): Path<String>| {
+                let calls = stop_calls.clone();
+                async move {
+                    calls.lock().await.push(format!("swarm-stop:{agent_id}"));
+                    Json(serde_json::json!({
+                        "agent_id": agent_id,
+                        "status": "stopping"
+                    }))
+                }
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+    format!("http://{}", addr)
+}
+
+async fn start_mock_swarm_delete(calls: Arc<tokio::sync::Mutex<Vec<String>>>) -> String {
+    let app = Router::new().route(
+        "/v1/agents/:agent_id",
+        delete(move |Path(agent_id): Path<String>| {
+            let calls = calls.clone();
+            async move {
+                calls.lock().await.push(format!("swarm-delete:{agent_id}"));
+                StatusCode::OK
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+    format!("http://{}", addr)
+}

--- a/apps/aura-os-server/tests/agent_create_test/main.rs
+++ b/apps/aura-os-server/tests/agent_create_test/main.rs
@@ -4,6 +4,7 @@ mod common;
 
 mod create_local;
 mod create_remote;
+mod delete_remote;
 mod mocks;
 mod recover;
 mod remote_only;

--- a/infra/evals/status/run-status-probes.mjs
+++ b/infra/evals/status/run-status-probes.mjs
@@ -426,10 +426,36 @@ async function withCleanup(args, work) {
     if (args.keepEntities) return;
     for (const item of cleanup.reverse()) {
       try {
-        await apiJson(args, "DELETE", item.endpoint);
+        await cleanupResource(args, item);
       } catch {
         // Cleanup is best-effort; probe result already captured the important failure.
       }
+    }
+  }
+}
+
+async function cleanupResource(args, item) {
+  if (item.resource === "agent") {
+    await removeAgentProjectBindings(args, item.id);
+  }
+  await apiJson(args, "DELETE", item.endpoint);
+}
+
+async function removeAgentProjectBindings(args, agentId) {
+  const bindings = await readOptionalJson(args, `/api/agents/${encodeURIComponent(agentId)}/projects`);
+  if (!bindings.ok) return;
+  for (const binding of collectionItems(bindings.payload)) {
+    const projectAgentId = firstTruthyString(binding, ["project_agent_id", "projectAgentId", "id"]);
+    if (!projectAgentId) continue;
+    try {
+      await apiJson(
+        args,
+        "DELETE",
+        `/api/agents/${encodeURIComponent(agentId)}/projects/${encodeURIComponent(projectAgentId)}`,
+      );
+    } catch {
+      // Best-effort. If a binding cannot be removed, the final agent delete
+      // will fail and withCleanup will swallow it as a cleanup failure.
     }
   }
 }

--- a/infra/evals/status/run-status-probes.test.mjs
+++ b/infra/evals/status/run-status-probes.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+const runnerPath = path.join(__dirname, "run-status-probes.mjs");
+
+test("status probe cleanup removes project bindings before deleting created agents", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "aura-status-probes-"));
+  const requests = [];
+  let bindingRemoved = false;
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    requests.push(`${req.method} ${url.pathname}`);
+
+    if (req.method === "GET" && url.pathname === "/api/orgs") {
+      return sendJson(res, 200, [{ id: "org-1" }]);
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/agents") {
+      await readBody(req);
+      return sendJson(res, 200, {
+        agent_id: "agent-1",
+        machine_type: "local",
+        environment: "local_host",
+      });
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/agents/agent-1/projects") {
+      return sendJson(res, 200, [{
+        project_agent_id: "project-agent-1",
+        project_id: "home",
+        project_name: "Home",
+      }]);
+    }
+
+    if (req.method === "DELETE" && url.pathname === "/api/agents/agent-1/projects/project-agent-1") {
+      bindingRemoved = true;
+      res.writeHead(204).end();
+      return;
+    }
+
+    if (req.method === "DELETE" && url.pathname === "/api/agents/agent-1") {
+      if (!bindingRemoved) {
+        return sendJson(res, 409, { error: "Cannot delete agent while it is added to projects." });
+      }
+      res.writeHead(204).end();
+      return;
+    }
+
+    sendJson(res, 404, { error: `Unhandled ${req.method} ${url.pathname}` });
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.equal(typeof address, "object");
+
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [
+        runnerPath,
+        "--base-url",
+        `http://127.0.0.1:${address.port}`,
+        "--token",
+        "test-token",
+        "--checks",
+        "local-agent-create",
+        "--out-dir",
+        path.join(tmp, "checks"),
+        "--environment",
+        "test",
+        "--runtime-environment",
+        "production-api",
+      ],
+      { cwd: repoRoot },
+    );
+
+    assert.match(stdout, /^pass\s+local-agent-create/m);
+    assert.equal(stderr, "");
+    assert.ok(bindingRemoved, "expected the project binding to be removed");
+
+    const bindingDeleteIndex = requests.indexOf("DELETE /api/agents/agent-1/projects/project-agent-1");
+    const agentDeleteIndex = requests.indexOf("DELETE /api/agents/agent-1");
+    assert.ok(bindingDeleteIndex >= 0, "expected project binding delete request");
+    assert.ok(agentDeleteIndex >= 0, "expected agent delete request");
+    assert.ok(bindingDeleteIndex < agentDeleteIndex, "binding must be removed before deleting the agent");
+  } finally {
+    server.close();
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+async function readBody(req) {
+  let body = "";
+  for await (const chunk of req) body += chunk;
+  return body;
+}


### PR DESCRIPTION
## Summary
- remove project bindings before deleting eval-created status probe agents
- delete swarm-side remote agents before deleting Aura/network agent records
- stop and retry swarm deletion when the gateway reports running/hibernating/stopping state conflicts

## Verification
- cargo test -p aura-os-server --test agent_create_test
- node --test infra/evals/status/*.test.mjs infra/evals/status/lib/*.test.mjs

## Production verification
- cleaned stale eval-owned status probe agents from Aura/network and swarm
- reran remote-agent probes; quota failure is resolved, remaining failure is real swarm scheduling capacity: Insufficient kata.peerpods.io/vm