### PR TITLE
Add usage signal analytics with billing enrichment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "aura-os-store",
  "aura-os-tasks",
  "aura-os-terminal",
+ "aura-os-usage-signals",
  "aura-protocol",
  "aura-run-heuristics",
  "axum",
@@ -814,6 +815,13 @@ dependencies = [
  "tracing",
  "uuid",
  "which 7.0.3",
+]
+
+[[package]]
+name = "aura-os-usage-signals"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/aura-os-store",
     "crates/aura-os-tasks",
     "crates/aura-os-terminal",
+    "crates/aura-os-usage-signals",
     "crates/aura-protocol",
     "crates/aura-loop-log-schema",
     "crates/aura-run-heuristics",

--- a/apps/aura-os-server/Cargo.toml
+++ b/apps/aura-os-server/Cargo.toml
@@ -26,6 +26,7 @@ aura-os-tasks = { path = "../../crates/aura-os-tasks" }
 aura-os-sessions = { path = "../../crates/aura-os-sessions" }
 aura-os-harness = { path = "../../crates/aura-os-harness" }
 aura-os-terminal = { path = "../../crates/aura-os-terminal" }
+aura-os-usage-signals = { path = "../../crates/aura-os-usage-signals" }
 aura-os-browser = { path = "../../crates/aura-os-browser" }
 aura-protocol = { path = "../../crates/aura-protocol" }
 aura-os-network = { path = "../../crates/aura-os-network" }

