### PR TITLE
Persist project agent archive status

### DIFF
--- a/crates/aura-os-agents/src/instance.rs
+++ b/crates/aura-os-agents/src/instance.rs
@@ -540,6 +540,7 @@ impl AgentInstanceService {
                 | (AgentStatus::Idle, AgentStatus::Stopped)
                 | (AgentStatus::Stopped, AgentStatus::Idle)
                 | (AgentStatus::Error, AgentStatus::Idle)
+                | (AgentStatus::Archived, AgentStatus::Idle)
                 | (_, AgentStatus::Archived)
         );
         if legal {

--- a/crates/aura-os-agents/src/instance/tests.rs
+++ b/crates/aura-os-agents/src/instance/tests.rs
@@ -78,6 +78,14 @@ fn pick_loop_template_returns_none_for_empty_slice() {
     assert!(pick_loop_template_from_instances(&[]).is_none());
 }
 
+#[test]
+fn validate_transition_allows_restoring_archived_instance() {
+    assert!(
+        AgentInstanceService::validate_transition(AgentStatus::Archived, AgentStatus::Idle)
+            .is_ok()
+    );
+}
+
 fn service_with_temp_store() -> (AgentInstanceService, tempfile::TempDir) {
     let dir = tempfile::tempdir().expect("create tempdir");
     let store = Arc::new(SettingsStore::open(dir.path()).expect("open settings store"));

--- a/interface/src/components/ProjectList/ProjectList.test.tsx
+++ b/interface/src/components/ProjectList/ProjectList.test.tsx
@@ -9,6 +9,7 @@ let latestSelectedId: string | null = null;
 type MockTreeNode = {
   id: string;
   label: string;
+  status?: React.ReactNode;
   children?: MockTreeNode[];
 };
 
@@ -58,6 +59,7 @@ vi.mock("../ListTree", () => ({
           return (
             <div key={node.id}>
               <span>{node.label}</span>
+              {node.status}
               {node.children?.map(renderNode)}
             </div>
           );
@@ -221,7 +223,13 @@ function renderList(path = "/projects") {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  localStorage.clear();
+  if (typeof localStorage.clear === "function") {
+    localStorage.clear();
+  } else {
+    for (const key of Object.keys(localStorage)) {
+      localStorage.removeItem(key);
+    }
+  }
   autoSelectDefaultIds = false;
   latestSelectedId = null;
   mockChatHandoffState.pendingCreateAgentHandoff = null;
@@ -285,6 +293,7 @@ describe("ProjectList", () => {
     expect(screen.getByText("No agents yet")).toBeInTheDocument();
     expect(screen.getByText("Archived")).toBeInTheDocument();
     expect(screen.getByText("Archived Agent")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restore Archived Agent" })).toBeInTheDocument();
   });
 
   it("moves an archived agent out of its project children when project data updates", () => {

--- a/interface/src/components/ProjectList/project-list-explorer-node.tsx
+++ b/interface/src/components/ProjectList/project-list-explorer-node.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from "react";
-import { Archive, Folder, FolderOpen, Gauge, Loader2 } from "lucide-react";
+import { Archive, ArchiveRestore, Folder, FolderOpen, Gauge, Loader2 } from "lucide-react";
 import { Avatar } from "../Avatar";
 import { ProjectsPlusButton } from "../ProjectsPlusButton";
 import type { ListTreeNode } from "../ListTree";
@@ -130,9 +130,11 @@ export function buildAgentNode(
       <span className={explorerStyles.streamingDot} />
     </span>
   ) : null;
-  const canArchive = agent.status !== "archived";
+  const isArchived = agent.status === "archived";
   const isArchiving = context.archivingAgentInstanceIds.includes(agent.agent_instance_id);
   const displayName = agentDisplayName(agent.name);
+  const archiveActionLabel = isArchived ? "Restore" : "Archive";
+  const ArchiveActionIcon = isArchived ? ArchiveRestore : Archive;
 
   return {
     id: agent.agent_instance_id,
@@ -147,38 +149,36 @@ export function buildAgentNode(
         isLocal={isLocal}
       />
     ),
-    status: canArchive || statusIndicator ? (
+    status: (
       <span className={explorerStyles.agentTrailing}>
         <span className={explorerStyles.agentStatusWrap}>
           {statusIndicator}
         </span>
-        {canArchive ? (
-          <span className={explorerStyles.agentActionWrap}>
-            <span
-              role="button"
-              tabIndex={isArchiving ? -1 : 0}
-              className={explorerStyles.agentActionButton}
-              onClick={(event) =>
-                activateArchiveAction(event, () => context.handleArchiveAgent(agent), isArchiving)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  activateArchiveAction(
-                    event,
-                    () => context.handleArchiveAgent(agent),
-                    isArchiving,
-                  );
-                }
-              }}
-              aria-label={`Archive ${displayName}`}
-              aria-disabled={isArchiving}
-              title="Archive agent"
-            >
-              <Archive size={12} />
-            </span>
+        <span className={explorerStyles.agentActionWrap}>
+          <span
+            role="button"
+            tabIndex={isArchiving ? -1 : 0}
+            className={explorerStyles.agentActionButton}
+            onClick={(event) =>
+              activateArchiveAction(event, () => context.handleArchiveAgent(agent), isArchiving)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                activateArchiveAction(
+                  event,
+                  () => context.handleArchiveAgent(agent),
+                  isArchiving,
+                );
+              }
+            }}
+            aria-label={`${archiveActionLabel} ${displayName}`}
+            aria-disabled={isArchiving}
+            title={`${archiveActionLabel} agent`}
+          >
+            <ArchiveActionIcon size={12} />
           </span>
-        ) : null}
+        </span>
       </span>
-    ) : undefined,
+    ),
     metadata: { type: "agent", projectId },
   };
 }

--- a/interface/src/hooks/use-project-list-actions.test.tsx
+++ b/interface/src/hooks/use-project-list-actions.test.tsx
@@ -229,7 +229,7 @@ describe("useProjectListActions", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("handleArchiveAgent archives the target instance locally", async () => {
+  it("handleArchiveAgent optimistically archives the target instance locally", async () => {
     mockAgentsByProject = {
       "p-2": [
         {
@@ -262,7 +262,9 @@ describe("useProjectListActions", () => {
       });
     });
 
-    expect(api.updateAgentInstance).not.toHaveBeenCalled();
+    expect(api.updateAgentInstance).toHaveBeenCalledWith("p-2", "ai-2", {
+      status: "archived",
+    });
     expect(mockSetAgentsByProject).toHaveBeenCalled();
     const updater = mockSetAgentsByProject.mock.calls[0]?.[0] as
       | ((prev: typeof mockAgentsByProject) => typeof mockAgentsByProject)
@@ -270,6 +272,143 @@ describe("useProjectListActions", () => {
     expect(updater).toBeTypeOf("function");
     const nextState = updater?.(mockAgentsByProject);
     expect(nextState?.["p-2"]?.[0]?.status).toBe("archived");
+  });
+
+  it("handleArchiveAgent persists the archive status to the server", async () => {
+    mockAgentsByProject = {
+      "p-2": [
+        {
+          agent_instance_id: "ai-2",
+          project_id: "p-2",
+          status: "idle",
+        },
+      ],
+    };
+    const { result } = renderHook(() => useProjectListActions(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleArchiveAgent({
+        agent_instance_id: "ai-2",
+        project_id: "p-2",
+        agent_id: "a-2",
+        name: "Agent",
+        role: "dev",
+        personality: "",
+        system_prompt: "",
+        skills: [],
+        icon: null,
+        status: "idle",
+        current_task_id: null,
+        current_session_id: null,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        created_at: "",
+        updated_at: "",
+      });
+    });
+
+    expect(api.updateAgentInstance).toHaveBeenCalledWith("p-2", "ai-2", {
+      status: "archived",
+    });
+  });
+
+  it("handleArchiveAgent rolls back the optimistic archive when persistence fails", async () => {
+    mockAgentsByProject = {
+      "p-2": [
+        {
+          agent_instance_id: "ai-2",
+          project_id: "p-2",
+          status: "idle",
+        },
+      ],
+    };
+    (api.updateAgentInstance as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("fail"));
+    const { result } = renderHook(() => useProjectListActions(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleArchiveAgent({
+        agent_instance_id: "ai-2",
+        project_id: "p-2",
+        agent_id: "a-2",
+        name: "Agent",
+        role: "dev",
+        personality: "",
+        system_prompt: "",
+        skills: [],
+        icon: null,
+        status: "idle",
+        current_task_id: null,
+        current_session_id: null,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        created_at: "",
+        updated_at: "",
+      });
+    });
+
+    expect(api.updateAgentInstance).toHaveBeenCalledWith("p-2", "ai-2", {
+      status: "archived",
+    });
+    const rollback = mockSetAgentsByProject.mock.calls.at(-1)?.[0] as
+      | ((prev: typeof mockAgentsByProject) => typeof mockAgentsByProject)
+      | undefined;
+    expect(rollback?.({ "p-2": [] })).toEqual(mockAgentsByProject);
+  });
+
+  it("handleArchiveAgent restores an archived instance through the server", async () => {
+    mockAgentsByProject = {
+      "p-2": [
+        {
+          agent_instance_id: "ai-2",
+          project_id: "p-2",
+          status: "archived",
+        },
+      ],
+    };
+    (api.updateAgentInstance as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      agent_instance_id: "ai-2",
+      project_id: "p-2",
+      agent_id: "a-2",
+      name: "Restored Agent",
+      role: "dev",
+      personality: "",
+      system_prompt: "",
+      skills: [],
+      icon: null,
+      status: "idle",
+      current_task_id: null,
+      current_session_id: null,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      created_at: "",
+      updated_at: "",
+    });
+    const { result } = renderHook(() => useProjectListActions(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleArchiveAgent({
+        agent_instance_id: "ai-2",
+        project_id: "p-2",
+        agent_id: "a-2",
+        name: "Agent",
+        role: "dev",
+        personality: "",
+        system_prompt: "",
+        skills: [],
+        icon: null,
+        status: "archived",
+        current_task_id: null,
+        current_session_id: null,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        created_at: "",
+        updated_at: "",
+      });
+    });
+
+    expect(api.updateAgentInstance).toHaveBeenCalledWith("p-2", "ai-2", {
+      status: "idle",
+    });
   });
 
   it("surfaces the unwrapped conflict message when deleting a project with agents", async () => {

--- a/interface/src/hooks/use-project-list-actions.ts
+++ b/interface/src/hooks/use-project-list-actions.ts
@@ -247,25 +247,47 @@ export function useProjectListActions() {
       return;
     }
 
+    const nextStatus: AgentInstance["status"] = target.status === "archived" ? "idle" : "archived";
     const optimisticUpdatedAt = new Date().toISOString();
-    const archivedAgent: AgentInstance = {
+    const optimisticAgent: AgentInstance = {
       ...target,
-      status: "archived",
+      status: nextStatus,
       updated_at: optimisticUpdatedAt,
     };
+    const prevAgents = agentsByProject[pid];
     setArchivingAgentInstanceIds((prev) => [...prev, aid]);
     setAgentsByProject((prev) => ({
       ...prev,
       [pid]: (prev[pid] ?? []).map((agent) =>
         agent.agent_instance_id === aid
-          ? { ...agent, status: "archived", updated_at: optimisticUpdatedAt }
+          ? { ...agent, status: nextStatus, updated_at: optimisticUpdatedAt }
           : agent,
       ),
     }));
 
-    queryClient.setQueryData(projectQueryKeys.agentInstance(pid, aid), archivedAgent);
-    setArchivingAgentInstanceIds((prev) => prev.filter((id) => id !== aid));
-  }, [setAgentsByProject]);
+    queryClient.setQueryData(projectQueryKeys.agentInstance(pid, aid), optimisticAgent);
+    try {
+      const updated = await api.updateAgentInstance(pid, aid, { status: nextStatus });
+      queryClient.setQueryData(projectQueryKeys.agentInstance(pid, aid), updated);
+      setAgentsByProject((prev) => ({
+        ...prev,
+        [pid]: mergeAgentIntoProjectAgents(prev[pid], updated),
+      }));
+    } catch (err) {
+      console.error(
+        nextStatus === "archived"
+          ? "Failed to archive agent instance"
+          : "Failed to restore agent instance",
+        err,
+      );
+      queryClient.setQueryData(projectQueryKeys.agentInstance(pid, aid), target);
+      if (prevAgents) {
+        setAgentsByProject((prev) => ({ ...prev, [pid]: prevAgents }));
+      }
+    } finally {
+      setArchivingAgentInstanceIds((prev) => prev.filter((id) => id !== aid));
+    }
+  }, [agentsByProject, setAgentsByProject]);
 
   const handleProjectSaved = useCallback(
     (project: Project) => {

--- a/interface/src/queries/project-queries.test.ts
+++ b/interface/src/queries/project-queries.test.ts
@@ -137,7 +137,29 @@ describe("project-queries agent merging", () => {
     });
   });
 
-  it("preserves archived status against a newer non-archived update", () => {
+  it("preserves archived status against a stale non-archived update", () => {
+    const merged = mergeAgentIntoProjectAgents(
+      [
+        makeAgent({
+          status: "archived",
+          updated_at: "2026-04-13T10:00:05.000Z",
+        }),
+      ],
+      {
+        agent_instance_id: "ai-1",
+        project_id: "p-1",
+        status: "idle",
+        updated_at: "2026-04-13T10:00:04.000Z",
+      },
+    );
+
+    expect(merged[0]).toMatchObject({
+      status: "archived",
+      updated_at: "2026-04-13T10:00:05.000Z",
+    });
+  });
+
+  it("accepts a newer server unarchive update", () => {
     const merged = mergeAgentIntoProjectAgents(
       [
         makeAgent({
@@ -154,7 +176,7 @@ describe("project-queries agent merging", () => {
     );
 
     expect(merged[0]).toMatchObject({
-      status: "archived",
+      status: "idle",
       updated_at: "2026-04-13T10:00:10.000Z",
     });
   });

--- a/interface/src/queries/project-queries.ts
+++ b/interface/src/queries/project-queries.ts
@@ -256,7 +256,8 @@ export function mergeAgentUpdate(
   if (incomingUpdate.status !== undefined) {
     const preserveArchivedStatus =
       currentAgent.status === "archived" &&
-      incomingUpdate.status !== "archived";
+      incomingUpdate.status !== "archived" &&
+      updatedAtComparison !== 1;
     if (!preserveArchivedStatus && updatedAtComparison !== -1) {
       nextAgent.status = incomingUpdate.status;
     }


### PR DESCRIPTION
## Summary
- persist project-sidebar archive/restore actions through `api.updateAgentInstance` instead of client-only state
- keep optimistic UI updates with rollback and authoritative server merge
- allow archived agent instances to transition back to idle for restore

## Validation
- `npm --prefix interface run test -- src/hooks/use-project-list-actions.test.tsx src/queries/project-queries.test.ts src/components/ProjectList/ProjectList.test.tsx`
- `cargo test -p aura-os-agents`
- `npm --prefix interface run build`