### PR TITLE
fix(left-menu): restore right-click context menu in LeftMenuTree

### DIFF
--- a/interface/src/features/left-menu/LeftMenuTree/LeftMenuTreeRows.tsx
+++ b/interface/src/features/left-menu/LeftMenuTree/LeftMenuTreeRows.tsx
@@ -51,6 +51,7 @@ function LeftMenuLeafRow({
   return (
     <button
       id={entry.id}
+      data-list-item=""
       type="button"
       className={className}
       aria-selected={entry.selected}
@@ -135,6 +136,7 @@ function LeftMenuGroup({
       >
         <button
           id={entry.id}
+          data-list-item=""
           type="button"
           className={buttonClassName}
           aria-expanded={entry.expanded}


### PR DESCRIPTION
## Problem

Right-click in the **Projects** sidebar does nothing — no context menu appears, so there's no way to **Remove from Project** (delete), **Rename**, **Add Agent**, or **Delete Project**, and F2-to-rename is also dead.

### Root cause

The projects sidebar was migrated from the legacy `ListItem`-based tree to `LeftMenuTree`, but the context-menu / keyboard handler in `useExplorerMenus` still resolves the clicked row with:

```ts
const target = (e.target as HTMLElement).closest("[data-list-item][id]");
if (!target) return;
```

The legacy `ListItem` emits `data-list-item=""` (`components/ListItem/ListItem.tsx`), but `LeftMenuTree`'s row buttons (`LeftMenuTreeRows.tsx`) render only `id={entry.id}` / `data-testid` — never `data-list-item`. The selector requires **both** `data-list-item` and `[id]` on the same element, so it never matches: `handleContextMenu` (and the F2 `handleKeyDown`) return early before `preventDefault` / opening the menu. The context menu is effectively dead in any surface that renders via `LeftMenuTree` (e.g. the desktop Projects nav).

A side effect: archived agents can't be deleted from the UI at all — the inline control is only Archive/Restore, and the full-delete action lives behind the broken right-click.

## Fix

Add `data-list-item=""` to both `LeftMenuTree` row buttons — the leaf/agent rows and the project/section group headers — so the existing `closest("[data-list-item][id]")` selector matches and `handleContextMenu` / `handleKeyDown` can resolve the node (`projectMap` / `agentMeta`) again. No handler or selector changes; this just restores the DOM contract the handler already expects.

`agentMeta` already includes archived agents (built from all `agentsByProject` with no status filter), so this also restores the delete path for archived agents.

## Testing

- Manually verified: right-click on project rows, active agent rows, and archived agent rows now opens the context menu; **Remove from Project** and **Rename** work; F2-rename works.
- `npm run build` (`tsc -b && vite build`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