--- a/apps/aura-os-server/src/auth_guard/mod.rs
+++ b/apps/aura-os-server/src/auth_guard/mod.rs
@@ -149,7 +149,7 @@ pub(crate) async fn require_verified_session(
 /// usable public IP is present (including loopback), so we never ask
 /// Mixpanel to geolocate the server itself — those events should simply
 /// carry no geo rather than a misleading one.
-fn client_ip_from_headers(headers: &axum::http::HeaderMap) -> Option<String> {
+pub(crate) fn client_ip_from_headers(headers: &axum::http::HeaderMap) -> Option<String> {
     let parse = |raw: &str| raw.trim().parse::<std::net::IpAddr>().ok();
 
     let candidate = headers

--- a/apps/aura-os-server/src/handlers/agents/chat/agent_route/mod.rs
+++ b/apps/aura-os-server/src/handlers/agents/chat/agent_route/mod.rs
@@ -287,6 +287,57 @@ pub(crate) async fn send_agent_event_stream(
     .await;
 
     let (computer_use, computer_executor_url) = computer_use_session_fields();
+    let local_project_counts =
+        crate::usage_signals::local_project_counts(&state, effective_org_id.as_ref());
+    let binding_source = persist_ctx
+        .as_ref()
+        .map(|ctx| {
+            crate::usage_signals::binding_source_from_project_agents(
+                &ctx.project_agent_id,
+                &matching,
+            )
+        })
+        .unwrap_or(crate::usage_signals::AgentBindingSource::Unknown);
+    let has_explicit_project_id = body
+        .project_id
+        .as_deref()
+        .map(|pid| !pid.trim().is_empty())
+        .unwrap_or(false);
+    let usage_signal_context = Some(crate::usage_signals::UsageSignalContext {
+        user_id: auth_session.user_id.clone(),
+        turn_started_at: std::time::Instant::now(),
+        route_kind: crate::usage_signals::TurnRouteKind::BareAgent,
+        binding_source,
+        // ZeroAuthSession::created_at is auth validation time, not account creation time.
+        account_age_days: None,
+        is_zero_pro: Some(auth_session.is_zero_pro),
+        is_access_granted: Some(auth_session.is_access_granted),
+        local_project_count: local_project_counts.local_project_count,
+        same_org_project_count: local_project_counts.same_org_project_count,
+        has_project_context: effective_project_id.is_some(),
+        has_user_project_instance: crate::usage_signals::user_visible_binding(binding_source),
+        is_auto_home_only: matches!(
+            binding_source,
+            crate::usage_signals::AgentBindingSource::AutoHome
+        ) && !has_explicit_project_id,
+        is_plan_mode,
+        is_cross_agent: body
+            .originating_agent_id
+            .as_deref()
+            .map(|id| !id.trim().is_empty())
+            .unwrap_or(false)
+            || body
+                .from_agent_id
+                .as_deref()
+                .map(|id| !id.trim().is_empty())
+                .unwrap_or(false),
+        is_council: active_council.is_some(),
+        is_new_session: force_new,
+        attachment_count: crate::usage_signals::attachment_count(&body.attachments),
+        installed_tool_count: crate::usage_signals::option_vec_len(&installed_tools),
+        installed_integration_count: crate::usage_signals::option_vec_len(&installed_integrations),
+        client_ip_hash: crate::usage_signals::client_ip_hash_from_headers(&headers),
+    });
     let config = SessionConfig {
         agent_id: Some(partition_agent_id),
         template_agent_id: Some(agent_id.to_string()),
@@ -335,6 +386,7 @@ pub(crate) async fn send_agent_event_stream(
             commands: body.commands,
             fork_info,
             is_plan_mode,
+            usage_signal_context,
         },
     )
     .await

--- a/apps/aura-os-server/src/handlers/agents/chat/instance_route/route.rs
+++ b/apps/aura-os-server/src/handlers/agents/chat/instance_route/route.rs
@@ -288,6 +288,45 @@ pub(crate) async fn send_event_stream(
     );
 
     let (computer_use, computer_executor_url) = computer_use_session_fields();
+    let local_project_counts =
+        crate::usage_signals::local_project_counts(&state, effective_org_id.as_ref());
+    let binding_source =
+        crate::usage_signals::AgentBindingSource::from_wire(instance.source.as_deref());
+    let usage_signal_context = Some(crate::usage_signals::UsageSignalContext {
+        user_id: auth_session.user_id.clone(),
+        turn_started_at: std::time::Instant::now(),
+        route_kind: crate::usage_signals::TurnRouteKind::ProjectAgent,
+        binding_source,
+        // ZeroAuthSession::created_at is auth validation time, not account creation time.
+        account_age_days: None,
+        is_zero_pro: Some(auth_session.is_zero_pro),
+        is_access_granted: Some(auth_session.is_access_granted),
+        local_project_count: local_project_counts.local_project_count,
+        same_org_project_count: local_project_counts.same_org_project_count,
+        has_project_context: true,
+        has_user_project_instance: crate::usage_signals::user_visible_binding(binding_source),
+        is_auto_home_only: matches!(
+            binding_source,
+            crate::usage_signals::AgentBindingSource::AutoHome
+        ),
+        is_plan_mode,
+        is_cross_agent: body
+            .originating_agent_id
+            .as_deref()
+            .map(|id| !id.trim().is_empty())
+            .unwrap_or(false)
+            || body
+                .from_agent_id
+                .as_deref()
+                .map(|id| !id.trim().is_empty())
+                .unwrap_or(false),
+        is_council: active_council.is_some(),
+        is_new_session: force_new,
+        attachment_count: crate::usage_signals::attachment_count(&body.attachments),
+        installed_tool_count: crate::usage_signals::option_vec_len(&installed_tools),
+        installed_integration_count: crate::usage_signals::option_vec_len(&installed_integrations),
+        client_ip_hash: crate::usage_signals::client_ip_hash_from_headers(&headers),
+    });
     let config = SessionConfig {
         agent_id: Some(partition_agent_id),
         template_agent_id: Some(instance.agent_id.to_string()),
@@ -336,6 +375,7 @@ pub(crate) async fn send_event_stream(
             commands: body.commands,
             fork_info,
             is_plan_mode,
+            usage_signal_context,
         },
     )
     .await

--- a/apps/aura-os-server/src/handlers/agents/chat/persist_task/auto_fork.rs
+++ b/apps/aura-os-server/src/handlers/agents/chat/persist_task/auto_fork.rs
@@ -165,6 +165,9 @@ mod tests {
             router_url: "http://localhost:9999".to_string(),
             auto_fork_threshold: 0.8,
             stability_metrics: Some(Arc::clone(&metrics)),
+            usage_signal_context: None,
+            mixpanel: None,
+            billing_client: None,
         };
         let ctx = ChatPersistCtx {
             storage: Arc::new(aura_os_storage::StorageClient::with_base_url(
@@ -209,6 +212,9 @@ mod tests {
             router_url: "http://localhost:9999".to_string(),
             auto_fork_threshold: 0.8,
             stability_metrics: Some(Arc::clone(&metrics)),
+            usage_signal_context: None,
+            mixpanel: None,
+            billing_client: None,
         };
         let ctx = ChatPersistCtx {
             storage: Arc::new(aura_os_storage::StorageClient::with_base_url(

--- a/apps/aura-os-server/src/handlers/agents/chat/persist_task/mod.rs
+++ b/apps/aura-os-server/src/handlers/agents/chat/persist_task/mod.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use aura_os_billing::BillingClient;
 use aura_os_harness::HarnessOutbound;
 use serde_json::Value;
 use tokio::sync::broadcast;
@@ -56,6 +57,13 @@ pub(crate) struct ChatPersistTaskExtras {
     /// `persist_task_dispatch` unit tests can construct extras
     /// without needing a real `StabilityMetrics` instance.
     pub stability_metrics: Option<Arc<StabilityMetrics>>,
+    /// Optional observe-only usage classification context. The pure
+    /// scoring rules live outside the chat stack; the persist task
+    /// only combines this ingress metadata with completed-turn facts
+    /// and emits a signal for analytics.
+    pub usage_signal_context: Option<crate::usage_signals::UsageSignalContext>,
+    pub mixpanel: Option<crate::mixpanel::MixpanelTracker>,
+    pub billing_client: Option<Arc<BillingClient>>,
 }
 
 pub(crate) fn spawn_chat_persist_task(

--- a/apps/aura-os-server/src/handlers/agents/chat/persist_task/run_loop.rs
+++ b/apps/aura-os-server/src/handlers/agents/chat/persist_task/run_loop.rs
@@ -95,6 +95,20 @@ pub(super) async fn run_persist_loop(
                         if let Some(metrics) = extras.stability_metrics.as_ref() {
                             metrics.inc_chat_turns_completed_ok();
                         }
+                        crate::usage_signals::emit_completed_turn_signal(
+                            &ctx,
+                            extras.usage_signal_context.as_ref(),
+                            extras.mixpanel.as_ref(),
+                            extras.billing_client.as_deref(),
+                            &end.usage,
+                            crate::usage_signals::CompletedTurnMetrics {
+                                tool_use_count: state.tool_use_count,
+                                files_changed_count: crate::usage_signals::count_files_changed(
+                                    &end.files_changed,
+                                ),
+                            },
+                        )
+                        .await;
                         // Phase 3 cross-agent reply delivery. When this
                         // turn was opened by another agent's
                         // `send_to_agent` call (Phase 1: harness sets
@@ -377,6 +391,16 @@ fn harness_outbound_kind(evt: &HarnessOutbound) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use aura_os_harness::{AssistantMessageEnd, FilesChanged, HarnessOutbound, SessionUsage};
+    use axum::{
+        extract::{Path, State},
+        response::IntoResponse,
+        routing::post,
+        Json, Router,
+    };
+    use tokio::net::TcpListener;
 
     #[test]
     fn normalize_and_collect_orphan_tool_uses_coerces_null_input_and_collects_id() {
@@ -483,5 +507,123 @@ mod tests {
         assert!(blocks[0]["input"].is_object(), "string must be coerced");
         assert_eq!(blocks[0]["input"], json!({}));
         assert_eq!(orphans.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn clean_assistant_end_persists_usage_signal_event() {
+        type Requests = Arc<Mutex<Vec<aura_os_storage::CreateSessionEventRequest>>>;
+
+        async fn create_event(
+            Path(session_id): Path<String>,
+            State(requests): State<Requests>,
+            Json(req): Json<aura_os_storage::CreateSessionEventRequest>,
+        ) -> axum::response::Response {
+            requests.lock().expect("requests lock").push(req.clone());
+            Json(aura_os_storage::StorageSessionEvent {
+                id: format!("evt-{session_id}"),
+                session_id: req.session_id,
+                user_id: req.user_id,
+                agent_id: req.agent_id,
+                sender: req.sender,
+                project_id: req.project_id,
+                org_id: req.org_id,
+                event_type: Some(req.event_type),
+                content: req.content,
+                created_at: Some("2026-06-22T00:00:00Z".to_string()),
+            })
+            .into_response()
+        }
+
+        let requests: Requests = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/api/sessions/:session_id/events", post(create_event))
+            .with_state(requests.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        let base_url = format!("http://{addr}");
+        let ctx = ChatPersistCtx {
+            storage: Arc::new(aura_os_storage::StorageClient::with_base_url(&base_url)),
+            session_id: aura_os_core::SessionId::new(),
+            project_id: "project-test".to_string(),
+            project_agent_id: "project-agent-test".to_string(),
+            agent_id: None,
+            originating_agent_id: None,
+            cross_agent_depth: 0,
+            jwt: "jwt".to_string(),
+            from_agent_id: None,
+        };
+
+        let signal_ctx = crate::usage_signals::UsageSignalContext {
+            user_id: "user-test".to_string(),
+            turn_started_at: std::time::Instant::now(),
+            route_kind: crate::usage_signals::TurnRouteKind::BareAgent,
+            binding_source: crate::usage_signals::AgentBindingSource::AutoHome,
+            account_age_days: Some(0),
+            is_zero_pro: Some(false),
+            is_access_granted: Some(false),
+            local_project_count: Some(1),
+            same_org_project_count: Some(1),
+            has_project_context: true,
+            has_user_project_instance: false,
+            is_auto_home_only: true,
+            is_plan_mode: false,
+            is_cross_agent: false,
+            is_council: false,
+            is_new_session: true,
+            attachment_count: 0,
+            installed_tool_count: 0,
+            installed_integration_count: 0,
+            client_ip_hash: Some("run-loop-usage-signal-test-ip".to_string()),
+        };
+        let usage = SessionUsage {
+            input_tokens: 3_500,
+            output_tokens: 1_200,
+            ..Default::default()
+        };
+
+        let (tx, rx) = broadcast::channel(4);
+        let (event_bus, _) = broadcast::channel(4);
+        tx.send(HarnessOutbound::AssistantMessageEnd(AssistantMessageEnd {
+            message_id: "msg-1".to_string(),
+            stop_reason: "end_turn".to_string(),
+            usage,
+            files_changed: FilesChanged::default(),
+            originating_user_id: None,
+        }))
+        .expect("send terminal event");
+
+        run_persist_loop(
+            rx,
+            ctx,
+            event_bus,
+            Some("claude-test".to_string()),
+            ChatPersistTaskExtras {
+                http_client: reqwest::Client::new(),
+                router_url: "http://localhost:9999".to_string(),
+                auto_fork_threshold: 0.8,
+                stability_metrics: None,
+                usage_signal_context: Some(signal_ctx),
+                mixpanel: None,
+                billing_client: None,
+            },
+        )
+        .await;
+
+        let seen = requests.lock().expect("requests lock");
+        let event_types: Vec<&str> = seen.iter().map(|req| req.event_type.as_str()).collect();
+        assert_eq!(
+            event_types,
+            vec!["assistant_message_end", "turn_usage_signal"]
+        );
+        let signal_payload = seen[1].content.as_ref().expect("signal payload");
+        assert_eq!(signal_payload["risk_bucket"], "high");
+        assert_eq!(signal_payload["usage_shape"], "generic_agent_chat");
+        assert_eq!(signal_payload["quota_review_candidate"], true);
+        assert_eq!(signal_payload["route_kind"], "bare_agent");
+        assert_eq!(signal_payload["binding_source"], "auto_home");
     }
 }

--- a/apps/aura-os-server/src/handlers/agents/chat/streaming/orchestrator.rs
+++ b/apps/aura-os-server/src/handlers/agents/chat/streaming/orchestrator.rs
@@ -60,6 +60,11 @@ pub(in super::super) struct OpenChatStreamArgs {
     /// plan-mode steering on this turn. See
     /// `crate::handlers::plan_mode` for the contract.
     pub(in super::super) is_plan_mode: bool,
+    /// Observe-only usage signal context. Route handlers populate
+    /// request-time facts; this orchestrator corrects
+    /// `is_new_session` after the session resolver returns the actual
+    /// cold-vs-warm outcome.
+    pub(in super::super) usage_signal_context: Option<crate::usage_signals::UsageSignalContext>,
 }
 
 pub(in super::super) async fn open_harness_chat_stream(
@@ -77,6 +82,7 @@ pub(in super::super) async fn open_harness_chat_stream(
         commands,
         fork_info,
         is_plan_mode,
+        mut usage_signal_context,
     } = args;
 
     // Guiding invariant: no silent success. If the inbound user message
@@ -206,6 +212,9 @@ pub(in super::super) async fn open_harness_chat_stream(
         turn,
     )
     .await?;
+    if let Some(signal_ctx) = usage_signal_context.as_mut() {
+        signal_ctx.is_new_session = is_new;
+    }
 
     // Register this turn as a reattachable live stream so a
     // reconnecting / reloading UI can rejoin the in-flight delta stream
@@ -314,6 +323,9 @@ pub(in super::super) async fn open_harness_chat_stream(
             router_url: state.router_url.clone(),
             auto_fork_threshold: state.chat_auto_fork_threshold,
             stability_metrics: Some(Arc::clone(&state.stability_metrics)),
+            usage_signal_context,
+            mixpanel: state.mixpanel.clone(),
+            billing_client: Some(Arc::clone(&state.billing_client)),
         },
     );
 

--- a/apps/aura-os-server/src/lib.rs
+++ b/apps/aura-os-server/src/lib.rs
@@ -31,6 +31,7 @@ pub(crate) mod router;
 pub mod stability_metrics;
 pub(crate) mod state;
 pub(crate) mod sync_state;
+pub(crate) mod usage_signals;
 pub(crate) mod workspace_index;
 
 pub use app_builder::build_app_state;

--- a/apps/aura-os-server/src/mixpanel.rs
+++ b/apps/aura-os-server/src/mixpanel.rs
@@ -1,8 +1,9 @@
 //! Lightweight Mixpanel event tracker for server-side analytics.
 //!
-//! Fires `session_active` once per user per calendar day so True DAU
-//! is accurate regardless of client version. Uses an in-memory
-//! `DashMap` for deduplication — no external state required.
+//! Fires privacy-safe server analytics such as `session_active` once
+//! per user per calendar day so True DAU is accurate regardless of
+//! client version. Uses an in-memory `DashMap` for deduplication — no
+//! external state required.
 
 use dashmap::DashMap;
 use reqwest::Client;
@@ -11,14 +12,15 @@ use std::sync::Arc;
 use tracing::warn;
 use uuid::Uuid;
 
-/// Canonical server-emitted analytics event names. These are the only
-/// three events the server fires. They mirror the `server_events` list in
-/// the shared analytics manifest (`interface/src/lib/analytics-events.json`)
-/// and the TS registry's `SERVER_EVENTS`; the tests below verify they stay
-/// in sync and that `session_active` is emitted from exactly one site.
+/// Canonical server-emitted analytics event names. These mirror the
+/// `server_events` list in the shared analytics manifest
+/// (`interface/src/lib/analytics-events.json`) and the TS registry's
+/// `SERVER_EVENTS`; the tests below verify they stay in sync and that
+/// `session_active` is emitted from exactly one site.
 pub(crate) const EVENT_SESSION_ACTIVE: &str = "session_active";
 pub(crate) const EVENT_SHARE_LINK_GENERATED: &str = "share_link_generated";
 pub(crate) const EVENT_SHARE_LINK_OPENED: &str = "share_link_opened";
+pub(crate) const EVENT_AGENT_TURN_CLASSIFIED: &str = "agent_turn_classified";
 
 /// Tracks which users have already fired `session_active` today.
 /// Key: `"user_id:YYYY-MM-DD"`, Value: `()`.
@@ -600,7 +602,7 @@ mod tests {
         assert!(empty.platform.is_none());
     }
 
-    /// The three server event-name constants must exactly match the
+    /// The server event-name constants must exactly match the
     /// `server_events` list in the shared cross-language manifest
     /// (`interface/src/lib/analytics-events.json`). The TS contract test
     /// checks that same manifest against the TS registry, so this is the
@@ -633,6 +635,7 @@ mod tests {
             EVENT_SESSION_ACTIVE.to_string(),
             EVENT_SHARE_LINK_GENERATED.to_string(),
             EVENT_SHARE_LINK_OPENED.to_string(),
+            EVENT_AGENT_TURN_CLASSIFIED.to_string(),
         ];
         constants.sort();
 

--- a/apps/aura-os-server/src/usage_signals.rs
+++ b/apps/aura-os-server/src/usage_signals.rs
@@ -1,0 +1,749 @@
+//! Server adapter for privacy-safe usage signal classification.
+//!
+//! The scoring rules live in `aura-os-usage-signals`; this module only
+//! gathers server facts, maintains a small process-local IP cluster counter,
+//! and emits the resulting signal to Mixpanel/storage.
+
+use std::collections::BTreeSet;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+use aura_os_core::BillingAccount;
+use aura_os_harness::{FilesChanged, SessionUsage};
+use aura_os_storage::ProjectStats;
+use aura_os_usage_signals::{
+    classify_turn, IpClusterBucket, TurnSignalClassification, TurnSignalInput,
+};
+pub(crate) use aura_os_usage_signals::{AgentBindingSource, TurnRouteKind};
+use dashmap::DashMap;
+use serde_json::{json, Value};
+
+use crate::handlers::agents::chat::{persist_event, ChatPersistCtx};
+
+static IP_USER_INDEX: LazyLock<DashMap<String, IpClusterEntry>> = LazyLock::new(DashMap::new);
+
+#[derive(Debug, Clone)]
+struct IpClusterEntry {
+    day: String,
+    users: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UsageSignalContext {
+    pub(crate) user_id: String,
+    pub(crate) turn_started_at: Instant,
+    pub(crate) route_kind: TurnRouteKind,
+    pub(crate) binding_source: AgentBindingSource,
+    pub(crate) account_age_days: Option<u32>,
+    pub(crate) is_zero_pro: Option<bool>,
+    pub(crate) is_access_granted: Option<bool>,
+    pub(crate) local_project_count: Option<u32>,
+    pub(crate) same_org_project_count: Option<u32>,
+    pub(crate) has_project_context: bool,
+    pub(crate) has_user_project_instance: bool,
+    pub(crate) is_auto_home_only: bool,
+    pub(crate) is_plan_mode: bool,
+    pub(crate) is_cross_agent: bool,
+    pub(crate) is_council: bool,
+    pub(crate) is_new_session: bool,
+    pub(crate) attachment_count: u32,
+    pub(crate) installed_tool_count: u32,
+    pub(crate) installed_integration_count: u32,
+    /// Short hash of the public client IP. Raw IP addresses are never
+    /// stored in this module or sent to Mixpanel.
+    pub(crate) client_ip_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CompletedTurnMetrics {
+    pub(crate) tool_use_count: u32,
+    pub(crate) files_changed_count: u32,
+}
+
+pub(crate) fn hash_client_ip(ip: &str) -> String {
+    blake3::hash(ip.as_bytes())
+        .to_hex()
+        .chars()
+        .take(16)
+        .collect()
+}
+
+pub(crate) fn count_files_changed(files: &FilesChanged) -> u32 {
+    files
+        .created
+        .len()
+        .saturating_add(files.modified.len())
+        .saturating_add(files.deleted.len())
+        .min(u32::MAX as usize) as u32
+}
+
+pub(crate) async fn emit_completed_turn_signal(
+    ctx: &ChatPersistCtx,
+    signal_ctx: Option<&UsageSignalContext>,
+    mixpanel: Option<&crate::mixpanel::MixpanelTracker>,
+    billing_client: Option<&aura_os_billing::BillingClient>,
+    usage: &SessionUsage,
+    metrics: CompletedTurnMetrics,
+) {
+    let Some(signal_ctx) = signal_ctx else {
+        return;
+    };
+
+    let ip_cluster_bucket = signal_ctx
+        .client_ip_hash
+        .as_deref()
+        .map(|hash| record_ip_user(hash, &signal_ctx.user_id))
+        .unwrap_or(IpClusterBucket::Unknown);
+
+    let billing_account = fetch_billing_account(billing_client, &ctx.jwt).await;
+    let billing_account_age_days = billing_account.as_ref().and_then(billing_account_age_days);
+
+    let input = TurnSignalInput {
+        route_kind: signal_ctx.route_kind,
+        binding_source: signal_ctx.binding_source,
+        account_age_days: billing_account_age_days.or(signal_ctx.account_age_days),
+        is_zero_pro: signal_ctx.is_zero_pro,
+        is_access_granted: signal_ctx.is_access_granted,
+        has_project_context: signal_ctx.has_project_context,
+        has_user_project_instance: signal_ctx.has_user_project_instance,
+        is_auto_home_only: signal_ctx.is_auto_home_only,
+        is_plan_mode: signal_ctx.is_plan_mode,
+        is_cross_agent: signal_ctx.is_cross_agent,
+        is_council: signal_ctx.is_council,
+        is_new_session: signal_ctx.is_new_session,
+        attachment_count: signal_ctx.attachment_count,
+        installed_tool_count: signal_ctx.installed_tool_count,
+        installed_integration_count: signal_ctx.installed_integration_count,
+        tool_use_count: metrics.tool_use_count,
+        files_changed_count: metrics.files_changed_count,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        ip_cluster_bucket,
+    };
+    let classification = classify_turn(&input);
+    let project_stats = fetch_project_stats(ctx).await;
+    let turn_duration_ms = signal_ctx
+        .turn_started_at
+        .elapsed()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
+    let payload = signal_payload(
+        signal_ctx,
+        &input,
+        usage,
+        &classification,
+        project_stats.as_ref(),
+        billing_account.as_ref(),
+        turn_duration_ms,
+    );
+
+    if persist_event(ctx, "turn_usage_signal", payload.clone()).await {
+        tracing::debug!(
+            session_id = %ctx.session_id,
+            project_agent_id = %ctx.project_agent_id,
+            risk_bucket = classification.risk_bucket.as_str(),
+            "persisted turn usage signal"
+        );
+    }
+
+    if let Some(mixpanel) = mixpanel {
+        mixpanel.track_event(
+            crate::mixpanel::EVENT_AGENT_TURN_CLASSIFIED,
+            signal_ctx.user_id.clone(),
+            payload,
+        );
+    }
+}
+
+async fn fetch_billing_account(
+    billing_client: Option<&aura_os_billing::BillingClient>,
+    jwt: &str,
+) -> Option<BillingAccount> {
+    let billing_client = billing_client?;
+
+    match tokio::time::timeout(Duration::from_millis(750), billing_client.get_account(jwt)).await {
+        Ok(Ok(account)) => Some(account),
+        Ok(Err(error)) => {
+            tracing::debug!(error = %error, "usage signal billing account unavailable");
+            None
+        }
+        Err(_) => {
+            tracing::debug!("usage signal billing account timed out");
+            None
+        }
+    }
+}
+
+async fn fetch_project_stats(ctx: &ChatPersistCtx) -> Option<ProjectStats> {
+    match tokio::time::timeout(
+        Duration::from_millis(750),
+        ctx.storage.get_project_stats(&ctx.project_id, &ctx.jwt),
+    )
+    .await
+    {
+        Ok(Ok(stats)) => Some(stats),
+        Ok(Err(error)) => {
+            tracing::debug!(
+                project_id = %ctx.project_id,
+                error = %error,
+                "usage signal project stats unavailable"
+            );
+            None
+        }
+        Err(_) => {
+            tracing::debug!(
+                project_id = %ctx.project_id,
+                "usage signal project stats timed out"
+            );
+            None
+        }
+    }
+}
+
+fn record_ip_user(ip_hash: &str, user_id: &str) -> IpClusterBucket {
+    let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let mut entry = IP_USER_INDEX
+        .entry(ip_hash.to_string())
+        .or_insert_with(|| IpClusterEntry {
+            day: today.clone(),
+            users: BTreeSet::new(),
+        });
+    if entry.day != today {
+        entry.day = today;
+        entry.users.clear();
+    }
+    entry.users.insert(user_id.to_string());
+    IpClusterBucket::from_distinct_users(Some(entry.users.len()))
+}
+
+fn signal_payload(
+    signal_ctx: &UsageSignalContext,
+    input: &TurnSignalInput,
+    usage: &SessionUsage,
+    classification: &TurnSignalClassification,
+    project_stats: Option<&ProjectStats>,
+    billing_account: Option<&BillingAccount>,
+    turn_duration_ms: u64,
+) -> Value {
+    let mut payload = json!({
+        "turn_duration_ms": turn_duration_ms,
+        "route_kind": input.route_kind.as_str(),
+        "binding_source": input.binding_source.as_str(),
+        "account_age_days": input.account_age_days,
+        "account_age_bucket": account_age_bucket(input.account_age_days),
+        "is_zero_pro": input.is_zero_pro,
+        "is_access_granted": input.is_access_granted,
+        "local_project_count": signal_ctx.local_project_count,
+        "same_org_project_count": signal_ctx.same_org_project_count,
+        "risk_bucket": classification.risk_bucket.as_str(),
+        "agentic_score": classification.agentic_score,
+        "generic_chat_score": classification.generic_chat_score,
+        "usage_shape": classification.usage_shape.as_str(),
+        "quota_review_candidate": classification.quota_review_candidate,
+        "reasons": classification.reasons,
+        "tool_use_count": input.tool_use_count,
+        "files_changed_count": input.files_changed_count,
+        "input_tokens": input.input_tokens,
+        "output_tokens": input.output_tokens,
+        "estimated_context_tokens": usage.estimated_context_tokens,
+        "context_utilization": usage.context_utilization,
+        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+        "cache_read_input_tokens": usage.cache_read_input_tokens,
+        "model": usage.model.as_str(),
+        "provider": usage.provider.as_str(),
+        "has_project_context": input.has_project_context,
+        "has_user_project_instance": input.has_user_project_instance,
+        "is_auto_home_only": input.is_auto_home_only,
+        "is_plan_mode": input.is_plan_mode,
+        "is_cross_agent": input.is_cross_agent,
+        "is_council": input.is_council,
+        "is_new_session": input.is_new_session,
+        "attachment_count": input.attachment_count,
+        "installed_tool_count": input.installed_tool_count,
+        "installed_integration_count": input.installed_integration_count,
+        "ip_cluster_bucket": input.ip_cluster_bucket.as_str(),
+    });
+
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert(
+            "current_project_total_sessions".to_string(),
+            json!(project_stats.map(|stats| stats.total_sessions)),
+        );
+        obj.insert(
+            "current_project_total_tasks".to_string(),
+            json!(project_stats.map(|stats| stats.total_tasks)),
+        );
+        obj.insert(
+            "current_project_total_specs".to_string(),
+            json!(project_stats.map(|stats| stats.total_specs)),
+        );
+        obj.insert(
+            "current_project_total_events".to_string(),
+            json!(project_stats.map(|stats| stats.total_events)),
+        );
+        obj.insert(
+            "current_project_total_agents".to_string(),
+            json!(project_stats.map(|stats| stats.total_agents)),
+        );
+        obj.insert(
+            "current_project_total_tokens".to_string(),
+            json!(project_stats.map(|stats| stats.total_tokens)),
+        );
+        obj.insert(
+            "current_project_lines_changed".to_string(),
+            json!(project_stats.map(|stats| stats.lines_changed)),
+        );
+        obj.insert(
+            "current_project_total_time_seconds".to_string(),
+            json!(project_stats.map(|stats| stats.total_time_seconds)),
+        );
+        insert_billing_fields(obj, billing_account);
+    }
+
+    payload
+}
+
+fn insert_billing_fields(
+    obj: &mut serde_json::Map<String, Value>,
+    billing_account: Option<&BillingAccount>,
+) {
+    let billing_account_age_days = billing_account.and_then(billing_account_age_days);
+    obj.insert(
+        "billing_account_age_days".to_string(),
+        json!(billing_account_age_days),
+    );
+    obj.insert(
+        "billing_account_age_bucket".to_string(),
+        json!(account_age_bucket(billing_account_age_days)),
+    );
+    obj.insert(
+        "billing_plan".to_string(),
+        json!(billing_account.map(|account| account.plan.as_str())),
+    );
+    obj.insert(
+        "billing_balance_cents".to_string(),
+        json!(billing_account.map(|account| account.balance_cents)),
+    );
+    obj.insert(
+        "billing_lifetime_purchased_cents".to_string(),
+        json!(billing_account.map(|account| account.lifetime_purchased_cents)),
+    );
+    obj.insert(
+        "billing_lifetime_granted_cents".to_string(),
+        json!(billing_account.map(|account| account.lifetime_granted_cents)),
+    );
+    obj.insert(
+        "billing_lifetime_used_cents".to_string(),
+        json!(billing_account.map(|account| account.lifetime_used_cents)),
+    );
+    obj.insert(
+        "billing_auto_refill_enabled".to_string(),
+        json!(billing_account.map(|account| account.auto_refill_enabled)),
+    );
+    obj.insert(
+        "billing_funding_bucket".to_string(),
+        json!(billing_account.map(billing_funding_bucket)),
+    );
+    obj.insert(
+        "billing_grant_usage_bucket".to_string(),
+        json!(billing_account.map(billing_grant_usage_bucket)),
+    );
+    obj.insert(
+        "billing_used_to_granted_ratio".to_string(),
+        json!(billing_account.and_then(billing_used_to_granted_ratio)),
+    );
+    obj.insert(
+        "billing_used_to_funded_ratio".to_string(),
+        json!(billing_account.and_then(billing_used_to_funded_ratio)),
+    );
+}
+
+fn billing_account_age_days(account: &BillingAccount) -> Option<u32> {
+    let created_at = chrono::DateTime::parse_from_rfc3339(&account.created_at)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    let days = chrono::Utc::now()
+        .signed_duration_since(created_at)
+        .num_days();
+    u32::try_from(days.max(0)).ok()
+}
+
+fn billing_funding_bucket(account: &BillingAccount) -> &'static str {
+    match (
+        account.lifetime_purchased_cents > 0,
+        account.lifetime_granted_cents > 0,
+    ) {
+        (false, false) => "none",
+        (false, true) => "grant_only",
+        (true, false) => "purchase_only",
+        (true, true) => "mixed",
+    }
+}
+
+fn billing_grant_usage_bucket(account: &BillingAccount) -> &'static str {
+    let granted = account.lifetime_granted_cents;
+    if granted <= 0 {
+        return "no_grants";
+    }
+    let used = account.lifetime_used_cents.max(0);
+    if used == 0 {
+        "0"
+    } else if used.saturating_mul(4) < granted {
+        "lt_25pct"
+    } else if used.saturating_mul(4) < granted.saturating_mul(3) {
+        "25_75pct"
+    } else if used < granted {
+        "75_100pct"
+    } else {
+        "100pct_plus"
+    }
+}
+
+fn billing_used_to_granted_ratio(account: &BillingAccount) -> Option<f64> {
+    (account.lifetime_granted_cents > 0).then_some(
+        account.lifetime_used_cents.max(0) as f64 / account.lifetime_granted_cents as f64,
+    )
+}
+
+fn billing_used_to_funded_ratio(account: &BillingAccount) -> Option<f64> {
+    let funded = account
+        .lifetime_granted_cents
+        .saturating_add(account.lifetime_purchased_cents);
+    (funded > 0).then_some(account.lifetime_used_cents.max(0) as f64 / funded as f64)
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct LocalProjectCounts {
+    pub(crate) local_project_count: Option<u32>,
+    pub(crate) same_org_project_count: Option<u32>,
+}
+
+pub(crate) fn local_project_counts(
+    state: &crate::state::AppState,
+    org_id: Option<&aura_os_core::OrgId>,
+) -> LocalProjectCounts {
+    let Ok(projects) = state.project_service.list_projects() else {
+        return LocalProjectCounts::default();
+    };
+
+    let local_project_count = Some(projects.len().min(u32::MAX as usize) as u32);
+    let same_org_project_count = org_id.map(|org_id| {
+        projects
+            .iter()
+            .filter(|project| project.org_id == *org_id)
+            .count()
+            .min(u32::MAX as usize) as u32
+    });
+
+    LocalProjectCounts {
+        local_project_count,
+        same_org_project_count,
+    }
+}
+
+fn account_age_bucket(days: Option<u32>) -> &'static str {
+    match days {
+        None => "unknown",
+        Some(0) => "0d",
+        Some(1) => "1d",
+        Some(2..=7) => "2_7d",
+        Some(8..=30) => "8_30d",
+        Some(31..=90) => "31_90d",
+        Some(_) => "91d_plus",
+    }
+}
+
+pub(crate) fn binding_source_from_project_agents(
+    project_agent_id: &str,
+    matching: &[aura_os_storage::StorageProjectAgent],
+) -> AgentBindingSource {
+    let source = matching
+        .iter()
+        .find(|agent| agent.id == project_agent_id)
+        .and_then(|agent| agent.source.as_deref());
+    AgentBindingSource::from_wire(source)
+}
+
+pub(crate) fn user_visible_binding(source: AgentBindingSource) -> bool {
+    source.is_user_visible()
+}
+
+pub(crate) fn attachment_count<T>(attachments: &Option<Vec<T>>) -> u32 {
+    attachments
+        .as_ref()
+        .map(|items| items.len().min(u32::MAX as usize) as u32)
+        .unwrap_or(0)
+}
+
+pub(crate) fn option_vec_len<T>(items: &Option<Vec<T>>) -> u32 {
+    items
+        .as_ref()
+        .map(|items| items.len().min(u32::MAX as usize) as u32)
+        .unwrap_or(0)
+}
+
+pub(crate) fn client_ip_hash_from_headers(headers: &axum::http::HeaderMap) -> Option<String> {
+    crate::auth_guard::client_ip_from_headers(headers).map(|ip| hash_client_ip(&ip))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use axum::{
+        extract::{Path, State},
+        response::IntoResponse,
+        routing::{get, post},
+        Json, Router,
+    };
+    use tokio::net::TcpListener;
+
+    #[test]
+    fn hashes_ip_without_returning_raw_value() {
+        let hash = hash_client_ip("203.0.113.1");
+        assert_eq!(hash.len(), 16);
+        assert_ne!(hash, "203.0.113.1");
+    }
+
+    #[test]
+    fn counts_file_mutations_without_paths() {
+        let files = FilesChanged {
+            created: vec!["a".into()],
+            modified: vec!["b".into(), "c".into()],
+            deleted: vec![],
+            diffs: Vec::new(),
+        };
+        assert_eq!(count_files_changed(&files), 3);
+    }
+
+    #[test]
+    fn parses_binding_source_from_selected_project_agent() {
+        let selected = aura_os_storage::StorageProjectAgent {
+            id: "pa-1".into(),
+            source: Some("auto_home".into()),
+            project_id: None,
+            org_id: None,
+            agent_id: None,
+            name: None,
+            role: None,
+            personality: None,
+            system_prompt: None,
+            skills: None,
+            icon: None,
+            harness: None,
+            status: None,
+            model: None,
+            total_input_tokens: None,
+            total_output_tokens: None,
+            instance_role: None,
+            permissions: None,
+            intent_classifier: None,
+            created_at: None,
+            updated_at: None,
+        };
+
+        assert_eq!(
+            binding_source_from_project_agents("pa-1", &[selected]),
+            AgentBindingSource::AutoHome
+        );
+    }
+
+    #[tokio::test]
+    async fn emit_completed_turn_signal_persists_expected_classification_event() {
+        type Requests = Arc<Mutex<Vec<aura_os_storage::CreateSessionEventRequest>>>;
+
+        async fn create_event(
+            Path(session_id): Path<String>,
+            State(requests): State<Requests>,
+            Json(req): Json<aura_os_storage::CreateSessionEventRequest>,
+        ) -> axum::response::Response {
+            requests.lock().expect("requests lock").push(req.clone());
+            Json(aura_os_storage::StorageSessionEvent {
+                id: format!("evt-{session_id}"),
+                session_id: req.session_id,
+                user_id: req.user_id,
+                agent_id: req.agent_id,
+                sender: req.sender,
+                project_id: req.project_id,
+                org_id: req.org_id,
+                event_type: Some(req.event_type),
+                content: req.content,
+                created_at: Some("2026-06-22T00:00:00Z".to_string()),
+            })
+            .into_response()
+        }
+
+        async fn project_stats() -> Json<ProjectStats> {
+            Json(ProjectStats {
+                total_tasks: 2,
+                pending_tasks: 0,
+                ready_tasks: 1,
+                in_progress_tasks: 0,
+                blocked_tasks: 0,
+                done_tasks: 1,
+                failed_tasks: 0,
+                completion_percentage: 50.0,
+                total_tokens: 4_700,
+                total_input_tokens: Some(3_500),
+                total_output_tokens: Some(1_200),
+                total_events: 3,
+                total_agents: 1,
+                total_sessions: 1,
+                total_time_seconds: 12.5,
+                lines_changed: 0,
+                total_specs: 1,
+                contributors: 1,
+                estimated_cost_usd: 0.0,
+            })
+        }
+
+        async fn billing_account() -> Json<Value> {
+            Json(json!({
+                "user_id": "user-test",
+                "balance_cents": 125,
+                "balance_formatted": "$1.25",
+                "lifetime_purchased_cents": 0,
+                "lifetime_granted_cents": 5_000,
+                "lifetime_used_cents": 4_000,
+                "plan": "free",
+                "auto_refill_enabled": false,
+                "created_at": "2026-01-01T00:00:00Z"
+            }))
+        }
+
+        let requests: Requests = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/api/sessions/:session_id/events", post(create_event))
+            .route("/api/stats", get(project_stats))
+            .route("/v1/accounts/me", get(billing_account))
+            .with_state(requests.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        let base_url = format!("http://{addr}");
+        let billing = aura_os_billing::BillingClient::with_base_url(base_url.clone());
+        let ctx = ChatPersistCtx {
+            storage: Arc::new(aura_os_storage::StorageClient::with_base_url(&base_url)),
+            session_id: aura_os_core::SessionId::new(),
+            project_id: "project-test".to_string(),
+            project_agent_id: "project-agent-test".to_string(),
+            agent_id: None,
+            originating_agent_id: None,
+            cross_agent_depth: 0,
+            jwt: "jwt".to_string(),
+            from_agent_id: None,
+        };
+        let signal_ctx = UsageSignalContext {
+            user_id: "user-test".to_string(),
+            turn_started_at: Instant::now(),
+            route_kind: TurnRouteKind::BareAgent,
+            binding_source: AgentBindingSource::AutoHome,
+            account_age_days: None,
+            is_zero_pro: Some(false),
+            is_access_granted: Some(false),
+            local_project_count: Some(1),
+            same_org_project_count: Some(1),
+            has_project_context: true,
+            has_user_project_instance: false,
+            is_auto_home_only: true,
+            is_plan_mode: false,
+            is_cross_agent: false,
+            is_council: false,
+            is_new_session: true,
+            attachment_count: 0,
+            installed_tool_count: 0,
+            installed_integration_count: 0,
+            client_ip_hash: Some("usage-signal-test-ip".to_string()),
+        };
+        let usage = SessionUsage {
+            input_tokens: 3_500,
+            output_tokens: 1_200,
+            model: "claude-test".to_string(),
+            provider: "anthropic".to_string(),
+            ..Default::default()
+        };
+
+        emit_completed_turn_signal(
+            &ctx,
+            Some(&signal_ctx),
+            None,
+            Some(&billing),
+            &usage,
+            CompletedTurnMetrics {
+                tool_use_count: 0,
+                files_changed_count: 0,
+            },
+        )
+        .await;
+
+        let seen = requests.lock().expect("requests lock");
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].event_type, "turn_usage_signal");
+        assert_eq!(seen[0].agent_id.as_deref(), Some("project-agent-test"));
+        assert_eq!(seen[0].sender.as_deref(), Some("agent"));
+
+        let payload = seen[0].content.as_ref().expect("signal payload");
+        assert_eq!(payload["route_kind"], "bare_agent");
+        assert_eq!(payload["binding_source"], "auto_home");
+        assert!(payload["account_age_days"].as_u64().is_some());
+        assert_eq!(payload["account_age_bucket"], "91d_plus");
+        assert_eq!(payload["is_zero_pro"], false);
+        assert_eq!(payload["is_access_granted"], false);
+        assert!(payload["turn_duration_ms"].as_u64().is_some());
+        assert_eq!(payload["local_project_count"], 1);
+        assert_eq!(payload["same_org_project_count"], 1);
+        assert_eq!(payload["current_project_total_sessions"], 1);
+        assert_eq!(payload["current_project_total_tasks"], 2);
+        assert_eq!(payload["current_project_total_specs"], 1);
+        assert_eq!(payload["current_project_total_events"], 3);
+        assert_eq!(payload["current_project_total_agents"], 1);
+        assert_eq!(payload["current_project_total_tokens"], 4_700);
+        assert_eq!(payload["current_project_lines_changed"], 0);
+        assert_eq!(payload["current_project_total_time_seconds"], 12.5);
+        assert_eq!(payload["risk_bucket"], "high");
+        assert_eq!(payload["usage_shape"], "generic_agent_chat");
+        assert_eq!(payload["quota_review_candidate"], true);
+        assert_eq!(payload["tool_use_count"], 0);
+        assert_eq!(payload["files_changed_count"], 0);
+        assert_eq!(payload["model"], "claude-test");
+        assert_eq!(payload["provider"], "anthropic");
+        assert_eq!(payload["ip_cluster_bucket"], "1");
+        assert!(payload["billing_account_age_days"].as_u64().is_some());
+        assert_eq!(payload["billing_account_age_bucket"], "91d_plus");
+        assert_eq!(payload["billing_plan"], "free");
+        assert_eq!(payload["billing_balance_cents"], 125);
+        assert_eq!(payload["billing_lifetime_purchased_cents"], 0);
+        assert_eq!(payload["billing_lifetime_granted_cents"], 5_000);
+        assert_eq!(payload["billing_lifetime_used_cents"], 4_000);
+        assert_eq!(payload["billing_auto_refill_enabled"], false);
+        assert_eq!(payload["billing_funding_bucket"], "grant_only");
+        assert_eq!(payload["billing_grant_usage_bucket"], "75_100pct");
+        assert!(
+            (payload["billing_used_to_granted_ratio"]
+                .as_f64()
+                .expect("billing grant usage ratio")
+                - 0.8)
+                .abs()
+                < 0.000_001
+        );
+        assert!(
+            (payload["billing_used_to_funded_ratio"]
+                .as_f64()
+                .expect("billing funded usage ratio")
+                - 0.8)
+                .abs()
+                < 0.000_001
+        );
+        assert!(payload["client_ip_hash"].is_null());
+        assert!(payload["raw_ip"].is_null());
+        assert!(payload["reasons"]
+            .as_array()
+            .expect("reasons array")
+            .iter()
+            .any(|reason| reason == "bare_agent_auto_home_only"));
+    }
+}

--- a/apps/aura-os-server/tests/chat_events_test/streaming.rs
+++ b/apps/aura-os-server/tests/chat_events_test/streaming.rs
@@ -1,7 +1,10 @@
 //! Chat-stream error paths and project-context-aware system prompt.
 
 use std::sync::Arc;
+use std::time::Duration;
 
+use axum::body;
+use axum::http::HeaderValue;
 use axum::routing::get;
 use axum::Json;
 use axum::Router;
@@ -9,6 +12,12 @@ use tokio::net::TcpListener;
 use tower::ServiceExt;
 
 use aura_os_core::*;
+use aura_os_harness::test_support::FakeHarness;
+use aura_os_harness::{
+    AssistantMessageEnd, FilesChanged, HarnessLink, HarnessOutbound, SessionUsage,
+};
+use aura_os_projects::CreateProjectInput;
+use aura_os_storage::CreateProjectAgentRequest;
 
 use super::common::*;
 
@@ -47,6 +56,22 @@ async fn start_mock_billing_for_test() -> String {
                 }))
             }),
         );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.ok() });
+    url
+}
+
+async fn start_404_network_for_test() -> String {
+    let app = Router::new().route(
+        "/api/agents/:agent_id",
+        get(|| async {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                axum::Json(serde_json::json!({ "error": "not found" })),
+            )
+        }),
+    );
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let url = format!("http://{}", listener.local_addr().unwrap());
     tokio::spawn(async move { axum::serve(listener, app).await.ok() });
@@ -245,6 +270,209 @@ async fn remote_only_agent_chat_rejects_local_agent_before_persistence() {
         .as_str()
         .unwrap_or_default()
         .contains("desktop app"));
+}
+
+#[tokio::test]
+async fn bare_agent_chat_route_persists_usage_signal_from_harness_end() {
+    let (storage_url, db) = aura_os_storage::testutil::start_mock_storage().await;
+    let storage = Arc::new(aura_os_storage::StorageClient::with_base_url(&storage_url));
+    let billing_url = start_mock_billing_for_test().await;
+    let billing = Arc::new(aura_os_billing::BillingClient::with_base_url(billing_url));
+    let network_url = start_404_network_for_test().await;
+    let network = Arc::new(aura_os_network::NetworkClient::with_base_url(&network_url));
+
+    let store_dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(aura_os_store::SettingsStore::open(store_dir.path()).unwrap());
+    store_zero_auth_session(&store);
+
+    let (_unused_app, mut state) = build_test_app_from_store(
+        store,
+        store_dir.path().to_path_buf(),
+        Some(network),
+        Some(storage.clone()),
+        None,
+        Some(billing),
+    );
+
+    let fake = Arc::new(FakeHarness::new());
+    let usage = SessionUsage {
+        input_tokens: 3_500,
+        output_tokens: 1_200,
+        model: "claude-test".to_string(),
+        provider: "anthropic".to_string(),
+        ..Default::default()
+    };
+    fake.set_script(vec![HarnessOutbound::AssistantMessageEnd(
+        AssistantMessageEnd {
+            message_id: "msg-1".to_string(),
+            stop_reason: "stop".to_string(),
+            usage,
+            files_changed: FilesChanged::default(),
+            originating_user_id: None,
+        },
+    )])
+    .await;
+    let harness: Arc<dyn HarnessLink> = fake.clone();
+    state.local_harness = harness.clone();
+    state.swarm_harness = harness;
+
+    let project = state
+        .project_service
+        .create_project(CreateProjectInput {
+            org_id: OrgId::new(),
+            name: "Usage Signal Route Test".into(),
+            description: "fixture project for usage signal route test".into(),
+            build_command: None,
+            test_command: None,
+            local_workspace_path: None,
+        })
+        .expect("create local project");
+
+    let agent_id = AgentId::new();
+    storage
+        .create_project_agent(
+            &project.project_id.to_string(),
+            TEST_JWT,
+            &CreateProjectAgentRequest {
+                agent_id: agent_id.to_string(),
+                name: "Usage Signal Agent".into(),
+                org_id: Some(project.org_id.to_string()),
+                role: Some("Generalist".into()),
+                instance_role: None,
+                source: Some("auto_home".into()),
+                personality: None,
+                system_prompt: None,
+                skills: Some(vec![]),
+                icon: None,
+                harness: None,
+                permissions: Some(AgentPermissions::empty()),
+                intent_classifier: None,
+            },
+        )
+        .await
+        .expect("create auto-home project_agent row");
+
+    state
+        .agent_service
+        .save_agent_shadow(&Agent {
+            agent_id,
+            user_id: "u1".into(),
+            org_id: Some(project.org_id),
+            name: "Usage Signal Agent".into(),
+            role: "Generalist".into(),
+            personality: String::new(),
+            system_prompt: String::new(),
+            skills: vec![],
+            icon: None,
+            machine_type: "local".into(),
+            adapter_type: "aura_harness".into(),
+            environment: "local_host".into(),
+            auth_source: "local".into(),
+            integration_id: None,
+            default_model: None,
+            vm_id: None,
+            wallet_address: None,
+            network_agent_id: None,
+            profile_id: None,
+            tags: vec![],
+            is_pinned: false,
+            listing_status: Default::default(),
+            expertise: vec![],
+            jobs: 0,
+            revenue_usd: 0.0,
+            reputation: 0.0,
+            local_workspace_path: None,
+            permissions: AgentPermissions::empty(),
+            intent_classifier: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .expect("save local agent shadow");
+
+    let app = aura_os_server::create_router_with_interface(state.clone(), None);
+    let mut req = json_request(
+        "POST",
+        &format!("/api/agents/{agent_id}/events/stream"),
+        Some(serde_json::json!({ "content": "Explain OAuth at length" })),
+    );
+    req.headers_mut()
+        .insert("x-forwarded-for", HeaderValue::from_static("203.0.113.10"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let _sse = tokio::time::timeout(
+        Duration::from_secs(3),
+        body::to_bytes(resp.into_body(), usize::MAX),
+    )
+    .await
+    .expect("SSE stream should complete after assistant_message_end")
+    .expect("read SSE body");
+
+    let signal_payload = wait_for_usage_signal_payload(&db).await;
+    assert_eq!(fake.session_count().await, 1);
+    assert_eq!(signal_payload["route_kind"], "bare_agent");
+    assert_eq!(signal_payload["binding_source"], "auto_home");
+    assert!(signal_payload["account_age_days"].as_u64().is_some());
+    assert_eq!(signal_payload["account_age_bucket"], "91d_plus");
+    assert_eq!(signal_payload["is_zero_pro"], true);
+    assert_eq!(signal_payload["is_access_granted"], false);
+    assert!(signal_payload["turn_duration_ms"].as_u64().is_some());
+    assert_eq!(signal_payload["local_project_count"], 1);
+    assert_eq!(signal_payload["same_org_project_count"], 1);
+    assert_eq!(signal_payload["risk_bucket"], "high");
+    assert_eq!(signal_payload["usage_shape"], "generic_agent_chat");
+    assert_eq!(signal_payload["quota_review_candidate"], true);
+    assert_eq!(signal_payload["tool_use_count"], 0);
+    assert_eq!(signal_payload["files_changed_count"], 0);
+    assert_eq!(signal_payload["ip_cluster_bucket"], "1");
+    assert_eq!(signal_payload["model"], "claude-test");
+    assert_eq!(signal_payload["provider"], "anthropic");
+    assert!(signal_payload["billing_account_age_days"]
+        .as_u64()
+        .is_some());
+    assert_eq!(signal_payload["billing_account_age_bucket"], "91d_plus");
+    assert_eq!(signal_payload["billing_plan"], "free");
+    assert_eq!(signal_payload["billing_balance_cents"], 999_999);
+    assert_eq!(
+        signal_payload["billing_lifetime_purchased_cents"],
+        1_000_000
+    );
+    assert_eq!(signal_payload["billing_lifetime_granted_cents"], 0);
+    assert_eq!(signal_payload["billing_lifetime_used_cents"], 1);
+    assert_eq!(signal_payload["billing_auto_refill_enabled"], false);
+    assert_eq!(signal_payload["billing_funding_bucket"], "purchase_only");
+    assert_eq!(signal_payload["billing_grant_usage_bucket"], "no_grants");
+    assert!(signal_payload["billing_used_to_granted_ratio"].is_null());
+    assert!(signal_payload["billing_used_to_funded_ratio"]
+        .as_f64()
+        .is_some());
+
+    let db = db.lock().await;
+    let event_types: Vec<&str> = db
+        .events
+        .iter()
+        .filter_map(|event| event.event_type.as_deref())
+        .collect();
+    assert!(event_types.contains(&"user_message"));
+    assert!(event_types.contains(&"assistant_message_end"));
+    assert!(event_types.contains(&"turn_usage_signal"));
+}
+
+async fn wait_for_usage_signal_payload(
+    db: &aura_os_storage::testutil::SharedDb,
+) -> serde_json::Value {
+    for _ in 0..40 {
+        if let Some(payload) = {
+            let db = db.lock().await;
+            db.events
+                .iter()
+                .find(|event| event.event_type.as_deref() == Some("turn_usage_signal"))
+                .and_then(|event| event.content.clone())
+        } {
+            return payload;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("expected turn_usage_signal event to be persisted");
 }
 
 /// Chat-WS migration shape pin: aura-os no longer bakes the

--- a/crates/aura-os-usage-signals/Cargo.toml
+++ b/crates/aura-os-usage-signals/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "aura-os-usage-signals"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/aura-os-usage-signals/src/lib.rs
+++ b/crates/aura-os-usage-signals/src/lib.rs
@@ -1,0 +1,438 @@
+//! Privacy-safe usage signal classification.
+//!
+//! This crate intentionally has no server, storage, Mixpanel, or harness
+//! dependencies. Aura OS passes in behavioural facts about a completed turn;
+//! the classifier returns scores and reasons that downstream sinks can chart
+//! or persist. Keeping this pure makes the rules easy to test and tune.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnRouteKind {
+    BareAgent,
+    ProjectAgent,
+    PublicDemo,
+    PublicX402,
+    Other,
+}
+
+impl TurnRouteKind {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BareAgent => "bare_agent",
+            Self::ProjectAgent => "project_agent",
+            Self::PublicDemo => "public_demo",
+            Self::PublicX402 => "public_x402",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentBindingSource {
+    Ui,
+    AutoHome,
+    AutoProjectDefault,
+    Sdk,
+    System,
+    Unknown,
+    None,
+}
+
+impl AgentBindingSource {
+    #[must_use]
+    pub fn from_wire(value: Option<&str>) -> Self {
+        match value.map(str::trim).filter(|v| !v.is_empty()) {
+            Some("ui") => Self::Ui,
+            Some("auto_home") => Self::AutoHome,
+            Some("auto_project_default") => Self::AutoProjectDefault,
+            Some("sdk") => Self::Sdk,
+            Some("system") => Self::System,
+            Some(_) => Self::Unknown,
+            None => Self::None,
+        }
+    }
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ui => "ui",
+            Self::AutoHome => "auto_home",
+            Self::AutoProjectDefault => "auto_project_default",
+            Self::Sdk => "sdk",
+            Self::System => "system",
+            Self::Unknown => "unknown",
+            Self::None => "none",
+        }
+    }
+
+    #[must_use]
+    pub const fn is_user_visible(self) -> bool {
+        matches!(self, Self::Ui | Self::None)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskBucket {
+    Low,
+    Medium,
+    High,
+}
+
+impl RiskBucket {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageShape {
+    AgenticWork,
+    GenericAgentChat,
+    Mixed,
+    LowSignal,
+}
+
+impl UsageShape {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AgenticWork => "agentic_work",
+            Self::GenericAgentChat => "generic_agent_chat",
+            Self::Mixed => "mixed",
+            Self::LowSignal => "low_signal",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IpClusterBucket {
+    Unknown,
+    One,
+    TwoToFive,
+    SixToTwenty,
+    TwentyOnePlus,
+}
+
+impl IpClusterBucket {
+    #[must_use]
+    pub fn from_distinct_users(count: Option<usize>) -> Self {
+        match count {
+            None | Some(0) => Self::Unknown,
+            Some(1) => Self::One,
+            Some(2..=5) => Self::TwoToFive,
+            Some(6..=20) => Self::SixToTwenty,
+            Some(_) => Self::TwentyOnePlus,
+        }
+    }
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::One => "1",
+            Self::TwoToFive => "2_5",
+            Self::SixToTwenty => "6_20",
+            Self::TwentyOnePlus => "21_plus",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnSignalInput {
+    pub route_kind: TurnRouteKind,
+    pub binding_source: AgentBindingSource,
+    pub account_age_days: Option<u32>,
+    pub is_zero_pro: Option<bool>,
+    pub is_access_granted: Option<bool>,
+    pub has_project_context: bool,
+    pub has_user_project_instance: bool,
+    pub is_auto_home_only: bool,
+    pub is_plan_mode: bool,
+    pub is_cross_agent: bool,
+    pub is_council: bool,
+    pub is_new_session: bool,
+    pub attachment_count: u32,
+    pub installed_tool_count: u32,
+    pub installed_integration_count: u32,
+    pub tool_use_count: u32,
+    pub files_changed_count: u32,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub ip_cluster_bucket: IpClusterBucket,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnSignalClassification {
+    pub agentic_score: u8,
+    pub generic_chat_score: u8,
+    pub usage_shape: UsageShape,
+    pub risk_bucket: RiskBucket,
+    pub quota_review_candidate: bool,
+    pub reasons: Vec<String>,
+}
+
+#[must_use]
+pub fn classify_turn(input: &TurnSignalInput) -> TurnSignalClassification {
+    let mut agentic = 0u16;
+    let mut generic = 0u16;
+    let mut reasons = Vec::new();
+
+    if input.route_kind == TurnRouteKind::ProjectAgent {
+        add(&mut agentic, &mut reasons, 20, "project_agent_route");
+    }
+    if input.has_user_project_instance {
+        add(&mut agentic, &mut reasons, 20, "user_project_instance");
+    }
+    if input.has_project_context && !input.is_auto_home_only {
+        add(&mut agentic, &mut reasons, 12, "project_context");
+    }
+    if input.tool_use_count > 0 {
+        add(&mut agentic, &mut reasons, 25, "tool_use");
+        if input.tool_use_count >= 3 {
+            add(&mut agentic, &mut reasons, 8, "multi_tool_turn");
+        }
+    }
+    if input.files_changed_count > 0 {
+        add(&mut agentic, &mut reasons, 25, "files_changed");
+    }
+    if input.is_plan_mode {
+        add(&mut agentic, &mut reasons, 12, "plan_mode");
+    }
+    if input.is_cross_agent {
+        add(&mut agentic, &mut reasons, 10, "cross_agent");
+    }
+    if input.is_council {
+        add(&mut agentic, &mut reasons, 8, "council");
+    }
+    if input.attachment_count > 0 {
+        add(&mut agentic, &mut reasons, 6, "attachments");
+    }
+    if input.installed_tool_count > 0 || input.installed_integration_count > 0 {
+        add(
+            &mut agentic,
+            &mut reasons,
+            5,
+            "agent_capabilities_available",
+        );
+    }
+
+    let no_side_effects = input.tool_use_count == 0 && input.files_changed_count == 0;
+    if input.route_kind == TurnRouteKind::BareAgent && input.is_auto_home_only {
+        add(&mut generic, &mut reasons, 28, "bare_agent_auto_home_only");
+    }
+    if !input.has_user_project_instance {
+        add(&mut generic, &mut reasons, 14, "no_user_project_instance");
+    }
+    if no_side_effects {
+        add(&mut generic, &mut reasons, 22, "zero_tools_zero_files");
+    }
+    if no_side_effects && input.input_tokens.saturating_add(input.output_tokens) >= 4_000 {
+        add(&mut generic, &mut reasons, 15, "high_token_text_only_turn");
+    }
+    if no_side_effects && input.output_tokens >= 1_000 {
+        add(
+            &mut generic,
+            &mut reasons,
+            8,
+            "long_text_response_without_actions",
+        );
+    }
+    if input.is_new_session && no_side_effects {
+        add(&mut generic, &mut reasons, 6, "new_text_only_session");
+    }
+    if no_side_effects
+        && !input.has_user_project_instance
+        && matches!(input.account_age_days, Some(0..=1))
+    {
+        add(
+            &mut generic,
+            &mut reasons,
+            10,
+            "new_account_text_only_no_project",
+        );
+    }
+    match input.ip_cluster_bucket {
+        IpClusterBucket::SixToTwenty => add(&mut generic, &mut reasons, 8, "shared_ip_cluster"),
+        IpClusterBucket::TwentyOnePlus => {
+            add(&mut generic, &mut reasons, 14, "large_shared_ip_cluster");
+        }
+        IpClusterBucket::Unknown | IpClusterBucket::One | IpClusterBucket::TwoToFive => {}
+    }
+
+    // Public paid/gated surfaces are allowed to be generic chat. We still
+    // classify their behaviour, but they should not trigger quota review by
+    // themselves.
+    if matches!(
+        input.route_kind,
+        TurnRouteKind::PublicDemo | TurnRouteKind::PublicX402
+    ) {
+        generic = generic.min(30);
+    }
+
+    let agentic_score = clamp_score(agentic);
+    let generic_chat_score = clamp_score(generic);
+    let usage_shape = usage_shape(agentic_score, generic_chat_score);
+    let risk_bucket = if generic_chat_score >= 70 && agentic_score <= 25 {
+        RiskBucket::High
+    } else if generic_chat_score >= 45 && agentic_score <= 45 {
+        RiskBucket::Medium
+    } else {
+        RiskBucket::Low
+    };
+
+    TurnSignalClassification {
+        agentic_score,
+        generic_chat_score,
+        usage_shape,
+        risk_bucket,
+        quota_review_candidate: matches!(risk_bucket, RiskBucket::Medium | RiskBucket::High),
+        reasons,
+    }
+}
+
+fn usage_shape(agentic_score: u8, generic_chat_score: u8) -> UsageShape {
+    if generic_chat_score >= 70 && agentic_score <= 25 {
+        UsageShape::GenericAgentChat
+    } else if agentic_score >= 60 && generic_chat_score <= 45 {
+        UsageShape::AgenticWork
+    } else if agentic_score >= 45 && generic_chat_score >= 45 {
+        UsageShape::Mixed
+    } else {
+        UsageShape::LowSignal
+    }
+}
+
+fn add(score: &mut u16, reasons: &mut Vec<String>, points: u16, reason: &str) {
+    *score = score.saturating_add(points);
+    reasons.push(reason.to_string());
+}
+
+fn clamp_score(score: u16) -> u8 {
+    score.min(100) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> TurnSignalInput {
+        TurnSignalInput {
+            route_kind: TurnRouteKind::ProjectAgent,
+            binding_source: AgentBindingSource::Ui,
+            account_age_days: Some(30),
+            is_zero_pro: Some(true),
+            is_access_granted: Some(false),
+            has_project_context: true,
+            has_user_project_instance: true,
+            is_auto_home_only: false,
+            is_plan_mode: false,
+            is_cross_agent: false,
+            is_council: false,
+            is_new_session: false,
+            attachment_count: 0,
+            installed_tool_count: 4,
+            installed_integration_count: 0,
+            tool_use_count: 0,
+            files_changed_count: 0,
+            input_tokens: 500,
+            output_tokens: 200,
+            ip_cluster_bucket: IpClusterBucket::One,
+        }
+    }
+
+    #[test]
+    fn project_agent_with_actions_is_low_risk_and_agentic() {
+        let input = TurnSignalInput {
+            tool_use_count: 2,
+            files_changed_count: 1,
+            ..base()
+        };
+
+        let classification = classify_turn(&input);
+
+        assert_eq!(classification.risk_bucket, RiskBucket::Low);
+        assert_eq!(classification.usage_shape, UsageShape::AgenticWork);
+        assert!(classification.agentic_score >= 80);
+        assert!(classification.generic_chat_score < 40);
+        assert!(!classification.quota_review_candidate);
+    }
+
+    #[test]
+    fn auto_home_bare_agent_text_only_is_high_risk_candidate() {
+        let input = TurnSignalInput {
+            route_kind: TurnRouteKind::BareAgent,
+            binding_source: AgentBindingSource::AutoHome,
+            has_project_context: true,
+            has_user_project_instance: false,
+            is_auto_home_only: true,
+            installed_tool_count: 0,
+            input_tokens: 3_500,
+            output_tokens: 1_200,
+            ip_cluster_bucket: IpClusterBucket::One,
+            ..base()
+        };
+
+        let classification = classify_turn(&input);
+
+        assert_eq!(classification.risk_bucket, RiskBucket::High);
+        assert_eq!(classification.usage_shape, UsageShape::GenericAgentChat);
+        assert!(classification.quota_review_candidate);
+        assert!(classification
+            .reasons
+            .iter()
+            .any(|r| r == "bare_agent_auto_home_only"));
+    }
+
+    #[test]
+    fn shared_ip_cluster_can_lift_borderline_generic_usage() {
+        let input = TurnSignalInput {
+            route_kind: TurnRouteKind::BareAgent,
+            binding_source: AgentBindingSource::AutoHome,
+            has_project_context: true,
+            has_user_project_instance: false,
+            is_auto_home_only: true,
+            input_tokens: 1_000,
+            output_tokens: 300,
+            ip_cluster_bucket: IpClusterBucket::SixToTwenty,
+            ..base()
+        };
+
+        let classification = classify_turn(&input);
+
+        assert!(classification.generic_chat_score >= 70);
+        assert_eq!(classification.risk_bucket, RiskBucket::High);
+    }
+
+    #[test]
+    fn public_x402_generic_chat_is_not_quota_review() {
+        let input = TurnSignalInput {
+            route_kind: TurnRouteKind::PublicX402,
+            binding_source: AgentBindingSource::None,
+            has_project_context: false,
+            has_user_project_instance: false,
+            is_auto_home_only: false,
+            installed_tool_count: 0,
+            input_tokens: 10_000,
+            output_tokens: 2_000,
+            ip_cluster_bucket: IpClusterBucket::TwentyOnePlus,
+            ..base()
+        };
+
+        let classification = classify_turn(&input);
+
+        assert_eq!(classification.risk_bucket, RiskBucket::Low);
+        assert!(!classification.quota_review_candidate);
+    }
+}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -23,6 +23,19 @@ how the product is used so we can improve it.
 - `session_active` (the basis for active-user metrics) is emitted **only by the
   server**, keyed to the ZERO `user_id` and de-duplicated per user per day, so a
   user is counted once regardless of how many devices or builds they use.
+- Server-side usage signals such as `agent_turn_classified` are observe-only:
+  they send privacy-safe classification metadata to Mixpanel and storage, never
+  prompts, model outputs, file paths, project names, or raw IP addresses.
+  These events classify traffic shape (`agentic_work`, `generic_agent_chat`,
+  `mixed`, `low_signal`) and whether a turn should be included in quota-review
+  analysis. They are not a standalone abuse verdict.
+  The same event is best-effort enriched from z-billing with account age,
+  plan, balance, lifetime purchased/granted/used cents, auto-refill state,
+  `billing_funding_bucket` (`none`, `grant_only`, `purchase_only`, `mixed`),
+  and `billing_grant_usage_bucket` (`no_grants`, `0`, `lt_25pct`,
+  `25_75pct`, `75_100pct`, `100pct_plus`). Mixpanel charts should combine
+  these billing fields with usage shape, project counts, token volume, and
+  session recency rather than treating one field as proof of misuse.
 - Release builds for every surface (desktop, web, mobile) fail if the analytics
   token didn't reach the bundle, so a build never silently ships with analytics
   disabled.

--- a/interface/src/lib/analytics-events.json
+++ b/interface/src/lib/analytics-events.json
@@ -1,4 +1,9 @@
 {
   "_comment": "Cross-language analytics contract. Source of truth for client events is analytics-registry.ts (ANALYTICS_EVENTS); this file is the bridge the Rust server tests check against. The TS contract test asserts SERVER_EVENTS in the registry matches server_events here; the Rust test (mixpanel.rs) asserts its EVENT_* constants match server_events here. Keep server_events in sync with both.",
-  "server_events": ["session_active", "share_link_generated", "share_link_opened"]
+  "server_events": [
+    "session_active",
+    "share_link_generated",
+    "share_link_opened",
+    "agent_turn_classified"
+  ]
 }

--- a/interface/src/lib/analytics-registry.ts
+++ b/interface/src/lib/analytics-registry.ts
@@ -85,4 +85,5 @@ export const SERVER_EVENTS = [
   "session_active",
   "share_link_generated",
   "share_link_opened",
+  "agent_turn_classified",
 ] as const;


### PR DESCRIPTION
Adds a pure usage-signal classifier plus server-side emission for completed chat turns, persisted as turn_usage_signal and sent to Mixpanel as agent_turn_classified.

Enriches the signal from z-billing account data with account age, funding buckets, grant usage buckets, lifetime purchased/granted/used cents, and balance fields.

Verified with cargo test -p aura-os-usage-signals; cargo test -p aura-os-server usage_signal; cargo test -p aura-os-server --test chat_events_test bare_agent_chat_route_persists_usage_signal_from_harness_end; cargo test -p aura-os-server mixpanel; npm --prefix interface run test -- src/lib/analytics-contract.test.ts; cargo clippy -p aura-os-usage-signals -- -D warnings; cargo clippy -p aura-os-server --tests -- -D warnings -A clippy::derivable_impls -A clippy::items_after_test_module.