### PR TITLE
Fix app QA blockers in chat, browser, and tasks

### DIFF
--- a/apps/aura-os-server/src/handlers/tasks/crud.rs
+++ b/apps/aura-os-server/src/handlers/tasks/crud.rs
@@ -1,8 +1,8 @@
-use axum::extract::{Path, State};
 use axum::Json;
+use axum::extract::{Path, State};
 use serde::Deserialize;
 
-use aura_os_core::{ProjectId, Task, TaskId, TaskStatus};
+use aura_os_core::{ProjectId, Spec, Task, TaskId, TaskStatus};
 use aura_os_tasks::TaskService;
 
 use super::common::storage_task_to_task;
@@ -10,6 +10,8 @@ use super::preflight::try_preflight_decompose_task;
 use crate::dto::TransitionTaskRequest;
 use crate::error::{ApiError, ApiResult};
 use crate::state::{AppState, AuthJwt};
+
+const MANUAL_TASKS_SPEC_TITLE: &str = "Manual Tasks";
 
 pub(crate) async fn transition_task(
     State(state): State<AppState>,
@@ -206,7 +208,7 @@ pub(crate) async fn redo_task(
 pub(crate) struct CreateTaskBody {
     pub title: String,
     #[serde(alias = "spec_id")]
-    pub spec_id: String,
+    pub spec_id: Option<String>,
     pub description: Option<String>,
     pub status: Option<String>,
     #[serde(alias = "order_index")]
@@ -230,12 +232,14 @@ pub(crate) async fn create_task(
     let detection_title = req.title.clone();
     let detection_description = req.description.clone().unwrap_or_default();
     let norm_title = req.title.trim().to_lowercase();
+    let spec_id =
+        resolve_create_task_spec_id(storage, &state, &jwt, &project_id, req.spec_id).await?;
 
     if !norm_title.is_empty() {
         match storage.list_tasks(&project_id.to_string(), &jwt).await {
             Ok(existing) => {
                 if let Some(dup) = existing.into_iter().find(|t| {
-                    t.spec_id.as_deref() == Some(req.spec_id.as_str())
+                    t.spec_id.as_deref() == Some(spec_id.as_str())
                         && t.title
                             .as_deref()
                             .map(|title| title.trim().to_lowercase() == norm_title)
@@ -260,7 +264,7 @@ pub(crate) async fn create_task(
             &project_id.to_string(),
             &jwt,
             &aura_os_storage::CreateTaskRequest {
-                spec_id: req.spec_id,
+                spec_id,
                 title: req.title,
                 org_id: None,
                 description: req.description,
@@ -295,6 +299,60 @@ pub(crate) async fn create_task(
     }
 
     Ok(Json(task))
+}
+
+async fn resolve_create_task_spec_id(
+    storage: &aura_os_storage::StorageClient,
+    state: &AppState,
+    jwt: &str,
+    project_id: &ProjectId,
+    requested: Option<String>,
+) -> ApiResult<String> {
+    if let Some(spec_id) = requested.map(|value| value.trim().to_string()) {
+        if !spec_id.is_empty() {
+            return Ok(spec_id);
+        }
+    }
+
+    let specs = storage
+        .list_specs(&project_id.to_string(), jwt)
+        .await
+        .map_err(|e| ApiError::internal(format!("listing specs for manual task: {e}")))?;
+
+    if let Some(existing) = specs
+        .iter()
+        .find(|spec| spec.title.as_deref() == Some(MANUAL_TASKS_SPEC_TITLE))
+    {
+        return Ok(existing.id.clone());
+    }
+
+    let order_index = specs
+        .iter()
+        .filter_map(|spec| spec.order_index)
+        .max()
+        .map_or(0, |max| max + 1);
+    let created = storage
+        .create_spec(
+            &project_id.to_string(),
+            jwt,
+            &aura_os_storage::CreateSpecRequest {
+                title: MANUAL_TASKS_SPEC_TITLE.to_string(),
+                org_id: None,
+                order_index: Some(order_index),
+                markdown_contents: Some("Tasks created directly from the Tasks board.".to_string()),
+            },
+        )
+        .await
+        .map_err(|e| ApiError::internal(format!("creating manual task spec: {e}")))?;
+    let spec = Spec::try_from(created).map_err(ApiError::internal)?;
+    let spec_id = spec.spec_id.to_string();
+    let _ = state.event_broadcast.send(serde_json::json!({
+        "type": "spec_saved",
+        "project_id": project_id.to_string(),
+        "spec": spec,
+        "spec_id": spec_id.clone(),
+    }));
+    Ok(spec_id)
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -589,7 +647,7 @@ mod tests {
         )
         .expect("snake_case body should deserialize");
         assert_eq!(body.title, "T");
-        assert_eq!(body.spec_id, "s");
+        assert_eq!(body.spec_id.as_deref(), Some("s"));
         assert_eq!(body.description.as_deref(), Some("d"));
         assert_eq!(body.order_index, Some(3));
         assert_eq!(
@@ -617,7 +675,7 @@ mod tests {
             }"#,
         )
         .expect("camelCase body should deserialize");
-        assert_eq!(body.spec_id, "s");
+        assert_eq!(body.spec_id.as_deref(), Some("s"));
         assert_eq!(body.order_index, Some(3));
         assert_eq!(body.dependency_ids.as_deref(), Some(&["a".to_string()][..]));
         assert!(body.skip_auto_decompose);
@@ -642,11 +700,26 @@ mod tests {
             }"#,
         )
         .expect("dependencyTaskIds alias should deserialize");
-        assert_eq!(body.spec_id, "s");
+        assert_eq!(body.spec_id.as_deref(), Some("s"));
         assert_eq!(
             body.dependency_ids.as_deref(),
             Some(&["a".to_string(), "b".to_string()][..])
         );
+    }
+
+    #[test]
+    fn create_task_body_allows_missing_spec_id_for_manual_tasks() {
+        let body: CreateTaskBody = serde_json::from_str(
+            r#"{
+                "title": "Manual task",
+                "description": "Created from the task board",
+                "status": "backlog"
+            }"#,
+        )
+        .expect("manual task body should deserialize without a spec id");
+
+        assert_eq!(body.title, "Manual task");
+        assert_eq!(body.spec_id, None);
     }
 
     /// `task_updated` payload pins the wire shape consumed by the

--- a/apps/aura-os-server/tests/api_tests/tasks.rs
+++ b/apps/aura-os-server/tests/api_tests/tasks.rs
@@ -137,6 +137,61 @@ async fn task_routes_support_storage_backed_crud_and_state_changes() {
     assert!(listed.as_array().unwrap().is_empty());
 }
 
+#[tokio::test]
+async fn create_task_without_spec_id_uses_manual_tasks_spec() {
+    let (app, _state, _storage, _db) = build_test_app_with_storage().await;
+    let project_id = ProjectId::new();
+
+    let req = json_request(
+        "POST",
+        &format!("/api/projects/{project_id}/tasks"),
+        Some(serde_json::json!({
+            "title": "Manual board task",
+            "description": "Created directly from the task board",
+            "status": "backlog",
+            "order_index": 0
+        })),
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let created = response_json(resp).await;
+    assert_eq!(created["title"], "Manual board task");
+    let spec_id = created["spec_id"]
+        .as_str()
+        .expect("manual task should receive a backing spec id");
+
+    let req = json_request("GET", &format!("/api/projects/{project_id}/specs"), None);
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let specs = response_json(resp).await;
+    let manual_specs: Vec<_> = specs
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|spec| spec["title"] == "Manual Tasks")
+        .collect();
+    assert_eq!(manual_specs.len(), 1);
+    assert_eq!(manual_specs[0]["spec_id"].as_str(), Some(spec_id));
+
+    let req = json_request(
+        "POST",
+        &format!("/api/projects/{project_id}/tasks"),
+        Some(serde_json::json!({
+            "title": "Second manual task",
+            "status": "backlog",
+            "order_index": 1
+        })),
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let second = response_json(resp).await;
+    assert_eq!(
+        second["spec_id"].as_str(),
+        Some(spec_id),
+        "subsequent manual tasks should reuse the Manual Tasks spec"
+    );
+}
+
 /// User-initiated "Re-do" of a previously completed task. Exercises
 /// the dedicated `done -> ready` edge added in
 /// `docs/migrations/2026-05-25-task-redo-transition.md` and verifies

--- a/crates/aura-os-browser/src/manager.rs
+++ b/crates/aura-os-browser/src/manager.rs
@@ -149,7 +149,12 @@ impl BrowserManager {
                     opts.project_id.as_ref(),
                     &self.config,
                     &ResolveOptions {
-                        allow_active_probe: opts.project_id.is_some(),
+                        // Active probes discover every reachable localhost
+                        // dev server, not the server that belongs to this
+                        // project. Keep probe results advisory for the URL
+                        // picker; automatic startup should only trust pinned,
+                        // terminal-detected, or previously visited URLs.
+                        allow_active_probe: false,
                     },
                 )
                 .await
@@ -435,6 +440,34 @@ mod tests {
         opts.project_id = Some(project);
         let handle = manager.spawn(opts).await.unwrap();
         assert_eq!(manager.project_id_of(handle.id), Some(project));
+    }
+
+    #[tokio::test]
+    async fn project_spawn_does_not_auto_open_arbitrary_probe_port() {
+        use crate::session::discovery::PORT_WHITELIST;
+        let dir = tempdir().unwrap();
+        let manager = BrowserManager::new(test_config(&dir));
+        let _listener = bind_first_available_port(PORT_WHITELIST)
+            .await
+            .expect("at least one whitelisted dev-server port should be bindable in tests");
+
+        let project = ProjectId::new();
+        let mut opts = SpawnOptions::new(1280, 800);
+        opts.project_id = Some(project);
+
+        let handle = manager.spawn(opts).await.unwrap();
+
+        assert_eq!(handle.initial_url, None);
+        assert!(handle.focus_address_bar);
+    }
+
+    async fn bind_first_available_port(ports: &[u16]) -> Option<tokio::net::TcpListener> {
+        for port in ports {
+            if let Ok(listener) = tokio::net::TcpListener::bind(("127.0.0.1", *port)).await {
+                return Some(listener);
+            }
+        }
+        None
     }
 
     #[tokio::test]

--- a/crates/aura-os-browser/src/session/resolver.rs
+++ b/crates/aura-os-browser/src/session/resolver.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 use crate::config::{BrowserConfig, ResolveOptions};
 use crate::session::probe::probe_dev_ports;
-use crate::session::settings::{ProjectBrowserSettings, SettingsStore};
+use crate::session::settings::{DetectionSource, ProjectBrowserSettings, SettingsStore};
 
 /// Outcome of [`resolve_initial_url`]: which URL to navigate to and whether
 /// the UI should focus the address bar on open.
@@ -30,7 +30,7 @@ pub struct ResolvedInitialUrl {
 /// Priority (first hit wins):
 ///
 /// 1. `settings.pinned_url`
-/// 2. Most-recent reachable entry in `settings.detected_urls`
+/// 2. Most-recent reachable non-probe entry in `settings.detected_urls`
 /// 3. Reachable `settings.last_url`
 /// 4. When `opts.allow_active_probe` is true, the first port that accepts a
 ///    TCP connection from [`probe_dev_ports`].
@@ -77,6 +77,9 @@ async fn pick_from_settings(
     }
     let deadline = Instant::now() + config.probe_budget;
     for entry in &settings.detected_urls {
+        if entry.source == DetectionSource::Probe {
+            continue;
+        }
         if Instant::now() >= deadline {
             break;
         }
@@ -208,5 +211,38 @@ mod tests {
         let resolved =
             resolve_initial_url(&store, Some(&project), &config, &ResolveOptions::default()).await;
         assert_eq!(resolved.url, Some(reachable));
+    }
+
+    #[tokio::test]
+    async fn probe_detected_url_is_advisory_for_initial_resolution() {
+        let dir = tempdir().unwrap();
+        let store = SettingsStore::new(dir.path().to_path_buf());
+        let project = ProjectId::new();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let reachable = Url::parse(&format!("http://127.0.0.1:{}/", addr.port())).unwrap();
+
+        store
+            .record_detected(
+                Some(&project),
+                DetectedUrl {
+                    url: reachable,
+                    source: DetectionSource::Probe,
+                    at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let config = BrowserConfig {
+            probe_per_port_timeout: Duration::from_millis(100),
+            probe_budget: Duration::from_millis(500),
+            ..BrowserConfig::default()
+        };
+        let resolved =
+            resolve_initial_url(&store, Some(&project), &config, &ResolveOptions::default()).await;
+        assert_eq!(resolved.url, None);
+        assert!(resolved.focus_address_bar);
     }
 }

--- a/interface/src/apps/tasks/components/AddTaskForm/AddTaskForm.test.tsx
+++ b/interface/src/apps/tasks/components/AddTaskForm/AddTaskForm.test.tsx
@@ -1,0 +1,219 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import type { ProjectActions } from "../../../../stores/project-action-store";
+import { useProjectActionStore } from "../../../../stores/project-action-store";
+import { useProjectsListStore } from "../../../../stores/projects-list-store";
+import { tasksApi } from "../../../../shared/api/tasks";
+import { emptyAgentPermissions } from "../../../../shared/types/permissions-wire";
+import type { AgentInstance, Project, Task } from "../../../../shared/types";
+import { AddTaskForm } from "./AddTaskForm";
+
+vi.mock("@cypher-asi/zui", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children?: ReactNode;
+    footer?: ReactNode;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        {children}
+        {footer}
+      </div>
+    ) : null,
+  Button: ({
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  Toggle: ({
+    checked,
+    label,
+    onChange,
+  }: {
+    checked: boolean;
+    label: string;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  }) => (
+    <label>
+      {label}
+      <input type="checkbox" checked={checked} onChange={onChange} />
+    </label>
+  ),
+  Spinner: () => <span data-testid="spinner" />,
+}));
+
+vi.mock("../../../../shared/api/tasks", () => ({
+  tasksApi: {
+    createTask: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+const project: Project = {
+  project_id: "project-1",
+  org_id: "org-1",
+  name: "Project",
+  description: "",
+  current_status: "active",
+  created_at: "2026-06-19T00:00:00.000Z",
+  updated_at: "2026-06-19T00:00:00.000Z",
+};
+
+const builderAgent: AgentInstance = {
+  agent_id: "agent-template-1",
+  agent_instance_id: "agent-1",
+  project_id: "project-1",
+  name: "Builder",
+  role: "Engineer",
+  personality: "",
+  system_prompt: "",
+  skills: [],
+  icon: null,
+  machine_type: "local",
+  adapter_type: "local",
+  environment: "desktop",
+  status: "idle",
+  current_task_id: null,
+  current_session_id: null,
+  total_input_tokens: 0,
+  total_output_tokens: 0,
+  permissions: emptyAgentPermissions(),
+  created_at: "2026-06-19T00:00:00.000Z",
+  updated_at: "2026-06-19T00:00:00.000Z",
+};
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    task_id: "task-1",
+    project_id: "project-1",
+    spec_id: "manual-spec",
+    title: "Task",
+    description: "",
+    status: "backlog",
+    order_index: 1,
+    dependency_ids: [],
+    parent_task_id: null,
+    assigned_agent_instance_id: null,
+    completed_by_agent_instance_id: null,
+    session_id: null,
+    execution_notes: "",
+    files_changed: [],
+    live_output: "",
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    created_at: "2026-06-19T00:00:00.000Z",
+    updated_at: "2026-06-19T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function registerProjectActions(overrides: Partial<ProjectActions> = {}) {
+  useProjectActionStore.setState({
+    actions: {
+      project,
+      setProject: vi.fn(),
+      message: "",
+      handleArchive: vi.fn(),
+      navigateToExecution: vi.fn(),
+      initialSpecs: [],
+      initialTasks: [],
+      ...overrides,
+    },
+  });
+}
+
+describe("AddTaskForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerProjectActions();
+    useProjectsListStore.setState({
+      agentsByProject: {
+        "project-1": [builderAgent],
+      },
+    });
+    vi.mocked(tasksApi.createTask).mockResolvedValue(makeTask());
+  });
+
+  it("allows creating a manual task when the project has no specs", async () => {
+    const onDone = vi.fn();
+    render(
+      <AddTaskForm
+        isOpen
+        projectId="project-1"
+        status="backlog"
+        onDone={onDone}
+        onStatusChange={vi.fn()}
+      />,
+    );
+
+    const createButton = screen.getByRole("button", { name: "Create Task" });
+    expect(createButton).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText("Task title"), {
+      target: { value: "Add metrics component coverage" },
+    });
+
+    expect(createButton).toBeEnabled();
+    fireEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(tasksApi.createTask).toHaveBeenCalledTimes(1);
+    });
+    const [, body] = vi.mocked(tasksApi.createTask).mock.calls[0];
+    expect(body).toMatchObject({
+      title: "Add metrics component coverage",
+      status: "backlog",
+    });
+    expect(body).not.toHaveProperty("spec_id");
+    await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps sending the selected spec id when specs exist", async () => {
+    registerProjectActions({
+      initialSpecs: [
+        {
+          spec_id: "spec-1",
+          project_id: "project-1",
+          title: "Plan",
+          order_index: 0,
+          markdown_contents: "",
+          created_at: "2026-06-19T00:00:00.000Z",
+          updated_at: "2026-06-19T00:00:00.000Z",
+        },
+      ],
+    });
+    render(
+      <AddTaskForm
+        isOpen
+        projectId="project-1"
+        status="to_do"
+        onDone={vi.fn()}
+        onStatusChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Task title"), {
+      target: { value: "Implement plan task" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Task" }));
+
+    await waitFor(() => {
+      expect(tasksApi.createTask).toHaveBeenCalledWith(
+        "project-1",
+        expect.objectContaining({ spec_id: "spec-1" }),
+      );
+    });
+  });
+});

--- a/interface/src/apps/tasks/components/AddTaskForm/AddTaskForm.tsx
+++ b/interface/src/apps/tasks/components/AddTaskForm/AddTaskForm.tsx
@@ -15,6 +15,8 @@ const STATUS_OPTIONS = [
   { value: "to_do", label: "To Do" },
 ];
 
+const PENDING_MANUAL_SPEC_ID = "pending-manual-task-spec";
+
 interface AddTaskFormProps {
   isOpen: boolean;
   projectId: string;
@@ -71,14 +73,14 @@ export function AddTaskForm({
   const handleSubmit = useCallback(async () => {
     const trimmed = title.trim();
     if (!trimmed || submitting) return;
-    if (specs.length === 0) return;
+    const specId = specs[0]?.spec_id;
 
     const optimisticTaskId = `pending-task-${crypto.randomUUID()}`;
     const now = new Date().toISOString();
     const optimisticTask: Task = {
       task_id: optimisticTaskId,
       project_id: projectId,
-      spec_id: specs[0].spec_id,
+      spec_id: specId ?? PENDING_MANUAL_SPEC_ID,
       title: trimmed,
       description: description.trim(),
       status,
@@ -103,7 +105,7 @@ export function AddTaskForm({
     try {
       const task = await tasksApi.createTask(projectId, {
         title: trimmed,
-        spec_id: specs[0].spec_id,
+        ...(specId ? { spec_id: specId } : {}),
         description: description.trim() || undefined,
         status,
         assigned_agent_instance_id: assignee || undefined,
@@ -195,7 +197,7 @@ export function AddTaskForm({
               variant="primary"
               size="sm"
               onClick={handleSubmit}
-              disabled={!title.trim() || submitting || specs.length === 0}
+              disabled={!title.trim() || submitting}
             >
               {submitting ? <><Spinner size="sm" /> Creating...</> : "Create Task"}
             </Button>

--- a/interface/src/components/InputBarShell/InputBarShell.test.tsx
+++ b/interface/src/components/InputBarShell/InputBarShell.test.tsx
@@ -46,6 +46,17 @@ function stubMirrorHeights(heights: { content: number; baseline: number }) {
 }
 
 describe("InputBarShell", () => {
+  it("opts the prompt textarea out of smart text rewriting", () => {
+    const { container } = render(<InputBarShell {...makeProps()} />);
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    expect(textarea!.getAttribute("autocomplete")).toBe("off");
+    expect(textarea!.getAttribute("autocorrect")).toBe("off");
+    expect(textarea!.getAttribute("autocapitalize")).toBe("off");
+    expect(textarea!.getAttribute("spellcheck")).toBe("false");
+  });
+
   it("keeps the start slot, end slot, and send button inline while the value fits one line", () => {
     // Default JSDOM: mirror scrollHeights are 0, so the content mirror
     // never exceeds the baseline → single-line layout.

--- a/interface/src/components/InputBarShell/InputBarShell.tsx
+++ b/interface/src/components/InputBarShell/InputBarShell.tsx
@@ -449,6 +449,9 @@ function InputBarShellInner(
           {isMultiLine ? null : inputRowStart}
           <textarea
             autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
             {...textareaProps}
             ref={textareaRef}
             className={styles.textarea}

--- a/interface/src/shared/api/tasks.ts
+++ b/interface/src/shared/api/tasks.ts
@@ -17,7 +17,7 @@ function runTaskQuery(agentInstanceId?: string, model?: string | null): string {
 export const tasksApi = {
   listTasks: (projectId: ProjectId) =>
     apiFetch<Task[]>(`/api/projects/${projectId}/tasks`),
-  createTask: (projectId: ProjectId, body: { title: string; spec_id: string; description?: string; status?: "backlog" | "to_do"; order_index?: number; assigned_agent_instance_id?: string }) =>
+  createTask: (projectId: ProjectId, body: { title: string; spec_id?: string; description?: string; status?: "backlog" | "to_do"; order_index?: number; assigned_agent_instance_id?: string }) =>
     apiFetch<Task>(`/api/projects/${projectId}/tasks`, {
       method: "POST",
       body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
- Preserve literal prompt text in chat sends instead of normalizing user punctuation.
- Avoid stale browser probe URLs becoming defaults when launching previews.
- Allow creating board tasks when a project has no specs by creating/reusing a backing Manual Tasks spec.

## Verification
- Reproduced the no-spec task blocker in the installed Aura macOS app with Computer Use: title, description, and assignee were filled but Create Task stayed disabled.
- `npm test -- AddTaskForm.test.tsx TasksProjectList.test.tsx kanban-store.test.ts` from `interface/`.
- `cargo test -p aura-os-server create_task`.

## Notes
- Installed app updater is currently latest at `0.1.0-nightly.699.1` / `cca0fdfc6d69`, which predates this branch. Real macOS verification of this fix requires a new release/nightly after merge.